### PR TITLE
[WIP] Readme empty files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,36 @@
+os: linux
+dist: bionic
+language: "node_js"
+
+node_js:
+  - "12"
+
+install:
+  - npm install -g bids-validator@1.5.4
+
+script:
+  # Checking for large files (there shouldn't be any)
+  - |
+    echo "Checking for big files ..."
+    found=`find . -not -path "./.git*" -type f -size +500k`
+    if [ "$found" == "" ]
+    then
+      echo "No big files present, great!"
+    else
+      echo "Found big files:"
+      echo "$found"
+      exit 1;
+    fi
+  # Validating the BIDS datasets using bids-validator
+  - |
+    rc=0;
+    for i in $(ls -d */ | grep -v node_modules);
+    do
+      echo "Validating dataset" $i
+      if [ -f ${i%%/}/.bids-validator-config.json ]; then
+        bids-validator ${i%%/} --ignoreNiftiHeaders || rc=$?
+      else
+        bids-validator ${i%%/} --ignoreNiftiHeaders -c $PWD/bidsconfig.json || rc=$?
+      fi
+    done
+    exit $rc;

--- a/README.md
+++ b/README.md
@@ -2,27 +2,57 @@
 
 # bids-examples
 
-This repository contains a set of [BIDS-compatible](https://bids.neuroimaging.io/)
-datasets with **empty raw data files**. These datasets can be useful to:
+This repository contains a collection of [BIDS-compatible](https://bids.neuroimaging.io/)
+datasets with **empty raw data files**. These datasets have been contributed as
+test data for lightweight software tests and to provide examples of how BIDS datasets
+may be structured. The [bids-starter-kit](https://github.com/bids-standard/bids-starter-kit)
+is also a good place to look for models of best practice for structuring your BIDS
+dataset.   
 
-1. write lightweight software tests
-1. serve as an example on how a BIDS dataset can be structured
+All of the raw data files in these example datasets are empty.
+Some of the datasets have intact metadata headers (including 
+`synthetic` and most EEG or iEEG datasets in BrainVision format).
+Other datasets have some empty metadata headers.
 
-**ALL RAW DATA FILES IN THIS REPOSITORY ARE EMPTY!**
+# Using the example datasets
 
-However for some of the data, the headers containing the metadata are still
-intact. This is true for the following datasets:
+If you want to use the example datasets with the bids-validator,
+you must indicate that empty raw files and certain empty headers should 
+be ignored during validation. 
 
-- `synthetic`
-- Most EEG or iEEG data in BrainVision format (e.g., `eeg_matchingpennies`)
+**Example:** For example, suppose you are running the bids-validator
+ from the command line and want to validate the example dataset
+ `eeg_matchingpennies`. From the parent directory of `eeg_matchingpennies`
+ execute the following command:
+ 
+````
+ bids-validator eeg_matchingpennies --config.ignore=99 --config.ignore=40
+````
 
-# Validator Exceptions
+See the [bids-validator home page](https://github.com/bids-validator) for
+instructions on how to install and/or use the bids-validator.
 
-Some datasets may include a custom `.bids-validator-config.json` to ignore errors generated from idiosyncracies of the datasets as they existed on creation.
+# Validator configuration for the example datasets
+
+You can put required validator configuration information in a custom 
+`.bids-validator-config.json` file in the root of your dataset.
+The configuration file that would be required to ignore 
+empty raw files and empty Nifti headers is:
+
+````json
+{
+     "ignore": [99, 40] 
+} 
+````
+ 
+Some datasets in [bids-examples](https://github.com/bids-examples) may 
+have a custom configuration file tailored to ignore errors generated 
+from idiosyncracies particular to that dataset. 
 
 | name | errors ignored |
 | --- | --- |
 | genetics_ukbb | SliceTiming values for tasks is larger than given TR, EchoTime1 and EchoTime2 are not provided for any of the phasediff files. |
+
 
 Other datasets may include a `.SKIP_VALIDATION` file, to skip the validation with the continuous integration service.
 This is useful for datasets that *cannot* pass at the moment due to lack of coverage in the [bids-validator](https://github.com/bids-standard/bids-validator).

--- a/eeg_ds000117/dataset_description.json
+++ b/eeg_ds000117/dataset_description.json
@@ -1,6 +1,7 @@
 {
 	"Name": "EEG derived data from 'A multi-subject, multi-modal human neuroimaging dataset: fMRI, EEG and MEG data on face processing'",
 	"BIDSVersion": "v1.X, BEP006",
+	"HEDVersion": "v8.0.0-alpha.1"
 	"License": " Creative Commons Attribution 4.0 International License",
 	"Authors": ["Cyril Pernet", "Ramon Martinez"],
 	"Acknowledgements": "UK Medical Research Council and Elekta Ltd",

--- a/eeg_ds000117/task-facerecoginition_events.json
+++ b/eeg_ds000117/task-facerecoginition_events.json
@@ -1,0 +1,60 @@
+{
+   "trial_type": {
+       "LongName": "Type of image",
+       "Description": "Main types of images ",
+       "Levels": {
+          "Famous": "Head photo of a famous person",
+          "Unfamiliar": "Head photo of an unknown person",
+          "Scrambled": "Scrambled image of a head photo"
+       },
+       "HED": {
+           "Famous": "Sensory-event, Visual, (Center-of, Screen), (Image, Face, (External-evidence, Familiar)),
+		   Description/Head photo of a famous person", 
+           "Unfamiliar": "Sensory-event, Visual, (Center-of, Screen), (Image, Face, (External-evidence, Unfamiliar)),
+		   Description/Head photo of an unknown person",
+           "Scrambled": "Sensory-event, Visual, (Center-of, Screen), (Image, Face, (External-evidence, Disordered)),
+		   Description/Scrambled image of a head photo",
+        }
+   },
+   "event_value": {
+       "LongName": "Indicator of type of image repetition",
+       "Description": "Image repetition triggers",
+       "Levels": {
+          "5": "Initial presentation of famous photo",
+          "6": "Immediate repetition of famous photo just seen",
+          "7": "Delayed repetition of famous photo",
+		  "13": "Initial presentation of unfamiliar photo",
+          "14": "Immediate repetition of unfamiliar photo just seen",
+          "15": "Delayed repetition of unfamiliar photo",
+		  "17": "Initial presentation of scrambled photo",
+          "18": "Immediate repetition of scrambled photo just seen",
+          "19": "Delayed repetition of scrambled photo"
+       },
+       "HED": {
+          "5": "First-item Image, Face, (External-evidence, Familiar), Description/Initial presentation of famous photo",
+          "6": "Next-item, Description/Immediate repetition of famous photo just seen",
+          "7": "Later-item, Description/Delayed repetition of famous photo",
+		  "13": "First-item, Description/Initial presentation of unfamiliar photo",
+          "14": "Next-item, Description/Immediate repetition of unfamiliar photo just seen",
+          "15": "Later-item, Description/Delayed repetition of unfamiliar photo",
+		  "17": "First-item, Description/Initial presentation of scrambled photo",
+          "18": "Next-item, Description/Immediate repetition of scrambled photo just seen",
+          "19": "Later-item, Description/Delayed repetition of scrambled photo"
+       },
+        }
+   }  "stim_file": {
+       "LongName": "Name of the image file presented",
+       "Description": "Image repetition triggers",
+       "Levels": {
+          "5": "Initial presentation of famous photo",
+          "6": "Immediate repetition of famous photo just seen",
+          "7": "Delayed repetition of famous photo",
+		  "13": "Initial presentation of unfamiliar photo",
+          "14": "Immediate repetition of unfamiliar photo just seen",
+          "15": "Delayed repetition of unfamiliar photo",
+		  "17": "Initial presentation of scrambled photo",
+          "18": "Immediate repetition of scrambled photo just seen",
+          "19": "Delayed repetition of scrambled photo"
+       },
+   
+}


### PR DESCRIPTION
Here is my first stab at expanding the README. I wasn't able to test the code as haven't figured out what the issue is with my local copy of the bids-validator.  My goal was to make it easier for people new to bids to try things out.  The easiest way is for people to use the bids-validator on the web --- but that isn't yet possible because the interface has no checkbox to ignore empty raw files.

This is just a start --- improvements are needed/welcome.