### PR TITLE
added "TotalReadoutTime"

### DIFF
--- a/asl004/sub-Sub1/perf/sub-Sub1_asl.json
+++ b/asl004/sub-Sub1/perf/sub-Sub1_asl.json
@@ -4,6 +4,7 @@
 "MRAcquisitionType":"2D",
 "PulseSequenceType":"EPI",
 "PhaseEncodingDirection":"j-",
+"TotalReadoutTime":0.06,
 "EchoTime":0.014,
 "SliceTiming":[0,0.0452,0.0904,0.1356,0.1808,0.226,0.2712,0.3164,0.3616,0.4068,0.452,0.4972,0.5424,0.5876,0.6328,0.678,0.7232,0.7684,0.8136,0.8588,0.904,0.9492,0.9944,1.0396],
 "FlipAngle":90,


### PR DESCRIPTION
Added TotalReadoutTime. In case of pe_polar, ASL analysis software required this information for asl as well. Therefore, we have added this in the example