### PR TITLE
stop validating derivatives dataset until it works

### DIFF
--- a/.github/workflows/validate_datasets.yml
+++ b/.github/workflows/validate_datasets.yml
@@ -74,7 +74,7 @@ jobs:
         do
           echo "Validating dataset" $i
           if [ -f ${i%%/}/.SKIP_VALIATION ]; then
-            echo "skipping validation for" ${i%%/}
+            echo "skipping validation for ${i%%/}"
           elif [ -f ${i%%/}/.bids-validator-config.json ]; then
             bids-validator ${i%%/} --ignoreNiftiHeaders || rc=$?
           else

--- a/.github/workflows/validate_datasets.yml
+++ b/.github/workflows/validate_datasets.yml
@@ -73,7 +73,9 @@ jobs:
         for i in $(ls -d */ | grep -v node_modules);
         do
           echo "Validating dataset" $i
-          if [ -f ${i%%/}/.bids-validator-config.json ]; then
+          if [ -f ${i%%/}/.SKIP_VALIATION ]; then
+            echo "skipping validation for" ${i%%/}
+          elif [ -f ${i%%/}/.bids-validator-config.json ]; then
             bids-validator ${i%%/} --ignoreNiftiHeaders || rc=$?
           else
             bids-validator ${i%%/} --ignoreNiftiHeaders -c $PWD/bidsconfig.json || rc=$?

--- a/.github/workflows/validate_datasets.yml
+++ b/.github/workflows/validate_datasets.yml
@@ -73,7 +73,7 @@ jobs:
         for i in $(ls -d */ | grep -v node_modules);
         do
           echo "Validating dataset" $i
-          if [ -f ${i%%/}/.SKIP_VALIATION ]; then
+          if [ -f ${i%%/}/.SKIP_VALIDATION ]; then
             echo "skipping validation for ${i%%/}"
           elif [ -f ${i%%/}/.bids-validator-config.json ]; then
             bids-validator ${i%%/} --ignoreNiftiHeaders || rc=$?

--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ Some datasets may include a custom `.bids-validator-config.json` to ignore error
 | --- | --- |
 | genetics_ukbb | SliceTiming values for tasks is larger than given TR, EchoTime1 and EchoTime2 are not provided for any of the phasediff files. |
 
+Other datasets may include a `.SKIP_VALIDATION` file, to skip the validation with the continuous integration service.
+This is useful for datasets that *cannot* pass at the moment due to lack of coverage in the [bids-validator](https://github.com/bids-standard/bids-validator).
+
+| name | why skipped |
+| --- | --- |
+| ds000001-fmriprep | lack of coverage in bids-validator |
+
 # Contributing
 
 If you want to contribute a dataset to the examples, we would be happy to
@@ -81,3 +88,4 @@ corresponding Pull Request.
 |  ieeg_visual | Stimulus dependence of gamma oscillations in human visual cortex |  |  |  | ieeg |  |
 |  ieeg_visual_multimodal |  |  |  |  | ieeg |  |
 |  synthetic | A synthetic dataset | mri |  |  |  |  |
+|  ds000001-fmriprep | Common derivatives example | mri | | | | | https://openneuro.org/datasets/ds000001/versions/1.0.0

--- a/ds000001-fmriprep/.bidsignore
+++ b/ds000001-fmriprep/.bidsignore
@@ -8,3 +8,4 @@ figures/
 *_mixing.tsv
 *_AROMAnoiseICs.csv
 *_timeseries.tsv
+SKIP_VALIDATION

--- a/ds000001-fmriprep/.bidsignore
+++ b/ds000001-fmriprep/.bidsignore
@@ -8,4 +8,3 @@ figures/
 *_mixing.tsv
 *_AROMAnoiseICs.csv
 *_timeseries.tsv
-SKIP_VALIDATION


### PR DESCRIPTION
This adds a `.SKIP_VALIDATION` file to the derivatives dataset, which will prevent the CI from evaluating it.

Once we want to reiterate on making the validator work for derivatives, a PR can be opened, the first commit being the remove of the `.SKIP_VALIDATION` file - then validation will work in that PR.

