### PR TITLE
ieeg: deprecate DCOffsetCorrection field

### DIFF
--- a/ieeg_epilepsy/sub-01/ses-postimp/ieeg/sub-01_ses-postimp_task-seizure_run-01_ieeg.json
+++ b/ieeg_epilepsy/sub-01/ses-postimp/ieeg/sub-01_ses-postimp_task-seizure_run-01_ieeg.json
@@ -3,7 +3,6 @@
     "SamplingFrequency": 512,
     "PowerLineFrequency": 50,
     "SoftwareFilters": "n/a",
-    "DCOffsetCorrection": "n/a",
     "HardwareFilters": "n/a",
     "Manufacturer": "Micromed",
     "ManufacturersModelName": "Unknown",

--- a/ieeg_epilepsy/sub-01/ses-postimp/ieeg/sub-01_ses-postimp_task-seizure_run-02_ieeg.json
+++ b/ieeg_epilepsy/sub-01/ses-postimp/ieeg/sub-01_ses-postimp_task-seizure_run-02_ieeg.json
@@ -3,7 +3,6 @@
     "SamplingFrequency": 512,
     "PowerLineFrequency": 50,
     "SoftwareFilters": "n/a",
-    "DCOffsetCorrection": "n/a",
     "HardwareFilters": "n/a",
     "Manufacturer": "Micromed",
     "ManufacturersModelName": "Unknown",

--- a/ieeg_epilepsy/sub-01/ses-postimp/ieeg/sub-01_ses-postimp_task-seizure_run-03_ieeg.json
+++ b/ieeg_epilepsy/sub-01/ses-postimp/ieeg/sub-01_ses-postimp_task-seizure_run-03_ieeg.json
@@ -3,7 +3,6 @@
     "SamplingFrequency": 512,
     "PowerLineFrequency": 50,
     "SoftwareFilters": "n/a",
-    "DCOffsetCorrection": "n/a",
     "HardwareFilters": "n/a",
     "Manufacturer": "Micromed",
     "ManufacturersModelName": "Unknown",

--- a/ieeg_epilepsy_ecog/sub-ecog01/ses-postimp/ieeg/sub-ecog01_ses-postimp_task-seizure_run-01_ieeg.json
+++ b/ieeg_epilepsy_ecog/sub-ecog01/ses-postimp/ieeg/sub-ecog01_ses-postimp_task-seizure_run-01_ieeg.json
@@ -6,7 +6,6 @@
     "PowerLineFrequency": 50,
     "HardwareFilters": "n/a",
     "SoftwareFilters": "n/a",
-    "DCOffsetCorrection": "n/a",
     "Manufacturer": "Neurofile NT",
     "ManufacturersModelName": "Neurofile NT digital video-EEG system with 128 channels and a 16-bit A/D converter",
     "InstitutionName": "Epilepsy Centre, University Hospital Freiburg, Germany",

--- a/ieeg_filtered_speech/sub-cm4/ieeg/sub-cm4_ieeg.json
+++ b/ieeg_filtered_speech/sub-cm4/ieeg/sub-cm4_ieeg.json
@@ -14,6 +14,5 @@
     "EMGChannelCount": 0,
     "MiscChannelCount": 0,
     "TriggerChannelCount": 0,
-    "iEEGReference": "common average",
-    "DCOffsetCorrection": "none"
+    "iEEGReference": "common average"
 }

--- a/ieeg_filtered_speech/sub-cm8/ieeg/sub-cm8_ieeg.json
+++ b/ieeg_filtered_speech/sub-cm8/ieeg/sub-cm8_ieeg.json
@@ -14,6 +14,5 @@
     "EMGChannelCount": 0,
     "MiscChannelCount": 0,
     "TriggerChannelCount": 0,
-    "iEEGReference": "common average",
-    "DCOffsetCorrection": "none"
+    "iEEGReference": "common average"
 }

--- a/ieeg_filtered_speech/sub-ir05/ieeg/sub-ir05_ieeg.json
+++ b/ieeg_filtered_speech/sub-ir05/ieeg/sub-ir05_ieeg.json
@@ -14,6 +14,5 @@
     "EMGChannelCount": 0,
     "MiscChannelCount": 0,
     "TriggerChannelCount": 0,
-    "iEEGReference": "common average",
-    "DCOffsetCorrection": "none"
+    "iEEGReference": "common average"
 }

--- a/ieeg_filtered_speech/sub-ir07/ieeg/sub-ir07_ieeg.json
+++ b/ieeg_filtered_speech/sub-ir07/ieeg/sub-ir07_ieeg.json
@@ -14,6 +14,5 @@
     "EMGChannelCount": 0,
     "MiscChannelCount": 0,
     "TriggerChannelCount": 0,
-    "iEEGReference": "common average",
-    "DCOffsetCorrection": "none"
+    "iEEGReference": "common average"
 }

--- a/ieeg_filtered_speech/sub-ir08/ieeg/sub-ir08_ieeg.json
+++ b/ieeg_filtered_speech/sub-ir08/ieeg/sub-ir08_ieeg.json
@@ -14,6 +14,5 @@
     "EMGChannelCount": 0,
     "MiscChannelCount": 0,
     "TriggerChannelCount": 0,
-    "iEEGReference": "common average",
-    "DCOffsetCorrection": "none"
+    "iEEGReference": "common average"
 }

--- a/ieeg_filtered_speech/sub-jh17/ieeg/sub-jh17_ieeg.json
+++ b/ieeg_filtered_speech/sub-jh17/ieeg/sub-jh17_ieeg.json
@@ -14,6 +14,5 @@
     "EMGChannelCount": 0,
     "MiscChannelCount": 0,
     "TriggerChannelCount": 0,
-    "iEEGReference": "common average",
-    "DCOffsetCorrection": "none"
+    "iEEGReference": "common average"
 }

--- a/ieeg_filtered_speech/sub-jh19/ieeg/sub-jh19_ieeg.json
+++ b/ieeg_filtered_speech/sub-jh19/ieeg/sub-jh19_ieeg.json
@@ -14,6 +14,5 @@
     "EMGChannelCount": 0,
     "MiscChannelCount": 0,
     "TriggerChannelCount": 0,
-    "iEEGReference": "common average",
-    "DCOffsetCorrection": "none"
+    "iEEGReference": "common average"
 }


### PR DESCRIPTION
cc @ftadel @dorahermes based on https://github.com/bids-standard/bids-specification/pull/799

I am removing the (in any case unused) DCOffsetCorrection field from some ieeg datasets. You may want to mirror these changes, if needed.

Also, please review and approve https://github.com/bids-standard/bids-specification/pull/799 ... or stop the process if you think it's going in the wrong direction.