### PR TITLE
CI: auto-cancel duplicate CI jobs

### DIFF
--- a/.github/workflows/validate_datasets.yml
+++ b/.github/workflows/validate_datasets.yml
@@ -11,6 +11,10 @@ on:
   schedule:
     - cron: "0 4 * * 1"
 
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION
this [new feature for GH actions](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency) may be helpful for the case where we open a PR to this repo **from** this repo (as oppposed to **from** a fork).

In those cases we had duplicate jobs running in the past, marked by "pull" and "push" --> with this feature, the duplicates should be cancelled.

Example of what we don't want anymore (screenshot):

![image](https://user-images.githubusercontent.com/9084751/118770283-6df50c00-b881-11eb-967a-c13b1c72d875.png)


see CI in https://github.com/bids-standard/bids-examples/pull/225

