### PR TITLE
ENH: Add models for ds003, ds114

### DIFF
--- a/ds003/models/model-001_smdl.json
+++ b/ds003/models/model-001_smdl.json
@@ -1,0 +1,77 @@
+{
+  "name": "ds003_model001",
+  "description": "",
+  "input": {
+    "task": "rhymejudgment"
+  },
+  "blocks": [
+    {
+      "level": "run",
+      "transformations": [
+        {
+          "name": "factor",
+          "input": [
+            "trial_type"
+          ]
+        }
+      ],
+      "model": {
+        "HRF_variables": [
+          "trial_type.word",
+          "trial_type.pseudoword"
+        ],
+        "variables": [
+          "trial_type.word",
+          "trial_type.pseudoword",
+          "FramewiseDisplacement",
+          "X",
+          "Y",
+          "Z",
+          "RotX",
+          "RotY",
+          "RotZ",
+          "aCompCor00",
+          "aCompCor01",
+          "aCompCor02",
+          "aCompCor03",
+          "aCompCor04",
+          "aCompCor05"
+        ]
+      },
+      "contrasts": [
+        {
+          "name": "word_gt_pseudo",
+          "condition_list": [
+            "trial_type.word",
+            "trial_type.pseudoword"
+          ],
+          "weights": [
+            1,
+            -1
+          ],
+          "type": "T"
+        }
+      ]
+    },
+    {
+      "level": "dataset",
+      "model": {
+        "variables": [
+          "word_gt_pseudo"
+        ]
+      },
+      "contrasts": [
+        {
+          "name": "group_word_gt_pseudo",
+          "condition_list": [
+            "word_gt_pseudo"
+          ],
+          "weights": [
+            1
+          ],
+          "type": "T"
+        }
+      ]
+    }
+  ]
+}

