### PR TITLE
Updated dataset_description in pet examples to be human readable

### DIFF
--- a/pet001/dataset_description.json
+++ b/pet001/dataset_description.json
@@ -1,1 +1,8 @@
-{"BIDSVersion":"1.0.2","License":"CCO license","Name":"[11C]CIMBI36 PET dataset of a pig","Authors":["Melanie Ganz-Benjaminsen","Martin Noergaard","Hanne Demant Hansen"],"Acknowledgements":"Knudsen GM, Jensen PS, Erritzoe D, Baaré WFC, Ettrup A, Fisher PM, Gillings N, Hansen HD, Hansen LK, Hasselbalch SG, Henningsson S, Herth MM, Holst KK, Iversen P, Kessing LV, Macoveanu J, Madsen KS, Mortensen EL, Nielsen FÅ, Paulson OB, Siebner HR, Stenbæk DS, Svarer C, Jernigan TL, Strother SC, Frokjaer VG. The Center for Integrated Molecular Brain Imaging (Cimbi) Database. NeuroImage. 2016 Jan 1;124(Pt B):1213-1219","HowToAcknowledge":"This data was obtained from the Cimbi database.","Funding":["Lundbeck Foundation R90-A7722","Danish Research Council 09-063598","Rigshospitalet"],"DatasetDOI":""}
+{"BIDSVersion":"1.5.0",
+    "License":"CCO license",
+    "Name":"[11C]CIMBI36 PET dataset of a pig",
+    "Authors":["Melanie Ganz-Benjaminsen","Martin Noergaard","Hanne Demant Hansen"],
+    "Acknowledgements":"Knudsen GM, Jensen PS, Erritzoe D, Baaré WFC, Ettrup A, Fisher PM, Gillings N, Hansen HD, Hansen LK, Hasselbalch SG, Henningsson S, Herth MM, Holst KK, Iversen P, Kessing LV, Macoveanu J, Madsen KS, Mortensen EL, Nielsen FÅ, Paulson OB, Siebner HR, Stenbæk DS, Svarer C, Jernigan TL, Strother SC, Frokjaer VG. The Center for Integrated Molecular Brain Imaging (Cimbi) Database. NeuroImage. 2016 Jan 1;124(Pt B):1213-1219",
+    "HowToAcknowledge":"This data was obtained from the Cimbi database.",
+    "Funding":["Lundbeck Foundation R90-A7722","Danish Research Council 09-063598","Rigshospitalet"],
+    "DatasetDOI":""}

--- a/pet002/dataset_description.json
+++ b/pet002/dataset_description.json
@@ -1,1 +1,8 @@
-{"BIDSVersion":"1.0.2","License":"CCO license","Name":"[11C]DASB PET Cimbi database example","Authors":["Melanie Ganz-Benjaminsen","Martin Noergaard"],"Acknowledgements":"Knudsen GM, Jensen PS, Erritzoe D, Baaré WFC, Ettrup A, Fisher PM, Gillings N, Hansen HD, Hansen LK, Hasselbalch SG, Henningsson S, Herth MM, Holst KK, Iversen P, Kessing LV, Macoveanu J, Madsen KS, Mortensen EL, Nielsen FÅ, Paulson OB, Siebner HR, Stenbæk DS, Svarer C, Jernigan TL, Strother SC, Frokjaer VG. The Center for Integrated Molecular Brain Imaging (Cimbi) Database. NeuroImage. 2016 Jan 1;124(Pt B):1213-1219","HowToAcknowledge":"This data was obtained from the Cimbi database.","Funding":["Lundbeck Foundation R90-A7722","Danish Research Council 09-063598","Rigshospitalet"],"DatasetDOI":""}
+{"BIDSVersion":"1.5.0",
+    "License":"CCO license",
+    "Name":"[11C]DASB PET Cimbi database example",
+    "Authors":["Melanie Ganz-Benjaminsen","Martin Noergaard"],
+    "Acknowledgements":"Knudsen GM, Jensen PS, Erritzoe D, Baaré WFC, Ettrup A, Fisher PM, Gillings N, Hansen HD, Hansen LK, Hasselbalch SG, Henningsson S, Herth MM, Holst KK, Iversen P, Kessing LV, Macoveanu J, Madsen KS, Mortensen EL, Nielsen FÅ, Paulson OB, Siebner HR, Stenbæk DS, Svarer C, Jernigan TL, Strother SC, Frokjaer VG. The Center for Integrated Molecular Brain Imaging (Cimbi) Database. NeuroImage. 2016 Jan 1;124(Pt B):1213-1219",
+    "HowToAcknowledge":"This data was obtained from the Cimbi database.",
+    "Funding":["Lundbeck Foundation R90-A7722","Danish Research Council 09-063598","Rigshospitalet"],
+    "DatasetDOI":""}

