### PR TITLE
Migrating Documentation from WIKI to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,19 +29,19 @@ corresponding Pull Request.
 
 |  name | description | mri | meg | eeg | ieeg | full data |
 | --- | --- | --- | --- | --- | --- | --- |
-|  7t_trt | field maps, physiological data, quantitative T1 maps, T1w, BOLD | x |  |  |  | https://bit.ly/2H0Z6Qt |
-|  ds000117 | A multi-subject, multi-modal human neuroimaging dataset of 19 subjects on a MEG visual task | x | x | x |  | https://openneuro.org/datasets/ds000117/ |
-|  ds000246 | Auditory dataset used for Brainstorm’s general online tutorial | x | x |  |  | https://openneuro.org/datasets/ds000246/versions/00001 |
-|  ds000247 | Five minutes, eyes-open, resting-state MEG data from 5 subjects. This is a sample from The Open MEG Archive (OMEGA). | x | x |  |  |  |
-|  ds000248 | MNE sample data: Data with visual and auditory stimuli | x | x |  |  | https://bit.ly/2JfNYkf |
-|  ds001 | single task, multiple runs, in-plane T2, events, T1w, BOLD | x |  |  |  | https://bit.ly/2H0Z6Qt |
-|  ds002 | multiple tasks, multiple runs, in-plane T2, events, T1w, BOLD | x |  |  |  | https://bit.ly/2H0Z6Qt |
-|  ds003 | single task, single run, in-plane T2, events, T1w, BOLD | x |  |  |  | https://bit.ly/2H0Z6Qt |
-|  ds005 | single task, multiple runs, in-plane T2, events, T1w, BOLD | x |  |  |  | https://bit.ly/2H0Z6Qt |
-|  ds006 | single task, multiple sessions, multiple runs, in-plane T2, events, T1w, BOLD | x |  |  |  | https://bit.ly/2H0Z6Qt |
-|  ds007 | single task, multiple runs, in-plane T2, events, T1w, BOLD | x |  |  |  | https://bit.ly/2H0Z6Qt |
-|  ds008 | multiple tasks, multiple runs, in-plane T2, events, T1w, BOLD | x |  |  |  | https://bit.ly/2H0Z6Qt |
-|  ds009 | multiple tasks, multiple runs, in-plane T2, events, T1w, BOLD | x |  |  |  | https://bit.ly/2H0Z6Qt |
+|  7t_trt | field maps, physiological data, quantitative T1 maps, T1w, BOLD | mri |  |  |  | https://bit.ly/2H0Z6Qt |
+|  ds000117 | A multi-subject, multi-modal human neuroimaging dataset of 19 subjects on a MEG visual task | mri | meg | eeg |  | https://openneuro.org/datasets/ds000117/ |
+|  ds000246 | Auditory dataset used for Brainstorm’s general online tutorial | mri | meg |  |  | https://openneuro.org/datasets/ds000246/versions/00001 |
+|  ds000247 | Five minutes, eyes-open, resting-state MEG data from 5 subjects. This is a sample from The Open MEG Archive (OMEGA). | mri | meg |  |  |  |
+|  ds000248 | MNE sample data: Data with visual and auditory stimuli | mri | meg |  |  | https://bit.ly/2JfNYkf |
+|  ds001 | single task, multiple runs, in-plane T2, events, T1w, BOLD | mri |  |  |  | https://bit.ly/2H0Z6Qt |
+|  ds002 | multiple tasks, multiple runs, in-plane T2, events, T1w, BOLD | mri |  |  |  | https://bit.ly/2H0Z6Qt |
+|  ds003 | single task, single run, in-plane T2, events, T1w, BOLD | mri |  |  |  | https://bit.ly/2H0Z6Qt |
+|  ds005 | single task, multiple runs, in-plane T2, events, T1w, BOLD | mri |  |  |  | https://bit.ly/2H0Z6Qt |
+|  ds006 | single task, multiple sessions, multiple runs, in-plane T2, events, T1w, BOLD | mri |  |  |  | https://bit.ly/2H0Z6Qt |
+|  ds007 | single task, multiple runs, in-plane T2, events, T1w, BOLD | mri |  |  |  | https://bit.ly/2H0Z6Qt |
+|  ds008 | multiple tasks, multiple runs, in-plane T2, events, T1w, BOLD | mri |  |  |  | https://bit.ly/2H0Z6Qt |
+|  ds009 | multiple tasks, multiple runs, in-plane T2, events, T1w, BOLD | mri |  |  |  | https://bit.ly/2H0Z6Qt |
 |  ds011 |  |  |  |  |  | https://bit.ly/2H0Z6Qt |
 |  ds051 |  |  |  |  |  | https://bit.ly/2H0Z6Qt |
 |  ds052 |  |  |  |  |  | https://bit.ly/2H0Z6Qt |
