### PR TITLE
CI: Install bids-validator from npm over git

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ node_js:
   - "8.0.0"
 
 install:
-  - npm install -g https://github.com/bids-standard/bids-validator.git#1.1.0
+  - npm install -g bids-validator@1.1.0
 
 script:
   - |


### PR DESCRIPTION
This should fix the CI issue reported in https://github.com/bids-standard/bids-validator/issues/723#issuecomment-467333257