--- a/ds003/models/model-001_smdl.json
+++ b/ds003/models/model-001_smdl.json
@@ -11,6 +11,11 @@
         {
           "Name": "Factor",
           "Input": ["trial_type"]
+        },
+        {
+          "Name": "Convolve",
+          "Input": ["trial_type.word", "trial_type.pseudoword"],
+          "Model": "DoubleGamma"
         }
       ],
       "Model": {

--- a/ds003/models/model-001_smdl.json
+++ b/ds003/models/model-001_smdl.json
@@ -1,77 +1,46 @@
 {
-  "name": "ds003_model001",
-  "description": "",
-  "input": {
+  "Name": "ds003_model001",
+  "Description": "",
+  "Input": {
     "task": "rhymejudgment"
   },
-  "blocks": [
+  "Steps": [
     {
-      "level": "run",
-      "transformations": [
+      "Level": "run",
+      "Transformations": [
         {
-          "name": "factor",
-          "input": [
-            "trial_type"
-          ]
+          "Name": "Factor",
+          "Input": ["trial_type"]
         }
       ],
-      "model": {
-        "HRF_variables": [
-          "trial_type.word",
-          "trial_type.pseudoword"
-        ],
-        "variables": [
+      "Model": {
+        "X": [
           "trial_type.word",
           "trial_type.pseudoword",
-          "FramewiseDisplacement",
-          "X",
-          "Y",
-          "Z",
-          "RotX",
-          "RotY",
-          "RotZ",
-          "aCompCor00",
-          "aCompCor01",
-          "aCompCor02",
-          "aCompCor03",
-          "aCompCor04",
-          "aCompCor05"
-        ]
+          "framewise_displacement",
+          "trans_x", "trans_y", "trans_z", "rot_x", "rot_y", "rot_z",
+          "a_comp_cor_00", "a_comp_cor_01", "a_comp_cor_02",
+          "a_comp_cor_03", "a_comp_cor_04", "a_comp_cor_05"
+        ],
+        "Options": {
+          "high_pass_filter_cutoff_secs": 128
+        },
       },
-      "contrasts": [
+      "Contrasts": [
         {
-          "name": "word_gt_pseudo",
-          "condition_list": [
+          "Name": "wordness",
+          "ConditionList": [
             "trial_type.word",
             "trial_type.pseudoword"
           ],
-          "weights": [
-            1,
-            -1
-          ],
-          "type": "T"
+          "Weights": [1, -1],
+          "Type": "t"
         }
       ]
     },
     {
-      "level": "dataset",
-      "model": {
-        "variables": [
-          "word_gt_pseudo"
-        ]
-      },
-      "contrasts": [
-        {
-          "name": "group_word_gt_pseudo",
-          "condition_list": [
-            "word_gt_pseudo"
-          ],
-          "weights": [
-            1
-          ],
-          "type": "T"
-        }
-      ]
+      "Level": "dataset",
+      "AutoContrasts": true
     }
   ]
 }

--- a/ds003/models/model-001_smdl.json
+++ b/ds003/models/model-001_smdl.json
@@ -10,12 +10,14 @@
       "Transformations": [
         {
           "Name": "Factor",
-          "Input": ["trial_type"]
+          "Input": [
+            "trial_type"
+          ]
         },
         {
           "Name": "Convolve",
           "Input": ["trial_type.word", "trial_type.pseudoword"],
-          "Model": "DoubleGamma"
+          "Model": "spm"
         }
       ],
       "Model": {
@@ -26,14 +28,11 @@
           "trans_x", "trans_y", "trans_z", "rot_x", "rot_y", "rot_z",
           "a_comp_cor_00", "a_comp_cor_01", "a_comp_cor_02",
           "a_comp_cor_03", "a_comp_cor_04", "a_comp_cor_05"
-        ],
-        "Options": {
-          "high_pass_filter_cutoff_secs": 128
-        },
+        ]
       },
       "Contrasts": [
         {
-          "Name": "wordness",
+          "Name": "word_gt_pseudo",
           "ConditionList": [
             "trial_type.word",
             "trial_type.pseudoword"
@@ -45,7 +44,7 @@
     },
     {
       "Level": "dataset",
-      "AutoContrasts": true
+      "AutoContrasts": ["word_gt_pseudo"]
     }
   ]
 }

--- a/ds114/models/model-1_smdl.json
+++ b/ds114/models/model-1_smdl.json
@@ -1,0 +1,130 @@
+{
+  "name": "ds114_model1",
+  "description": "sample model for ds114",
+  "input": {
+    "task": "fingerfootlips"
+  },
+  "blocks": [
+    {
+      "level": "run",
+      "transformations": [
+        {
+          "name": "factor",
+          "input": [
+            "trial_type"
+          ]
+        }
+      ],
+      "model": {
+        "HRF_variables": [
+          "trial_type.Finger",
+          "trial_type.Foot",
+          "trial_type.Lips"
+        ],
+        "variables": [
+          "trial_type.Finger",
+          "trial_type.Foot",
+          "trial_type.Lips",
+          "FramewiseDisplacement",
+          "X",
+          "Y",
+          "Z",
+          "RotX",
+          "RotY",
+          "RotZ",
+          "aCompCor00",
+          "aCompCor01",
+          "aCompCor02",
+          "aCompCor03",
+          "aCompCor04",
+          "aCompCor05"
+        ]
+      },
+      "contrasts": [
+        {
+          "name": "finger_vs_others",
+          "condition_list": [
+            "trial_type.Finger",
+            "trial_type.Foot",
+            "trial_type.Lips"
+          ],
+          "weights": [
+            1,
+            -0.5,
+            -0.5
+          ],
+          "type": "T"
+        },
+        {
+          "name": "lips_vs_others",
+          "condition_list": [
+            "trial_type.Finger",
+            "trial_type.Foot",
+            "trial_type.Lips"
+          ],
+          "weights": [
+            -0.5,
+            -0.5,
+            1
+          ],
+          "type": "T"
+        }
+      ]
+    },
+    {
+      "level": "session",
+      "transformations": [
+        {
+          "name": "split",
+          "input": [
+            "finger_vs_others"
+          ],
+          "by": "session"
+        }
+      ]
+    },
+    {
+      "level": "subject",
+      "model": {
+        "variables": [
+          "finger_vs_others.test",
+          "finger_vs_others.retest"
+        ]
+      },
+      "contrasts": [
+        {
+          "name": "session_diff",
+          "condition_list": [
+            "finger_vs_others.test",
+            "finger_vs_others.retest"
+          ],
+          "weights": [
+            1,
+            -1
+          ],
+          "type": "T"
+        }
+      ]
+    },
+    {
+      "level": "dataset",
+      "model": {
+        "variables": [
+          "session_diff"
+        ]
+      },
+      "contrasts": [
+        {
+          "name": "session_diff_finger_vs_others",
+          "condition_list": [
+            "session_diff"
+          ],
+          "weights": [
+            1
+          ],
+          "type": "T"
+        }
+      ]
+    }
+  ]
+}

--- a/ds114/models/model-1_smdl.json
+++ b/ds114/models/model-1_smdl.json
@@ -48,7 +48,7 @@
           "Input": ["finger_vs_others"],
           "By": "session"
         }
-      ]
+      ],
       "Model": {
         "X": [
           "finger_vs_others.test",

--- a/ds114/models/model-1_smdl.json
+++ b/ds114/models/model-1_smdl.json
@@ -1,130 +1,74 @@
 {
-  "name": "ds114_model1",
-  "description": "sample model for ds114",
-  "input": {
+  "Name": "ds114_model1",
+  "Description": "sample model for ds114",
+  "Input": {
     "task": "fingerfootlips"
   },
-  "blocks": [
+  "Steps": [
     {
-      "level": "run",
-      "transformations": [
+      "Level": "run",
+      "Transformations": [
         {
-          "name": "factor",
-          "input": [
-            "trial_type"
-          ]
+          "Name": "Factor",
+          "Input": ["trial_type"]
         }
       ],
-      "model": {
-        "HRF_variables": [
-          "trial_type.Finger",
-          "trial_type.Foot",
-          "trial_type.Lips"
-        ],
-        "variables": [
+      "Model": {
+        "X": [
           "trial_type.Finger",
           "trial_type.Foot",
           "trial_type.Lips",
-          "FramewiseDisplacement",
-          "X",
-          "Y",
-          "Z",
-          "RotX",
-          "RotY",
-          "RotZ",
-          "aCompCor00",
-          "aCompCor01",
-          "aCompCor02",
-          "aCompCor03",
-          "aCompCor04",
-          "aCompCor05"
-        ]
-      },
-      "contrasts": [
-        {
-          "name": "finger_vs_others",
-          "condition_list": [
-            "trial_type.Finger",
-            "trial_type.Foot",
-            "trial_type.Lips"
-          ],
-          "weights": [
-            1,
-            -0.5,
-            -0.5
-          ],
-          "type": "T"
+          "framewise_displacement",
+          "trans_x", "trans_y", "trans_z", "rot_x", "rot_y", "rot_z",
+          "a_comp_cor_00", "a_comp_cor_01", "a_comp_cor_02",
+          "a_comp_cor_03", "a_comp_cor_04", "a_comp_cor_05"
+        ],
+        "Options": {
+          "high_pass_filter_cutoff_secs": 128
         },
+      },
+      "Contrasts": [
         {
-          "name": "lips_vs_others",
-          "condition_list": [
+          "Name": "finger_vs_others",
+          "ConditionList": [
             "trial_type.Finger",
             "trial_type.Foot",
             "trial_type.Lips"
           ],
-          "weights": [
-            -0.5,
-            -0.5,
-            1
-          ],
-          "type": "T"
-        }
+          "Weights": [1, -0.5, -0.5],
+          "Type": "t"
+        },
       ]
     },
     {
-      "level": "session",
-      "transformations": [
+      "Level": "subject",
+      "Transformations": [
         {
-          "name": "split",
-          "input": [
-            "finger_vs_others"
-          ],
-          "by": "session"
+          "Name": "Split",
+          "Input": ["finger_vs_others"],
+          "By": "session"
         }
       ]
-    },
-    {
-      "level": "subject",
-      "model": {
-        "variables": [
+      "Model": {
+        "X": [
           "finger_vs_others.test",
           "finger_vs_others.retest"
         ]
       },
-      "contrasts": [
+      "Contrasts": [
         {
-          "name": "session_diff",
-          "condition_list": [
+          "Name": "test_vs_retest",
+          "ConditionList": [
             "finger_vs_others.test",
             "finger_vs_others.retest"
           ],
-          "weights": [
-            1,
-            -1
-          ],
-          "type": "T"
+          "Weights": [1, -1]
         }
       ]
     },
     {
-      "level": "dataset",
-      "model": {
-        "variables": [
-          "session_diff"
-        ]
-      },
-      "contrasts": [
-        {
-          "name": "session_diff_finger_vs_others",
-          "condition_list": [
-            "session_diff"
-          ],
-          "weights": [
-            1
-          ],
-          "type": "T"
-        }
-      ]
+      "Level": "dataset",
+      "AutoContrasts": ["test_vs_retest"]
     }
   ]
 }

--- a/ds114/models/model-1_smdl.json
+++ b/ds114/models/model-1_smdl.json
@@ -11,6 +11,11 @@
         {
           "Name": "Factor",
           "Input": ["trial_type"]
+        },
+        {
+          "Name": "Convolve",
+          "Input": ["trial_type.Finger", "trial_type.Foot", "trial_type.Lips"],
+          "Model": "DoubleGamma"
         }
       ],
       "Model": {


### PR DESCRIPTION
Not yet conformant with latest changes in [BEP 002](https://docs.google.com/document/d/1bq5eNDHTb6Nkx3WUiOBgKvLNnaa5OMcGtD0AZ9yms2M/edit?ts=5bcb2e82#).

ds000030 an ds000117, for which models either exist or are in-progress, are not represented in this repository.

Closes #129.