@@ -53,18 +53,19 @@ corresponding Pull Request.
 |  ds109 |  |  |  |  |  | https://bit.ly/2H0Z6Qt |
 |  ds110 |  |  |  |  |  | https://bit.ly/2H0Z6Qt |
 |  ds113b |  |  |  |  |  | https://bit.ly/2H0Z6Qt |
-|  ds114 | DWI, multiple tasks, events, T1w, BOLD | x |  |  |  | https://bit.ly/2H0Z6Qt |
+|  ds114 | DWI, multiple tasks, events, T1w, BOLD | mri |  |  |  | https://bit.ly/2H0Z6Qt |
 |  ds116 |  |  |  |  |  | https://bit.ly/2H0Z6Qt |
 |  ds210 |  |  |  |  |  | https://bit.ly/2H0Z6Qt |
 |  eeg_cbm | Rest EEG. European Data Format (.edf) |  |  |  |  |  |
-|  eeg_ds000117 | Multimodal (fMRI, MEG, EEG) stripped down to EEG with MRI anatomical scan and electrode coordinates. EEGLAB data format (.set, .fdt) | x |  | x |  | https://openneuro.org/datasets/ds000117/ |
-|  eeg_matchingpennies | Offline data of BCI experiment decoding left vs. right hand movement. See Matching Pennies: A Brain Computer Interface Implementation Dataset for more information. BrainVision data format (.eeg, .vhdr, .vmrk) |  |  | x |  | https://osf.io/cj2dr/ |
-|  eeg_rest_fmri | Resting state with simultaneous fMRI. BrainVision data format (.eeg, .vhdr, .vmrk) |  |  |  |  |  |
-|  eeg_rishikesh | Mind wandering experiment. EEG data in Biosemi (.bdf) format |  |  | x |  | https://zenodo.org/record/2536267 |
+|  eeg_ds000117 | Multimodal (fMRI, MEG, EEG) stripped down to EEG with MRI anatomical scan and electrode coordinates. EEGLAB data format (.set, .fdt) | mri |  | eeg |  | https://openneuro.org/datasets/ds000117/ |
+|  eeg_matchingpennies | Offline data of BCI experiment decoding left vs. right hand movement. See Matching Pennies: A Brain Computer Interface Implementation Dataset for more information. BrainVision data format (.eeg, .vhdr, .vmrk) |  |  | eeg |  | https://osf.io/cj2dr/ |
+|  eeg_rest_fmri | Resting state with simultaneous fMRI. BrainVision data format (.eeg, .vhdr, .vmrk) |  |  | eeg |  |  |
+|  eeg_rishikesh | Mind wandering experiment. EEG data in Biosemi (.bdf) format |  |  | eeg |  | https://zenodo.org/record/2536267 |
 |  hcp_example_bids |  |  |  |  |  | https://bit.ly/2H0Z6Qt |
-|  ieeg_epilepsy |  |  |  |  | x | https://openneuro.org/datasets/ds001779 |
-|  ieeg_filtered_speech | recordings of three seizures |  |  |  | x |  |
-|  ieeg_motorMiller2007 | Cue-based hand & tongue movement data |  |  |  | x |  |
-|  ieeg_visual | Stimulus dependence of gamma oscillations in human visual cortex |  |  |  | x |  |
-|  ieeg_visual_multimodal |  |  |  |  | x |  |
+|  ieeg_epilepsy |  |  |  |  | ieeg | https://openneuro.org/datasets/ds001779 |
+|  ieeg_epilepsy_ecog |  |  |  |  | ieeg | https://openneuro.org/datasets/ds001868 |
+|  ieeg_filtered_speech | recordings of three seizures |  |  |  | ieeg |  |
+|  ieeg_motorMiller2007 | Cue-based hand & tongue movement data |  |  |  | ieeg |  |
+|  ieeg_visual | Stimulus dependence of gamma oscillations in human visual cortex |  |  |  | ieeg |  |
+|  ieeg_visual_multimodal |  |  |  |  | ieeg |  |
 |  synthetic | A synthetic dataset |  |  |  |  |  |