--- a/pet003/dataset_description.json
+++ b/pet003/dataset_description.json
@@ -1,4 +1,4 @@
-{"BIDSVersion":"1.0.4",
+{"BIDSVersion":"1.5.0",
     "License":"CCO license",
     "Name":"[11C]DASB data set",
     "Authors":["Martin Norgaard","Christine Delorenzo","Ramin Parsey"],

--- a/pet004/dataset_description.json
+++ b/pet004/dataset_description.json
@@ -1,1 +1,8 @@
-{"BIDSVersion":"1.5.0","License":"CCO license","Name":"[11C]CIMBI36 PET dataset of a pig, with ketanserin intervention","Authors":["Melanie Ganz-Benjaminsen","Martin Noergaard","Hanne Demant Hansen"],"Acknowledgements":"Knudsen GM, Jensen PS, Erritzoe D, Baaré WFC, Ettrup A, Fisher PM, Gillings N, Hansen HD, Hansen LK, Hasselbalch SG, Henningsson S, Herth MM, Holst KK, Iversen P, Kessing LV, Macoveanu J, Madsen KS, Mortensen EL, Nielsen FÅ, Paulson OB, Siebner HR, Stenbæk DS, Svarer C, Jernigan TL, Strother SC, Frokjaer VG. The Center for Integrated Molecular Brain Imaging (Cimbi) Database. NeuroImage. 2016 Jan 1;124(Pt B):1213-1219","HowToAcknowledge":"This data was obtained from the Cimbi database.","Funding":["Lundbeck Foundation R90-A7722","Danish Research Council 09-063598","Rigshospitalet"],"DatasetDOI":""}
+{"BIDSVersion":"1.5.0",
+    "License":"CCO license",
+    "Name":"[11C]CIMBI36 PET dataset of a pig, with ketanserin intervention",
+    "Authors":["Melanie Ganz-Benjaminsen","Martin Noergaard","Hanne Demant Hansen"],
+    "Acknowledgements":"Knudsen GM, Jensen PS, Erritzoe D, Baaré WFC, Ettrup A, Fisher PM, Gillings N, Hansen HD, Hansen LK, Hasselbalch SG, Henningsson S, Herth MM, Holst KK, Iversen P, Kessing LV, Macoveanu J, Madsen KS, Mortensen EL, Nielsen FÅ, Paulson OB, Siebner HR, Stenbæk DS, Svarer C, Jernigan TL, Strother SC, Frokjaer VG. The Center for Integrated Molecular Brain Imaging (Cimbi) Database. NeuroImage. 2016 Jan 1;124(Pt B):1213-1219",
+    "HowToAcknowledge":"This data was obtained from the Cimbi database.",
+    "Funding":["Lundbeck Foundation R90-A7722","Danish Research Council 09-063598","Rigshospitalet"],
+    "DatasetDOI":""}

--- a/pet005/dataset_description.json
+++ b/pet005/dataset_description.json
@@ -1,1 +1,7 @@
-{"BIDSVersion":"1.5.0","License":"CCO license","Name":"[11C]AZ10419369 PET dataset of a single person","Authors":["Hanne Demant Hansen","Melanie Ganz-Benjaminsen","Martin Noergaard"],"Acknowledgements":"Hansen, HD, Lindberg, U, Ozenne, B, et al. Visual stimuli induce serotonin release in occipital cortex: A simultaneous positron emission tomography/magnetic resonance imaging study. Hum Brain Mapp. 2020; 41: 4753– 4763. https://doi.org/10.1002/hbm.25156.","Funding":["Funding for the project was provided by the Lundbeck Foundation (R-165-2013-15637, R231-2016-3236), Innovation Fund Denmark (4108-00004B) and from the European Union's Horizon 2020 research and innovation program under the Marie Sklodowska-Curie grant agreement No 746850"],"DatasetDOI":""}
+{"BIDSVersion":"1.5.0",
+    "License":"CCO license",
+    "Name":"[11C]AZ10419369 PET dataset of a single person",
+    "Authors":["Hanne Demant Hansen","Melanie Ganz-Benjaminsen","Martin Noergaard"],
+    "Acknowledgements":"Hansen, HD, Lindberg, U, Ozenne, B, et al. Visual stimuli induce serotonin release in occipital cortex: A simultaneous positron emission tomography/magnetic resonance imaging study. Hum Brain Mapp. 2020; 41: 4753– 4763. https://doi.org/10.1002/hbm.25156.",
+    "Funding":["Funding for the project was provided by the Lundbeck Foundation (R-165-2013-15637, R231-2016-3236), Innovation Fund Denmark (4108-00004B) and from the European Union's Horizon 2020 research and innovation program under the Marie Sklodowska-Curie grant agreement No 746850"],
+    "DatasetDOI":""}


### PR DESCRIPTION
Fixing dataset_description for pet examples from https://github.com/bids-standard/bids-examples/pull/205#discussion_r604142005 @sappelhoff 