--- a/README.md
+++ b/README.md
@@ -2,25 +2,30 @@
 
 # bids-examples
 
-This repository contains a set of BIDS compatible datasets with **empty raw
-data files**. These datasets can be useful to:
+This repository contains a set of [BIDS-compatible](http://bids.neuroimaging.io/)
+datasets with **empty raw data files**. These datasets can be useful to:
 
 1. write lightweight software tests
 1. serve as an example on how a BIDS dataset can be structured
 
 ALL RAW DATA FILES IN THIS REPOSITORY ARE EMPTY!
 
-To learn more about the Brain Imaging Data Structure (BIDS), visit
-http://bids.neuroimaging.io/
+However for some of the data, the headers containing the metadata are still
+intact. This is true for the following datasets:
+
+- `synthetic`
+- Most EEG or iEEG data in BrainVision format (e.g., `eeg_matchingpennies`)
+
+# Contributing
 
 If you want to contribute a dataset to the examples, we would be happy to
 accommodate it, as long as it exhibits some structure or particularity that is
-not covered by the already present examples so far.
+not covered by the examples that are already present so far.
 
 # Dataset index
 
-If you want to update this table, please open a new issue. For simple editing,
-this table is maintained in a [Google sheet](https://docs.google.com/spreadsheets/d/1d9KfmaKvTOpFWgi0Kd-tZGgVTsZk_4BHH9prcgFeigw/edit?usp=sharing), which is then converted to Markdown for this README file.
+If you want to update this table, please open a new GitHub Issue and a
+corresponding Pull Request.
 
 |  name | description | mri | meg | eeg | ieeg | full data |
 | --- | --- | --- | --- | --- | --- | --- |

--- a/README.md
+++ b/README.md
@@ -32,40 +32,40 @@ corresponding Pull Request.
 |  7t_trt | field maps, physiological data, quantitative T1 maps, T1w, BOLD | mri |  |  |  | https://bit.ly/2H0Z6Qt |
 |  ds000117 | A multi-subject, multi-modal human neuroimaging dataset of 19 subjects on a MEG visual task | mri | meg | eeg |  | https://openneuro.org/datasets/ds000117/ |
 |  ds000246 | Auditory dataset used for Brainstorm’s general online tutorial | mri | meg |  |  | https://openneuro.org/datasets/ds000246/versions/00001 |
-|  ds000247 | Five minutes, eyes-open, resting-state MEG data from 5 subjects. This is a sample from The Open MEG Archive (OMEGA). | mri | meg |  |  |  |
-|  ds000248 | MNE sample data: Data with visual and auditory stimuli | mri | meg |  |  | https://bit.ly/2JfNYkf |
-|  ds001 | single task, multiple runs, in-plane T2, events, T1w, BOLD | mri |  |  |  | https://bit.ly/2H0Z6Qt |
-|  ds002 | multiple tasks, multiple runs, in-plane T2, events, T1w, BOLD | mri |  |  |  | https://bit.ly/2H0Z6Qt |
-|  ds003 | single task, single run, in-plane T2, events, T1w, BOLD | mri |  |  |  | https://bit.ly/2H0Z6Qt |
-|  ds005 | single task, multiple runs, in-plane T2, events, T1w, BOLD | mri |  |  |  | https://bit.ly/2H0Z6Qt |
-|  ds006 | single task, multiple sessions, multiple runs, in-plane T2, events, T1w, BOLD | mri |  |  |  | https://bit.ly/2H0Z6Qt |
-|  ds007 | single task, multiple runs, in-plane T2, events, T1w, BOLD | mri |  |  |  | https://bit.ly/2H0Z6Qt |
-|  ds008 | multiple tasks, multiple runs, in-plane T2, events, T1w, BOLD | mri |  |  |  | https://bit.ly/2H0Z6Qt |
-|  ds009 | multiple tasks, multiple runs, in-plane T2, events, T1w, BOLD | mri |  |  |  | https://bit.ly/2H0Z6Qt |
-|  ds011 |  |  |  |  |  | https://bit.ly/2H0Z6Qt |
-|  ds051 |  |  |  |  |  | https://bit.ly/2H0Z6Qt |
-|  ds052 |  |  |  |  |  | https://bit.ly/2H0Z6Qt |
-|  ds101 |  |  |  |  |  | https://bit.ly/2H0Z6Qt |
-|  ds102 |  |  |  |  |  | https://bit.ly/2H0Z6Qt |
-|  ds105 |  |  |  |  |  | https://bit.ly/2H0Z6Qt |
-|  ds107 |  |  |  |  |  | https://bit.ly/2H0Z6Qt |
-|  ds108 |  |  |  |  |  | https://bit.ly/2H0Z6Qt |
-|  ds109 |  |  |  |  |  | https://bit.ly/2H0Z6Qt |
-|  ds110 |  |  |  |  |  | https://bit.ly/2H0Z6Qt |
-|  ds113b |  |  |  |  |  | https://bit.ly/2H0Z6Qt |
-|  ds114 | DWI, multiple tasks, events, T1w, BOLD | mri |  |  |  | https://bit.ly/2H0Z6Qt |
-|  ds116 |  |  |  |  |  | https://bit.ly/2H0Z6Qt |
-|  ds210 |  |  |  |  |  | https://bit.ly/2H0Z6Qt |
-|  eeg_cbm | Rest EEG. European Data Format (.edf) |  |  |  |  |  |
+|  ds000247 | Five minutes, eyes-open, resting-state MEG data from 5 subjects. This is a sample from The Open MEG Archive (OMEGA). | mri | meg |  |  | https://openneuro.org/datasets/ds000247/versions/00001 |
+|  ds000248 | MNE sample data: Data with visual and auditory stimuli | mri | meg |  |  | https://openneuro.org/datasets/ds000248/versions/00001 |
+|  ds001 | single task, multiple runs, in-plane T2, events, T1w, BOLD | mri |  |  |  | https://openneuro.org/datasets/ds000001/versions/00006 |
+|  ds002 | multiple tasks, multiple runs, in-plane T2, events, T1w, BOLD | mri |  |  |  | https://openneuro.org/datasets/ds000002/versions/00002 |
+|  ds003 | single task, single run, in-plane T2, events, T1w, BOLD | mri |  |  |  | https://openneuro.org/datasets/ds000003/versions/00001 |
+|  ds005 | single task, multiple runs, in-plane T2, events, T1w, BOLD | mri |  |  |  | https://openneuro.org/datasets/ds000005/versions/00001 |
+|  ds006 | single task, multiple sessions, multiple runs, in-plane T2, events, T1w, BOLD | mri |  |  |  | https://openneuro.org/datasets/ds000006/versions/00001 |
+|  ds007 | single task, multiple runs, in-plane T2, events, T1w, BOLD | mri |  |  |  | https://openneuro.org/datasets/ds000007/versions/00001 |
+|  ds008 | multiple tasks, multiple runs, in-plane T2, events, T1w, BOLD | mri |  |  |  | https://openneuro.org/datasets/ds000008/versions/00001 |
+|  ds009 | multiple tasks, multiple runs, in-plane T2, events, T1w, BOLD | mri |  |  |  | https://openneuro.org/datasets/ds000009/versions/00002 |
+|  ds011 | multiple tasks, multiple runs, T1w, BOLD | mri |  |  |  | https://openneuro.org/datasets/ds000011/versions/00001 |
+|  ds051 | multiple tasks, multiple runs, T1w, BOLD, inplane T2 | mri |  |  |  | https://openneuro.org/datasets/ds000051/versions/00001 |
+|  ds052 | multiple tasks, multiple runs, T1w, BOLD, inplane T2 | mri |  |  |  | https://openneuro.org/datasets/ds000052/versions/00001 |
+|  ds101 | single task, multiple runs, T1w, BOLD | mri |  |  |  | https://openneuro.org/datasets/ds000101/versions/00004 |
+|  ds102 | single task, multiple runs, T1w, BOLD | mri |  |  |  | https://openneuro.org/datasets/ds000102/versions/00001 |
+|  ds105 | single task, multiple runs, T1w, BOLD | mri |  |  |  | https://openneuro.org/datasets/ds000105/versions/00001 |
+|  ds107 | single task, multiple runs, T1w, BOLD | mri |  |  |  | https://openneuro.org/datasets/ds000107/versions/00001 |
+|  ds108 | single task, multiple runs, T1w, BOLD | mri |  |  |  | https://openneuro.org/datasets/ds000108/versions/00002 |
+|  ds109 | multiple tasks, multiple runs, T1w, BOLD | mri |  |  |  | https://openneuro.org/datasets/ds000109/versions/00001 |
+|  ds110 | single task, multiple runs, T1w, BOLD, in plane T2 | mri |  |  |  | https://openneuro.org/datasets/ds000110/versions/00001 |
+|  ds113b | forrest gump watching, multiple sessions, multiple runs, T1w, T2w, BOLD, angiography, dwi, fieldmaps | mri |  |  |  | https://openneuro.org/datasets/ds000113/versions/1.3.0 |
+|  ds114 | multiple tasks, multiple runs, T1w, BOLD, DWI | mri |  |  |  | https://openneuro.org/datasets/ds000114/versions/1.0.1 |
+|  ds116 | multiple tasks, multiple runs, T1w, BOLD, inplane T2 | mri |  |  |  | https://openneuro.org/datasets/ds000116/versions/00003 |
+|  ds210 | multiple tasks, multiple runs, T1w, BOLD | mri |  |  |  | https://openneuro.org/datasets/ds000210/versions/00002 |
+|  eeg_cbm | Rest EEG. European Data Format (.edf) | mri |  |  |  |  |
 |  eeg_ds000117 | Multimodal (fMRI, MEG, EEG) stripped down to EEG with MRI anatomical scan and electrode coordinates. EEGLAB data format (.set, .fdt) | mri |  | eeg |  | https://openneuro.org/datasets/ds000117/ |
 |  eeg_matchingpennies | Offline data of BCI experiment decoding left vs. right hand movement. See Matching Pennies: A Brain Computer Interface Implementation Dataset for more information. BrainVision data format (.eeg, .vhdr, .vmrk) |  |  | eeg |  | https://osf.io/cj2dr/ |
 |  eeg_rest_fmri | Resting state with simultaneous fMRI. BrainVision data format (.eeg, .vhdr, .vmrk) |  |  | eeg |  |  |
 |  eeg_rishikesh | Mind wandering experiment. EEG data in Biosemi (.bdf) format |  |  | eeg |  | https://zenodo.org/record/2536267 |
 |  hcp_example_bids |  |  |  |  |  | https://bit.ly/2H0Z6Qt |
-|  ieeg_epilepsy |  |  |  |  | ieeg | https://openneuro.org/datasets/ds001779 |
-|  ieeg_epilepsy_ecog |  |  |  |  | ieeg | https://openneuro.org/datasets/ds001868 |
+|  ieeg_epilepsy | multiple sessions, tutorial | mri |  |  | ieeg | https://openneuro.org/datasets/ds001779 |
+|  ieeg_epilepsy_ecog | multiple sessions, tutorial | mri |  |  | ieeg | https://openneuro.org/datasets/ds001868 |
 |  ieeg_filtered_speech | recordings of three seizures |  |  |  | ieeg |  |
 |  ieeg_motorMiller2007 | Cue-based hand & tongue movement data |  |  |  | ieeg |  |
 |  ieeg_visual | Stimulus dependence of gamma oscillations in human visual cortex |  |  |  | ieeg |  |
 |  ieeg_visual_multimodal |  |  |  |  | ieeg |  |
-|  synthetic | A synthetic dataset |  |  |  |  |  |
+|  synthetic | A synthetic dataset | mri |  |  |  |  |

--- a/README.md
+++ b/README.md
@@ -1,16 +1,65 @@
 [![Travis](https://api.travis-ci.org/bids-standard/bids-examples.svg?branch=master "Travis")](https://travis-ci.org/bids-standard/bids-examples)
 
-# BIDS-examples
-A set of BIDS compatible datasets with **empty raw data files** that can be used for writing lightweight software tests.
+# bids-examples
+
+This repository contains a set of BIDS compatible datasets with **empty raw
+data files**. These datasets can be useful to:
+
+1. write lightweight software tests
+1. serve as an example on how a BIDS dataset can be structured
 
 ALL RAW DATA FILES IN THIS REPOSITORY ARE EMPTY!
 
-- You can find full versions of most MRI datasets in this repository [here](https://drive.google.com/drive/u/0/folders/0B2JWN60ZLkgkMGlUY3B4MXZIZW8).
-- You can find the full version of mne_sample_data [here](https://drive.google.com/drive/folders/0B_sb8NJ9KsLUQ3BMS0dxZW5nSHM).
-- You can find the full version of ds000246 (Brainstorm auditory tutorial) [here](https://openneuro.org/datasets/ds000246/versions/00001).
-- You can find the full version of ieeg_epilepsy (Brainstorm epileptogenicity tutorial) [here](https://openneuro.org/datasets/ds001779).
-- You can find the full version of ieeg_epilepsy_ecog (Brainstorm ECoG tutorial) [here](https://openneuro.org/datasets/ds001868).
+To learn more about the Brain Imaging Data Structure (BIDS), visit
+http://bids.neuroimaging.io/
 
-To learn more about the Brain Imaging Data Structure (BIDS), visit http://bids.neuroimaging.io/
+If you want to contribute a dataset to the examples, we would be happy to
+accommodate it, as long as it exhibits some structure or particularity that is
+not covered by the already present examples so far.
 
-If you are looking for datasets with particular features, you can check out the documentation in the [WIKI](https://github.com/bids-standard/bids-examples/wiki/), which is sorted by imaging modalities.
+# Dataset index
+
+If you want to update this table, please open a new issue. For simple editing,
+this table is maintained in a [Google sheet](https://docs.google.com/spreadsheets/d/1d9KfmaKvTOpFWgi0Kd-tZGgVTsZk_4BHH9prcgFeigw/edit?usp=sharing), which is then converted to Markdown for this README file.
+
+|  name | description | mri | meg | eeg | ieeg | full data |
+| --- | --- | --- | --- | --- | --- | --- |
+|  7t_trt | field maps, physiological data, quantitative T1 maps, T1w, BOLD | x |  |  |  | https://bit.ly/2H0Z6Qt |
+|  ds000117 | A multi-subject, multi-modal human neuroimaging dataset of 19 subjects on a MEG visual task | x | x | x |  | https://openneuro.org/datasets/ds000117/ |
+|  ds000246 | Auditory dataset used for Brainstorm’s general online tutorial | x | x |  |  | https://openneuro.org/datasets/ds000246/versions/00001 |
+|  ds000247 | Five minutes, eyes-open, resting-state MEG data from 5 subjects. This is a sample from The Open MEG Archive (OMEGA). | x | x |  |  |  |
+|  ds000248 | MNE sample data: Data with visual and auditory stimuli | x | x |  |  | https://bit.ly/2JfNYkf |
+|  ds001 | single task, multiple runs, in-plane T2, events, T1w, BOLD | x |  |  |  | https://bit.ly/2H0Z6Qt |
+|  ds002 | multiple tasks, multiple runs, in-plane T2, events, T1w, BOLD | x |  |  |  | https://bit.ly/2H0Z6Qt |
+|  ds003 | single task, single run, in-plane T2, events, T1w, BOLD | x |  |  |  | https://bit.ly/2H0Z6Qt |
+|  ds005 | single task, multiple runs, in-plane T2, events, T1w, BOLD | x |  |  |  | https://bit.ly/2H0Z6Qt |
+|  ds006 | single task, multiple sessions, multiple runs, in-plane T2, events, T1w, BOLD | x |  |  |  | https://bit.ly/2H0Z6Qt |
+|  ds007 | single task, multiple runs, in-plane T2, events, T1w, BOLD | x |  |  |  | https://bit.ly/2H0Z6Qt |
+|  ds008 | multiple tasks, multiple runs, in-plane T2, events, T1w, BOLD | x |  |  |  | https://bit.ly/2H0Z6Qt |
+|  ds009 | multiple tasks, multiple runs, in-plane T2, events, T1w, BOLD | x |  |  |  | https://bit.ly/2H0Z6Qt |
+|  ds011 |  |  |  |  |  | https://bit.ly/2H0Z6Qt |
+|  ds051 |  |  |  |  |  | https://bit.ly/2H0Z6Qt |
+|  ds052 |  |  |  |  |  | https://bit.ly/2H0Z6Qt |
+|  ds101 |  |  |  |  |  | https://bit.ly/2H0Z6Qt |
+|  ds102 |  |  |  |  |  | https://bit.ly/2H0Z6Qt |
+|  ds105 |  |  |  |  |  | https://bit.ly/2H0Z6Qt |
+|  ds107 |  |  |  |  |  | https://bit.ly/2H0Z6Qt |
+|  ds108 |  |  |  |  |  | https://bit.ly/2H0Z6Qt |
+|  ds109 |  |  |  |  |  | https://bit.ly/2H0Z6Qt |
+|  ds110 |  |  |  |  |  | https://bit.ly/2H0Z6Qt |
+|  ds113b |  |  |  |  |  | https://bit.ly/2H0Z6Qt |
+|  ds114 | DWI, multiple tasks, events, T1w, BOLD | x |  |  |  | https://bit.ly/2H0Z6Qt |
+|  ds116 |  |  |  |  |  | https://bit.ly/2H0Z6Qt |
+|  ds210 |  |  |  |  |  | https://bit.ly/2H0Z6Qt |
+|  eeg_cbm | Rest EEG. European Data Format (.edf) |  |  |  |  |  |
+|  eeg_ds000117 | Multimodal (fMRI, MEG, EEG) stripped down to EEG with MRI anatomical scan and electrode coordinates. EEGLAB data format (.set, .fdt) | x |  | x |  | https://openneuro.org/datasets/ds000117/ |
+|  eeg_matchingpennies | Offline data of BCI experiment decoding left vs. right hand movement. See Matching Pennies: A Brain Computer Interface Implementation Dataset for more information. BrainVision data format (.eeg, .vhdr, .vmrk) |  |  | x |  | https://osf.io/cj2dr/ |
+|  eeg_rest_fmri | Resting state with simultaneous fMRI. BrainVision data format (.eeg, .vhdr, .vmrk) |  |  |  |  |  |
+|  eeg_rishikesh | Mind wandering experiment. EEG data in Biosemi (.bdf) format |  |  | x |  | https://zenodo.org/record/2536267 |
+|  hcp_example_bids |  |  |  |  |  | https://bit.ly/2H0Z6Qt |
+|  ieeg_epilepsy |  |  |  |  | x | https://openneuro.org/datasets/ds001779 |
+|  ieeg_filtered_speech | recordings of three seizures |  |  |  | x |  |
+|  ieeg_motorMiller2007 | Cue-based hand & tongue movement data |  |  |  | x |  |
+|  ieeg_visual | Stimulus dependence of gamma oscillations in human visual cortex |  |  |  | x |  |
+|  ieeg_visual_multimodal |  |  |  |  | x |  |
+|  synthetic | A synthetic dataset |  |  |  |  |  |


### PR DESCRIPTION
This PR fixes #74, by making the documentation on available datasets more accessible and providing a table that shows (approximately) which modalities are present in each dataset.

Also fixes #154 to some extend, by adding all available links to the full data. The rest will have to be added by the respective dataset-authors later on.

The table is quite large although I tried hard to cut down on complexity. I would be very grateful for a review and some feedback.

Note that I also inserted a comment in the README, that we are interested in new examples **as long as** ... they cover some aspects that are not already covered. 

I don't see a point of hosting many datasets here if they are all the same in terms of their structure. Personally, I would even be up for cutting down on some example datasets we are hosting here - so please let me know about your opinion on this as well.

- [ ] Upon merge, delete Wiki

--- 
Rendered version: https://github.com/sappelhoff/bids-examples/blob/overhaul_docs/README.md

Google Sheet version: https://docs.google.com/spreadsheets/d/1d9KfmaKvTOpFWgi0Kd-tZGgVTsZk_4BHH9prcgFeigw/edit?usp=sharing