### PR TITLE
Updated eeg_hed_small to be HED-3G compliant

### DIFF
--- a/eeg_hed_small/dataset_description.json
+++ b/eeg_hed_small/dataset_description.json
@@ -1,6 +1,6 @@
 {
     "Name": "Face processing MEEG dataset with HED annotation",
-    "BIDSVersion": "v1.8.2",
+    "BIDSVersion": "v1.6.0",
     "HEDVersion": "8.0.0",
     "License": "CC0",
     "Authors": [

--- a/eeg_hed_small/dataset_description.json
+++ b/eeg_hed_small/dataset_description.json
@@ -1,7 +1,7 @@
 {
     "Name": "Face processing MEEG dataset with HED annotation",
-    "BIDSVersion": "v1.4.0",
-    "HEDVersion": "8.0.0-alpha.2",
+    "BIDSVersion": "v1.8.2",
+    "HEDVersion": "8.0.0",
     "License": "CC0",
     "Authors": [
         "Daniel G. Wakeman",

--- a/eeg_hed_small/sub-002/eeg/sub-002_task-FacePerception_run-1_events.tsv
+++ b/eeg_hed_small/sub-002/eeg/sub-002_task-FacePerception_run-1_events.tsv
@@ -1,554 +1,554 @@
-onset	duration	sample	event_type	face_type	repetition_type	trigger	stim_file
-0.0040000000	n/a	1	setup	n/a	n/a	n/a	n/a
-0.0040000000	n/a	1	right_sym	n/a	n/a	n/a	n/a
-24.2098181818	n/a	6052.4545	show_face	unfamiliar_face	first_show	13	u032.bmp
-25.0352727273	n/a	6258.8182	show_circle	n/a	n/a	0	circle.bmp
-25.1580000000	n/a	6289.5	left_press	n/a	n/a	256	n/a
-26.7352727273	n/a	6683.8182	show_cross	n/a	n/a	n/a	cross.bmp
-27.2498181818	n/a	6812.4545	show_face	unfamiliar_face	immediate_repeat	14	u032.bmp
-27.8970909091	n/a	6974.2727	left_press	n/a	n/a	256	n/a
-28.0998181818	n/a	7024.9545	show_circle	n/a	n/a	0	circle.bmp
-29.7998181818	n/a	7449.9545	show_cross	n/a	n/a	n/a	cross.bmp
-30.3570909091	n/a	7589.2727	show_face	unfamiliar_face	first_show	13	u088.bmp
-31.1880000000	n/a	7797	show_circle	n/a	n/a	0	circle.bmp
-32.8880000000	n/a	8222	show_cross	n/a	n/a	n/a	cross.bmp
-33.3643636364	n/a	8341.0909	show_face	unfamiliar_face	first_show	13	u084.bmp
-34.3680000000	n/a	8592	show_circle	n/a	n/a	0	circle.bmp
-36.0680000000	n/a	9017	show_cross	n/a	n/a	n/a	cross.bmp
-36.5561818182	n/a	9139.0455	show_face	famous_face	first_show	5	f123.bmp
-37.3161818182	n/a	9329.0455	right_press	n/a	n/a	4096	n/a
-37.3825454545	n/a	9345.6364	show_circle	n/a	n/a	0	circle.bmp
-39.0825454545	n/a	9770.6364	show_cross	n/a	n/a	n/a	cross.bmp
-39.5789090909	n/a	9894.7273	show_face	unfamiliar_face	first_show	13	u022.bmp
-40.5816363636	n/a	10145.4091	show_circle	n/a	n/a	0	circle.bmp
-42.2816363636	n/a	10570.4091	show_cross	n/a	n/a	n/a	cross.bmp
-42.8025454545	n/a	10700.6364	show_face	famous_face	first_show	5	f094.bmp
-43.5489090909	n/a	10887.2273	right_press	n/a	n/a	4096	n/a
-43.7198181818	n/a	10929.9545	show_circle	n/a	n/a	0	circle.bmp
-45.4198181818	n/a	11354.9545	show_cross	n/a	n/a	n/a	cross.bmp
-46.0434545455	n/a	11510.8636	show_face	scrambled_face	first_show	17	s150.bmp
-46.9507272727	n/a	11737.6818	show_circle	n/a	n/a	0	circle.bmp
-48.6507272727	n/a	12162.6818	show_cross	n/a	n/a	n/a	cross.bmp
-49.1343636364	n/a	12283.5909	show_face	unfamiliar_face	delayed_repeat	15	u088.bmp
-50.1352727273	n/a	12533.8182	show_circle	n/a	n/a	0	circle.bmp
-51.8352727273	n/a	12958.8182	show_cross	n/a	n/a	n/a	cross.bmp
-52.3916363636	n/a	13097.9091	show_face	famous_face	first_show	5	f063.bmp
-53.1007272727	n/a	13275.1818	right_press	n/a	n/a	4096	n/a
-53.2616363636	n/a	13315.4091	show_circle	n/a	n/a	0	circle.bmp
-54.9616363636	n/a	13740.4091	show_cross	n/a	n/a	n/a	cross.bmp
-55.5489090909	n/a	13887.2273	show_face	unfamiliar_face	delayed_repeat	15	u084.bmp
-56.5589090909	n/a	14139.7273	show_circle	n/a	n/a	0	circle.bmp
-58.2589090909	n/a	14564.7273	show_cross	n/a	n/a	n/a	cross.bmp
-58.8061818182	n/a	14701.5455	show_face	unfamiliar_face	first_show	13	u004.bmp
-59.5407272727	n/a	14885.1818	left_press	n/a	n/a	256	n/a
-59.7270909091	n/a	14931.7727	show_circle	n/a	n/a	0	circle.bmp
-61.4270909091	n/a	15356.7727	show_cross	n/a	n/a	n/a	cross.bmp
-61.9134545455	n/a	15478.3636	show_face	unfamiliar_face	immediate_repeat	14	u004.bmp
-62.8507272727	n/a	15712.6818	left_press	n/a	n/a	256	n/a
-62.8934545455	n/a	15723.3636	show_circle	n/a	n/a	0	circle.bmp
-64.5934545455	n/a	16148.3636	show_cross	n/a	n/a	n/a	cross.bmp
-65.1043636364	n/a	16276.0909	show_face	famous_face	delayed_repeat	7	f123.bmp
-65.7989090909	n/a	16449.7273	right_press	n/a	n/a	4096	n/a
-66.1043636364	n/a	16526.0909	show_circle	n/a	n/a	0	circle.bmp
-67.8043636364	n/a	16951.0909	show_cross	n/a	n/a	n/a	cross.bmp
-68.4289090909	n/a	17107.2273	show_face	famous_face	first_show	5	f006.bmp
-69.3470909091	n/a	17336.7727	right_press	n/a	n/a	4096	n/a
-69.3625454545	n/a	17340.6364	show_circle	n/a	n/a	0	circle.bmp
-71.0625454545	n/a	17765.6364	show_cross	n/a	n/a	n/a	cross.bmp
-71.6025454545	n/a	17900.6364	show_face	unfamiliar_face	delayed_repeat	15	u022.bmp
-72.3298181818	n/a	18082.4545	right_press	n/a	n/a	4096	n/a
-72.5616363636	n/a	18140.4091	show_circle	n/a	n/a	0	circle.bmp
-74.2616363636	n/a	18565.4091	show_cross	n/a	n/a	n/a	cross.bmp
-74.7598181818	n/a	18689.9545	show_face	scrambled_face	first_show	17	s043.bmp
-75.6989090909	n/a	18924.7273	left_press	n/a	n/a	256	n/a
-75.7334545455	n/a	18933.3636	show_circle	n/a	n/a	0	circle.bmp
-77.4334545455	n/a	19358.3636	show_cross	n/a	n/a	n/a	cross.bmp
-78.0670909091	n/a	19516.7727	show_face	scrambled_face	immediate_repeat	18	s043.bmp
-78.8107272727	n/a	19702.6818	left_press	n/a	n/a	256	n/a
-78.9434545455	n/a	19735.8636	show_circle	n/a	n/a	0	circle.bmp
-80.6434545455	n/a	20160.8636	show_cross	n/a	n/a	n/a	cross.bmp
-81.1916363636	n/a	20297.9091	show_face	famous_face	delayed_repeat	7	f094.bmp
-81.8416363636	n/a	20460.4091	right_press	n/a	n/a	4096	n/a
-82.1370909091	n/a	20534.2727	show_circle	n/a	n/a	0	circle.bmp
-83.8370909091	n/a	20959.2727	show_cross	n/a	n/a	n/a	cross.bmp
-84.4989090909	n/a	21124.7273	show_face	scrambled_face	first_show	17	s083.bmp
-85.4307272727	n/a	21357.6818	show_circle	n/a	n/a	0	circle.bmp
-85.6189090909	n/a	21404.7273	left_press	n/a	n/a	256	n/a
-87.1307272727	n/a	21782.6818	show_cross	n/a	n/a	n/a	cross.bmp
-87.7561818182	n/a	21939.0455	show_face	scrambled_face	immediate_repeat	18	s083.bmp
-88.6252727273	n/a	22156.3182	show_circle	n/a	n/a	0	circle.bmp
-90.3252727273	n/a	22581.3182	show_cross	n/a	n/a	n/a	cross.bmp
-90.8970909091	n/a	22724.2727	show_face	scrambled_face	delayed_repeat	19	s150.bmp
-91.7243636364	n/a	22931.0909	show_circle	n/a	n/a	0	circle.bmp
-93.4243636364	n/a	23356.0909	show_cross	n/a	n/a	n/a	cross.bmp
-93.8870909091	n/a	23471.7727	show_face	famous_face	first_show	5	f093.bmp
-94.7770909091	n/a	23694.2727	show_circle	n/a	n/a	0	circle.bmp
-94.8107272727	n/a	23702.6818	left_press	n/a	n/a	256	n/a
-96.4770909091	n/a	24119.2727	show_cross	n/a	n/a	n/a	cross.bmp
-97.0780000000	n/a	24269.5	show_face	famous_face	delayed_repeat	7	f063.bmp
-97.6680000000	n/a	24417	right_press	n/a	n/a	4096	n/a
-97.9389090909	n/a	24484.7273	show_circle	n/a	n/a	0	circle.bmp
-99.6389090909	n/a	24909.7273	show_cross	n/a	n/a	n/a	cross.bmp
-100.2180000000	n/a	25054.5	show_face	famous_face	first_show	5	f143.bmp
-100.9407272727	n/a	25235.1818	right_press	n/a	n/a	4096	n/a
-101.2198181818	n/a	25304.9545	show_circle	n/a	n/a	0	circle.bmp
-102.9198181818	n/a	25729.9545	show_cross	n/a	n/a	n/a	cross.bmp
-103.4589090909	n/a	25864.7273	show_face	famous_face	immediate_repeat	6	f143.bmp
-104.0743636364	n/a	26018.5909	right_press	n/a	n/a	4096	n/a
-104.3925454545	n/a	26098.1364	show_circle	n/a	n/a	0	circle.bmp
-106.0925454545	n/a	26523.1364	show_cross	n/a	n/a	n/a	cross.bmp
-106.5661818182	n/a	26641.5455	show_face	scrambled_face	first_show	17	s142.bmp
-107.4080000000	n/a	26852	show_circle	n/a	n/a	0	circle.bmp
-107.4134545455	n/a	26853.3636	left_press	n/a	n/a	256	n/a
-109.1080000000	n/a	27277	show_cross	n/a	n/a	n/a	cross.bmp
-109.7407272727	n/a	27435.1818	show_face	famous_face	delayed_repeat	7	f006.bmp
-110.5252727273	n/a	27631.3182	left_press	n/a	n/a	256	n/a
-110.7089090909	n/a	27677.2273	show_circle	n/a	n/a	0	circle.bmp
-112.4089090909	n/a	28102.2273	show_cross	n/a	n/a	n/a	cross.bmp
-112.9980000000	n/a	28249.5	show_face	unfamiliar_face	first_show	13	u131.bmp
-113.7443636364	n/a	28436.0909	left_press	n/a	n/a	256	n/a
-113.9298181818	n/a	28482.4545	show_circle	n/a	n/a	0	circle.bmp
-115.6298181818	n/a	28907.4545	show_cross	n/a	n/a	n/a	cross.bmp
-116.1380000000	n/a	29034.5	show_face	unfamiliar_face	first_show	13	u020.bmp
-117.1143636364	n/a	29278.5909	show_circle	n/a	n/a	0	circle.bmp
-118.8143636364	n/a	29703.5909	show_cross	n/a	n/a	n/a	cross.bmp
-119.2789090909	n/a	29819.7273	show_face	unfamiliar_face	immediate_repeat	14	u020.bmp
-119.8943636364	n/a	29973.5909	left_press	n/a	n/a	256	n/a
-120.1043636364	n/a	30026.0909	show_circle	n/a	n/a	0	circle.bmp
-121.8043636364	n/a	30451.0909	show_cross	n/a	n/a	n/a	cross.bmp
-122.3025454545	n/a	30575.6364	show_face	scrambled_face	first_show	17	s088.bmp
-123.1370909091	n/a	30784.2727	left_press	n/a	n/a	256	n/a
-123.2089090909	n/a	30802.2273	show_circle	n/a	n/a	0	circle.bmp
-124.9089090909	n/a	31227.2273	show_cross	n/a	n/a	n/a	cross.bmp
-125.4098181818	n/a	31352.4545	show_face	famous_face	delayed_repeat	7	f093.bmp
-126.0852727273	n/a	31521.3182	right_press	n/a	n/a	4096	n/a
-126.3307272727	n/a	31582.6818	show_circle	n/a	n/a	0	circle.bmp
-128.0307272727	n/a	32007.6818	show_cross	n/a	n/a	n/a	cross.bmp
-128.5834545455	n/a	32145.8636	show_face	scrambled_face	first_show	17	s081.bmp
-129.5343636364	n/a	32383.5909	show_circle	n/a	n/a	0	circle.bmp
-129.7780000000	n/a	32444.5	right_press	n/a	n/a	4096	n/a
-131.2343636364	n/a	32808.5909	show_cross	n/a	n/a	n/a	cross.bmp
-131.7580000000	n/a	32939.5	show_face	scrambled_face	immediate_repeat	18	s081.bmp
-132.7398181818	n/a	33184.9545	show_circle	n/a	n/a	0	circle.bmp
-132.7798181818	n/a	33194.9545	left_press	n/a	n/a	256	n/a
-134.4398181818	n/a	33609.9545	show_cross	n/a	n/a	n/a	cross.bmp
-135.0816363636	n/a	33770.4091	show_face	unfamiliar_face	first_show	13	u077.bmp
-135.9107272727	n/a	33977.6818	show_circle	n/a	n/a	0	circle.bmp
-135.9407272727	n/a	33985.1818	right_press	n/a	n/a	4096	n/a
-137.6107272727	n/a	34402.6818	show_cross	n/a	n/a	n/a	cross.bmp
-138.2061818182	n/a	34551.5455	show_face	unfamiliar_face	immediate_repeat	14	u077.bmp
-139.1061818182	n/a	34776.5455	show_circle	n/a	n/a	0	circle.bmp
-139.1234545455	n/a	34780.8636	right_press	n/a	n/a	4096	n/a
-140.8061818182	n/a	35201.5455	show_cross	n/a	n/a	n/a	cross.bmp
-141.4307272727	n/a	35357.6818	show_face	scrambled_face	delayed_repeat	19	s142.bmp
-142.2698181818	n/a	35567.4545	show_circle	n/a	n/a	0	circle.bmp
-142.3225454545	n/a	35580.6364	left_press	n/a	n/a	256	n/a
-143.9698181818	n/a	35992.4545	show_cross	n/a	n/a	n/a	cross.bmp
-144.6207272727	n/a	36155.1818	show_face	scrambled_face	first_show	17	s034.bmp
-145.4498181818	n/a	36362.4545	right_press	n/a	n/a	4096	n/a
-145.4780000000	n/a	36369.5	show_circle	n/a	n/a	0	circle.bmp
-147.1780000000	n/a	36794.5	show_cross	n/a	n/a	n/a	cross.bmp
-147.7443636364	n/a	36936.0909	show_face	scrambled_face	immediate_repeat	18	s034.bmp
-148.7343636364	n/a	37183.5909	show_circle	n/a	n/a	0	circle.bmp
-148.7452727273	n/a	37186.3182	right_press	n/a	n/a	4096	n/a
-150.4343636364	n/a	37608.5909	show_cross	n/a	n/a	n/a	cross.bmp
-150.9016363636	n/a	37725.4091	show_face	unfamiliar_face	delayed_repeat	15	u131.bmp
-151.8680000000	n/a	37967	right_press	n/a	n/a	4096	n/a
-151.9189090909	n/a	37979.7273	show_circle	n/a	n/a	0	circle.bmp
-151.9752727273	n/a	37993.8182	4352	n/a	n/a	4352	n/a
-153.6189090909	n/a	38404.7273	show_cross	n/a	n/a	n/a	cross.bmp
-154.2598181818	n/a	38564.9545	show_face	unfamiliar_face	first_show	13	u100.bmp
-155.0989090909	n/a	38774.7273	show_circle	n/a	n/a	0	circle.bmp
-155.1689090909	n/a	38792.2273	left_press	n/a	n/a	256	n/a
-156.7989090909	n/a	39199.7273	show_cross	n/a	n/a	n/a	cross.bmp
-157.4334545455	n/a	39358.3636	show_face	unfamiliar_face	immediate_repeat	14	u100.bmp
-157.9898181818	n/a	39497.4545	left_press	n/a	n/a	256	n/a
-158.3389090909	n/a	39584.7273	show_circle	n/a	n/a	0	circle.bmp
-160.0389090909	n/a	40009.7273	show_cross	n/a	n/a	n/a	cross.bmp
-160.5070909091	n/a	40126.7727	show_face	scrambled_face	first_show	17	s087.bmp
-161.3289090909	n/a	40332.2273	left_press	n/a	n/a	256	n/a
-161.4152727273	n/a	40353.8182	show_circle	n/a	n/a	0	circle.bmp
-163.1152727273	n/a	40778.8182	show_cross	n/a	n/a	n/a	cross.bmp
-163.7480000000	n/a	40937	show_face	scrambled_face	immediate_repeat	18	s087.bmp
-164.4807272727	n/a	41120.1818	right_press	n/a	n/a	4096	n/a
-164.7252727273	n/a	41181.3182	show_circle	n/a	n/a	0	circle.bmp
-166.4252727273	n/a	41606.3182	show_cross	n/a	n/a	n/a	cross.bmp
-166.9725454545	n/a	41743.1364	show_face	scrambled_face	delayed_repeat	19	s088.bmp
-167.9352727273	n/a	41983.8182	show_circle	n/a	n/a	0	circle.bmp
-168.1816363636	n/a	42045.4091	left_press	n/a	n/a	256	n/a
-169.6352727273	n/a	42408.8182	show_cross	n/a	n/a	n/a	cross.bmp
-170.2298181818	n/a	42557.4545	show_face	scrambled_face	first_show	17	s074.bmp
-171.0552727273	n/a	42763.8182	show_circle	n/a	n/a	0	circle.bmp
-171.3980000000	n/a	42849.5	right_press	n/a	n/a	4096	n/a
-172.7552727273	n/a	43188.8182	show_cross	n/a	n/a	n/a	cross.bmp
-173.2534545455	n/a	43313.3636	show_face	unfamiliar_face	first_show	13	u058.bmp
-174.1370909091	n/a	43534.2727	right_press	n/a	n/a	4096	n/a
-174.1789090909	n/a	43544.7273	show_circle	n/a	n/a	0	circle.bmp
-175.8789090909	n/a	43969.7273	show_cross	n/a	n/a	n/a	cross.bmp
-176.4943636364	n/a	44123.5909	show_face	unfamiliar_face	immediate_repeat	14	u058.bmp
-177.3343636364	n/a	44333.5909	show_circle	n/a	n/a	0	circle.bmp
-177.4043636364	n/a	44351.0909	right_press	n/a	n/a	4096	n/a
-179.0343636364	n/a	44758.5909	show_cross	n/a	n/a	n/a	cross.bmp
-179.6343636364	n/a	44908.5909	show_face	famous_face	first_show	5	f038.bmp
-180.4970909091	n/a	45124.2727	show_circle	n/a	n/a	0	circle.bmp
-180.6652727273	n/a	45166.3182	left_press	n/a	n/a	256	n/a
-182.1970909091	n/a	45549.2727	show_cross	n/a	n/a	n/a	cross.bmp
-182.6752727273	n/a	45668.8182	show_face	scrambled_face	first_show	17	s090.bmp
-183.4961818182	n/a	45874.0455	show_circle	n/a	n/a	0	circle.bmp
-183.4961818182	n/a	45874.0455	right_press	n/a	n/a	4096	n/a
-185.1961818182	n/a	46299.0455	show_cross	n/a	n/a	n/a	cross.bmp
-185.6652727273	n/a	46416.3182	show_face	famous_face	first_show	5	f020.bmp
-186.3670909091	n/a	46591.7727	right_press	n/a	n/a	4096	n/a
-186.6225454545	n/a	46655.6364	show_circle	n/a	n/a	0	circle.bmp
-188.3225454545	n/a	47080.6364	show_cross	n/a	n/a	n/a	cross.bmp
-188.9225454545	n/a	47230.6364	show_face	unfamiliar_face	first_show	13	u114.bmp
-189.8616363636	n/a	47465.4091	left_press	n/a	n/a	256	n/a
-189.9234545455	n/a	47480.8636	show_circle	n/a	n/a	0	circle.bmp
-191.6234545455	n/a	47905.8636	show_cross	n/a	n/a	n/a	cross.bmp
-192.2307272727	n/a	48057.6818	show_face	scrambled_face	delayed_repeat	19	s074.bmp
-192.9752727273	n/a	48243.8182	right_press	n/a	n/a	4096	n/a
-193.0698181818	n/a	48267.4545	show_circle	n/a	n/a	0	circle.bmp
-194.7698181818	n/a	48692.4545	show_cross	n/a	n/a	n/a	cross.bmp
-195.3880000000	n/a	48847	show_face	scrambled_face	first_show	17	s065.bmp
-196.1743636364	n/a	49043.5909	right_press	n/a	n/a	4096	n/a
-196.3552727273	n/a	49088.8182	show_circle	n/a	n/a	0	circle.bmp
-198.0552727273	n/a	49513.8182	show_cross	n/a	n/a	n/a	cross.bmp
-198.6116363636	n/a	49652.9091	show_face	scrambled_face	immediate_repeat	18	s065.bmp
-199.5325454545	n/a	49883.1364	show_circle	n/a	n/a	0	circle.bmp
-199.5343636364	n/a	49883.5909	right_press	n/a	n/a	4096	n/a
-201.2325454545	n/a	50308.1364	show_cross	n/a	n/a	n/a	cross.bmp
-201.7025454545	n/a	50425.6364	show_face	famous_face	first_show	5	f040.bmp
-202.4389090909	n/a	50609.7273	right_press	n/a	n/a	4096	n/a
-202.5389090909	n/a	50634.7273	show_circle	n/a	n/a	0	circle.bmp
-204.2389090909	n/a	51059.7273	show_cross	n/a	n/a	n/a	cross.bmp
-204.7089090909	n/a	51177.2273	show_face	famous_face	immediate_repeat	6	f040.bmp
-205.3080000000	n/a	51327	right_press	n/a	n/a	4096	n/a
-205.6398181818	n/a	51409.9545	show_circle	n/a	n/a	0	circle.bmp
-207.3398181818	n/a	51834.9545	show_cross	n/a	n/a	n/a	cross.bmp
-207.7998181818	n/a	51949.9545	show_face	famous_face	delayed_repeat	7	f038.bmp
-208.7607272727	n/a	52190.1818	left_press	n/a	n/a	256	n/a
-208.7634545455	n/a	52190.8636	show_circle	n/a	n/a	0	circle.bmp
-210.4634545455	n/a	52615.8636	show_cross	n/a	n/a	n/a	cross.bmp
-211.0070909091	n/a	52751.7727	show_face	unfamiliar_face	first_show	13	u034.bmp
-211.7843636364	n/a	52946.0909	right_press	n/a	n/a	4096	n/a
-212.0107272727	n/a	53002.6818	show_circle	n/a	n/a	0	circle.bmp
-213.7107272727	n/a	53427.6818	show_cross	n/a	n/a	n/a	cross.bmp
-214.2980000000	n/a	53574.5	show_face	unfamiliar_face	immediate_repeat	14	u034.bmp
-214.9061818182	n/a	53726.5455	right_press	n/a	n/a	4096	n/a
-215.1670909091	n/a	53791.7727	show_circle	n/a	n/a	0	circle.bmp
-216.8670909091	n/a	54216.7727	show_cross	n/a	n/a	n/a	cross.bmp
-217.4052727273	n/a	54351.3182	show_face	scrambled_face	delayed_repeat	19	s090.bmp
-218.2198181818	n/a	54554.9545	left_press	n/a	n/a	256	n/a
-218.3480000000	n/a	54587	show_circle	n/a	n/a	0	circle.bmp
-220.0480000000	n/a	55012	show_cross	n/a	n/a	n/a	cross.bmp
-220.5789090909	n/a	55144.7273	show_face	scrambled_face	first_show	17	s015.bmp
-221.4761818182	n/a	55369.0455	show_circle	n/a	n/a	0	circle.bmp
-221.4843636364	n/a	55371.0909	left_press	n/a	n/a	256	n/a
-223.1761818182	n/a	55794.0455	show_cross	n/a	n/a	n/a	cross.bmp
-223.7861818182	n/a	55946.5455	show_face	famous_face	delayed_repeat	7	f020.bmp
-224.4452727273	n/a	56111.3182	right_press	n/a	n/a	4096	n/a
-224.6198181818	n/a	56154.9545	show_circle	n/a	n/a	0	circle.bmp
-226.3198181818	n/a	56579.9545	show_cross	n/a	n/a	n/a	cross.bmp
-226.8434545455	n/a	56710.8636	show_face	unfamiliar_face	first_show	13	u009.bmp
-227.5880000000	n/a	56897	left_press	n/a	n/a	256	n/a
-227.6889090909	n/a	56922.2273	show_circle	n/a	n/a	0	circle.bmp
-229.3889090909	n/a	57347.2273	show_cross	n/a	n/a	n/a	cross.bmp
-229.9507272727	n/a	57487.6818	show_face	unfamiliar_face	immediate_repeat	14	u009.bmp
-230.5243636364	n/a	57631.0909	left_press	n/a	n/a	256	n/a
-230.8816363636	n/a	57720.4091	show_circle	n/a	n/a	0	circle.bmp
-232.5816363636	n/a	58145.4091	show_cross	n/a	n/a	n/a	cross.bmp
-233.0743636364	n/a	58268.5909	show_face	unfamiliar_face	delayed_repeat	15	u114.bmp
-234.0289090909	n/a	58507.2273	show_circle	n/a	n/a	0	circle.bmp
-235.7289090909	n/a	58932.2273	show_cross	n/a	n/a	n/a	cross.bmp
-236.1980000000	n/a	59049.5	show_face	famous_face	first_show	5	f097.bmp
-237.0480000000	n/a	59262	left_press	n/a	n/a	256	n/a
-237.0843636364	n/a	59271.0909	show_circle	n/a	n/a	0	circle.bmp
-238.7843636364	n/a	59696.0909	show_cross	n/a	n/a	n/a	cross.bmp
-239.3389090909	n/a	59834.7273	show_face	scrambled_face	first_show	17	s023.bmp
-240.0216363636	n/a	60005.4091	left_press	n/a	n/a	256	n/a
-240.2307272727	n/a	60057.6818	show_circle	n/a	n/a	0	circle.bmp
-241.9307272727	n/a	60482.6818	show_cross	n/a	n/a	n/a	cross.bmp
-242.5961818182	n/a	60649.0455	show_face	famous_face	first_show	5	f048.bmp
-243.2434545455	n/a	60810.8636	right_press	n/a	n/a	4096	n/a
-243.5170909091	n/a	60879.2727	show_circle	n/a	n/a	0	circle.bmp
-245.2170909091	n/a	61304.2727	show_cross	n/a	n/a	n/a	cross.bmp
-245.7870909091	n/a	61446.7727	show_face	famous_face	first_show	5	f062.bmp
-246.4125454545	n/a	61603.1364	left_press	n/a	n/a	256	n/a
-246.7225454545	n/a	61680.6364	show_circle	n/a	n/a	0	circle.bmp
-248.4225454545	n/a	62105.6364	show_cross	n/a	n/a	n/a	cross.bmp
-248.8780000000	n/a	62219.5	show_face	famous_face	immediate_repeat	6	f062.bmp
-249.6443636364	n/a	62411.0909	left_press	n/a	n/a	256	n/a
-249.8825454545	n/a	62470.6364	show_circle	n/a	n/a	0	circle.bmp
-251.5825454545	n/a	62895.6364	show_cross	n/a	n/a	n/a	cross.bmp
-252.2352727273	n/a	63058.8182	show_face	scrambled_face	delayed_repeat	19	s015.bmp
-253.0880000000	n/a	63272	show_circle	n/a	n/a	0	circle.bmp
-254.7880000000	n/a	63697	show_cross	n/a	n/a	n/a	cross.bmp
-255.3770909091	n/a	63844.2727	show_face	scrambled_face	first_show	17	s144.bmp
-256.1670909091	n/a	64041.7727	right_press	n/a	n/a	4096	n/a
-256.2180000000	n/a	64054.5	show_circle	n/a	n/a	0	circle.bmp
-257.9180000000	n/a	64479.5	show_cross	n/a	n/a	n/a	cross.bmp
-258.3825454545	n/a	64595.6364	show_face	scrambled_face	immediate_repeat	18	s144.bmp
-259.2298181818	n/a	64807.4545	show_circle	n/a	n/a	0	circle.bmp
-260.9298181818	n/a	65232.4545	show_cross	n/a	n/a	n/a	cross.bmp
-261.4398181818	n/a	65359.9545	show_face	unfamiliar_face	first_show	13	u086.bmp
-262.3125454545	n/a	65578.1364	show_circle	n/a	n/a	0	circle.bmp
-262.4143636364	n/a	65603.5909	right_press	n/a	n/a	4096	n/a
-264.0125454545	n/a	66003.1364	show_cross	n/a	n/a	n/a	cross.bmp
-264.6134545455	n/a	66153.3636	show_face	famous_face	delayed_repeat	7	f097.bmp
-265.4907272727	n/a	66372.6818	show_circle	n/a	n/a	0	circle.bmp
-267.1907272727	n/a	66797.6818	show_cross	n/a	n/a	n/a	cross.bmp
-267.6707272727	n/a	66917.6818	show_face	unfamiliar_face	first_show	13	u102.bmp
-268.3125454545	n/a	67078.1364	right_press	n/a	n/a	4096	n/a
-268.5470909091	n/a	67136.7727	show_circle	n/a	n/a	0	circle.bmp
-270.2470909091	n/a	67561.7727	show_cross	n/a	n/a	n/a	cross.bmp
-270.7443636364	n/a	67686.0909	show_face	unfamiliar_face	immediate_repeat	14	u102.bmp
-271.6707272727	n/a	67917.6818	show_circle	n/a	n/a	0	circle.bmp
-273.3707272727	n/a	68342.6818	show_cross	n/a	n/a	n/a	cross.bmp
-273.9689090909	n/a	68492.2273	show_face	scrambled_face	delayed_repeat	19	s023.bmp
-274.8243636364	n/a	68706.0909	show_circle	n/a	n/a	0	circle.bmp
-276.5243636364	n/a	69131.0909	show_cross	n/a	n/a	n/a	cross.bmp
-277.1925454545	n/a	69298.1364	show_face	scrambled_face	first_show	17	s114.bmp
-278.0370909091	n/a	69509.2727	right_press	n/a	n/a	4096	n/a
-278.1180000000	n/a	69529.5	show_circle	n/a	n/a	0	circle.bmp
-279.8180000000	n/a	69954.5	show_cross	n/a	n/a	n/a	cross.bmp
-280.3843636364	n/a	70096.0909	show_face	scrambled_face	immediate_repeat	18	s114.bmp
-281.1352727273	n/a	70283.8182	right_press	n/a	n/a	4096	n/a
-281.2107272727	n/a	70302.6818	show_circle	n/a	n/a	0	circle.bmp
-282.9107272727	n/a	70727.6818	show_cross	n/a	n/a	n/a	cross.bmp
-283.4243636364	n/a	70856.0909	show_face	famous_face	delayed_repeat	7	f048.bmp
-284.1570909091	n/a	71039.2727	right_press	n/a	n/a	4096	n/a
-284.3680000000	n/a	71092	show_circle	n/a	n/a	0	circle.bmp
-286.0680000000	n/a	71517	show_cross	n/a	n/a	n/a	cross.bmp
-286.5816363636	n/a	71645.4091	show_face	famous_face	first_show	5	f021.bmp
-287.3034545455	n/a	71825.8636	right_press	n/a	n/a	4096	n/a
-287.4507272727	n/a	71862.6818	show_circle	n/a	n/a	0	circle.bmp
-289.1507272727	n/a	72287.6818	show_cross	n/a	n/a	n/a	cross.bmp
-289.6389090909	n/a	72409.7273	show_face	scrambled_face	first_show	17	s052.bmp
-290.5852727273	n/a	72646.3182	show_circle	n/a	n/a	0	circle.bmp
-292.2852727273	n/a	73071.3182	show_cross	n/a	n/a	n/a	cross.bmp
-292.8961818182	n/a	73224.0455	show_face	scrambled_face	immediate_repeat	18	s052.bmp
-293.8325454545	n/a	73458.1364	show_circle	n/a	n/a	0	circle.bmp
-295.5325454545	n/a	73883.1364	show_cross	n/a	n/a	n/a	cross.bmp
-296.0361818182	n/a	74009.0455	show_face	scrambled_face	first_show	17	s055.bmp
-296.9389090909	n/a	74234.7273	show_circle	n/a	n/a	0	circle.bmp
-298.6389090909	n/a	74659.7273	show_cross	n/a	n/a	n/a	cross.bmp
-299.1270909091	n/a	74781.7727	show_face	unfamiliar_face	delayed_repeat	15	u086.bmp
-300.1307272727	n/a	75032.6818	show_circle	n/a	n/a	0	circle.bmp
-301.8307272727	n/a	75457.6818	show_cross	n/a	n/a	n/a	cross.bmp
-302.4343636364	n/a	75608.5909	show_face	scrambled_face	first_show	17	s123.bmp
-303.1598181818	n/a	75789.9545	left_press	n/a	n/a	256	n/a
-303.2970909091	n/a	75824.2727	show_circle	n/a	n/a	0	circle.bmp
-304.9970909091	n/a	76249.2727	show_cross	n/a	n/a	n/a	cross.bmp
-305.5916363636	n/a	76397.9091	show_face	scrambled_face	immediate_repeat	18	s123.bmp
-306.2243636364	n/a	76556.0909	left_press	n/a	n/a	256	n/a
-306.6070909091	n/a	76651.7727	show_circle	n/a	n/a	0	circle.bmp
-308.3070909091	n/a	77076.7727	show_cross	n/a	n/a	n/a	cross.bmp
-308.7652727273	n/a	77191.3182	show_face	famous_face	first_show	5	f013.bmp
-309.3834545455	n/a	77345.8636	right_press	n/a	n/a	4096	n/a
-309.7643636364	n/a	77441.0909	show_circle	n/a	n/a	0	circle.bmp
-311.4643636364	n/a	77866.0909	show_cross	n/a	n/a	n/a	cross.bmp
-312.0561818182	n/a	78014.0455	show_face	famous_face	immediate_repeat	6	f013.bmp
-312.6434545455	n/a	78160.8636	right_press	n/a	n/a	4096	n/a
-312.9843636364	n/a	78246.0909	show_circle	n/a	n/a	0	circle.bmp
-314.6843636364	n/a	78671.0909	show_cross	n/a	n/a	n/a	cross.bmp
-315.3143636364	n/a	78828.5909	show_face	famous_face	first_show	5	f026.bmp
-315.9480000000	n/a	78987	right_press	n/a	n/a	4096	n/a
-316.2725454545	n/a	79068.1364	show_circle	n/a	n/a	0	circle.bmp
-317.9725454545	n/a	79493.1364	show_cross	n/a	n/a	n/a	cross.bmp
-318.5216363636	n/a	79630.4091	show_face	famous_face	delayed_repeat	7	f021.bmp
-319.2307272727	n/a	79807.6818	right_press	n/a	n/a	4096	n/a
-319.4316363636	n/a	79857.9091	show_circle	n/a	n/a	0	circle.bmp
-321.1316363636	n/a	80282.9091	show_cross	n/a	n/a	n/a	cross.bmp
-321.7125454545	n/a	80428.1364	show_face	famous_face	first_show	5	f128.bmp
-322.6325454545	n/a	80658.1364	show_circle	n/a	n/a	0	circle.bmp
-324.3325454545	n/a	81083.1364	show_cross	n/a	n/a	n/a	cross.bmp
-324.9025454545	n/a	81225.6364	show_face	famous_face	immediate_repeat	6	f128.bmp
-325.6880000000	n/a	81422	right_press	n/a	n/a	4096	n/a
-325.7243636364	n/a	81431.0909	show_circle	n/a	n/a	0	circle.bmp
-327.4243636364	n/a	81856.0909	show_cross	n/a	n/a	n/a	cross.bmp
-328.0770909091	n/a	82019.2727	show_face	scrambled_face	first_show	17	s102.bmp
-329.0807272727	n/a	82270.1818	show_circle	n/a	n/a	0	circle.bmp
-329.4961818182	n/a	82374.0455	right_press	n/a	n/a	4096	n/a
-330.7807272727	n/a	82695.1818	show_cross	n/a	n/a	n/a	cross.bmp
-331.4180000000	n/a	82854.5	show_face	scrambled_face	delayed_repeat	19	s055.bmp
-332.3352727273	n/a	83083.8182	show_circle	n/a	n/a	0	circle.bmp
-334.0352727273	n/a	83508.8182	show_cross	n/a	n/a	n/a	cross.bmp
-334.5916363636	n/a	83647.9091	show_face	scrambled_face	first_show	17	s136.bmp
-335.4243636364	n/a	83856.0909	show_circle	n/a	n/a	0	circle.bmp
-337.1243636364	n/a	84281.0909	show_cross	n/a	n/a	n/a	cross.bmp
-337.6825454545	n/a	84420.6364	show_face	scrambled_face	immediate_repeat	18	s136.bmp
-338.5707272727	n/a	84642.6818	left_press	n/a	n/a	256	n/a
-338.6525454545	n/a	84663.1364	show_circle	n/a	n/a	0	circle.bmp
-340.3525454545	n/a	85088.1364	show_cross	n/a	n/a	n/a	cross.bmp
-340.9898181818	n/a	85247.4545	show_face	unfamiliar_face	first_show	13	u134.bmp
-341.6507272727	n/a	85412.6818	left_press	n/a	n/a	256	n/a
-341.8970909091	n/a	85474.2727	show_circle	n/a	n/a	0	circle.bmp
-343.5970909091	n/a	85899.2727	show_cross	n/a	n/a	n/a	cross.bmp
-344.1643636364	n/a	86041.0909	show_face	scrambled_face	first_show	17	s010.bmp
-344.9489090909	n/a	86237.2273	right_press	n/a	n/a	4096	n/a
-345.1525454545	n/a	86288.1364	show_circle	n/a	n/a	0	circle.bmp
-345.1634545455	n/a	86290.8636	right_press	n/a	n/a	4096	n/a
-346.8525454545	n/a	86713.1364	show_cross	n/a	n/a	n/a	cross.bmp
-347.3880000000	n/a	86847	show_face	famous_face	delayed_repeat	7	f026.bmp
-348.0480000000	n/a	87012	right_press	n/a	n/a	4096	n/a
-348.2380000000	n/a	87059.5	show_circle	n/a	n/a	0	circle.bmp
-349.9380000000	n/a	87484.5	show_cross	n/a	n/a	n/a	cross.bmp
-350.4125454545	n/a	87603.1364	show_face	scrambled_face	first_show	17	s084.bmp
-351.2261818182	n/a	87806.5455	right_press	n/a	n/a	4096	n/a
-351.3634545455	n/a	87840.8636	show_circle	n/a	n/a	0	circle.bmp
-353.0634545455	n/a	88265.8636	show_cross	n/a	n/a	n/a	cross.bmp
-353.6025454545	n/a	88400.6364	show_face	famous_face	first_show	5	f009.bmp
-354.3489090909	n/a	88587.2273	right_press	n/a	n/a	4096	n/a
-354.5489090909	n/a	88637.2273	show_circle	n/a	n/a	0	circle.bmp
-356.2489090909	n/a	89062.2273	show_cross	n/a	n/a	n/a	cross.bmp
-356.7261818182	n/a	89181.5455	show_face	famous_face	immediate_repeat	6	f009.bmp
-357.4452727273	n/a	89361.3182	right_press	n/a	n/a	4096	n/a
-357.6516363636	n/a	89412.9091	show_circle	n/a	n/a	0	circle.bmp
-359.3516363636	n/a	89837.9091	show_cross	n/a	n/a	n/a	cross.bmp
-359.9670909091	n/a	89991.7727	show_face	scrambled_face	delayed_repeat	19	s102.bmp
-360.8334545455	n/a	90208.3636	left_press	n/a	n/a	256	n/a
-360.9743636364	n/a	90243.5909	show_circle	n/a	n/a	0	circle.bmp
-362.6743636364	n/a	90668.5909	show_cross	n/a	n/a	n/a	cross.bmp
-363.2916363636	n/a	90822.9091	show_face	famous_face	first_show	5	f129.bmp
-364.0898181818	n/a	91022.4545	right_press	n/a	n/a	4096	n/a
-364.2007272727	n/a	91050.1818	show_circle	n/a	n/a	0	circle.bmp
-365.9007272727	n/a	91475.1818	show_cross	n/a	n/a	n/a	cross.bmp
-366.4152727273	n/a	91603.8182	show_face	unfamiliar_face	first_show	13	u051.bmp
-367.2980000000	n/a	91824.5	left_press	n/a	n/a	256	n/a
-367.3789090909	n/a	91844.7273	show_circle	n/a	n/a	0	circle.bmp
-369.0789090909	n/a	92269.7273	show_cross	n/a	n/a	n/a	cross.bmp
-369.6061818182	n/a	92401.5455	show_face	unfamiliar_face	delayed_repeat	15	u134.bmp
-370.2952727273	n/a	92573.8182	left_press	n/a	n/a	256	n/a
-370.5289090909	n/a	92632.2273	show_circle	n/a	n/a	0	circle.bmp
-372.2289090909	n/a	93057.2273	show_cross	n/a	n/a	n/a	cross.bmp
-372.7634545455	n/a	93190.8636	show_face	unfamiliar_face	first_show	13	u140.bmp
-373.5170909091	n/a	93379.2727	right_press	n/a	n/a	4096	n/a
-373.5989090909	n/a	93399.7273	show_circle	n/a	n/a	0	circle.bmp
-375.2989090909	n/a	93824.7273	show_cross	n/a	n/a	n/a	cross.bmp
-375.7534545455	n/a	93938.3636	show_face	scrambled_face	delayed_repeat	19	s010.bmp
-376.6016363636	n/a	94150.4091	show_circle	n/a	n/a	0	circle.bmp
-376.6034545455	n/a	94150.8636	left_press	n/a	n/a	256	n/a
-378.3016363636	n/a	94575.4091	show_cross	n/a	n/a	n/a	cross.bmp
-378.8270909091	n/a	94706.7727	show_face	famous_face	first_show	5	f096.bmp
-379.5380000000	n/a	94884.5	left_press	n/a	n/a	256	n/a
-379.7116363636	n/a	94927.9091	show_circle	n/a	n/a	0	circle.bmp
-381.4116363636	n/a	95352.9091	show_cross	n/a	n/a	n/a	cross.bmp
-382.0007272727	n/a	95500.1818	show_face	famous_face	immediate_repeat	6	f096.bmp
-382.4925454545	n/a	95623.1364	left_press	n/a	n/a	256	n/a
-382.9516363636	n/a	95737.9091	show_circle	n/a	n/a	0	circle.bmp
-384.6516363636	n/a	96162.9091	show_cross	n/a	n/a	n/a	cross.bmp
-385.1089090909	n/a	96277.2273	show_face	scrambled_face	delayed_repeat	19	s084.bmp
-385.8380000000	n/a	96459.5	right_press	n/a	n/a	4096	n/a
-386.0170909091	n/a	96504.2727	show_circle	n/a	n/a	0	circle.bmp
-387.7170909091	n/a	96929.2727	show_cross	n/a	n/a	n/a	cross.bmp
-388.1816363636	n/a	97045.4091	show_face	unfamiliar_face	first_show	13	u139.bmp
-389.1398181818	n/a	97284.9545	show_circle	n/a	n/a	0	circle.bmp
-390.8398181818	n/a	97709.9545	show_cross	n/a	n/a	n/a	cross.bmp
-391.4225454545	n/a	97855.6364	show_face	unfamiliar_face	immediate_repeat	14	u139.bmp
-392.3016363636	n/a	98075.4091	show_circle	n/a	n/a	0	circle.bmp
-394.0016363636	n/a	98500.4091	show_cross	n/a	n/a	n/a	cross.bmp
-394.4798181818	n/a	98619.9545	show_face	scrambled_face	first_show	17	s140.bmp
-395.3098181818	n/a	98827.4545	show_circle	n/a	n/a	0	circle.bmp
-395.3525454545	n/a	98838.1364	right_press	n/a	n/a	4096	n/a
-397.0098181818	n/a	99252.4545	show_cross	n/a	n/a	n/a	cross.bmp
-397.6034545455	n/a	99400.8636	show_face	scrambled_face	immediate_repeat	18	s140.bmp
-398.2980000000	n/a	99574.5	right_press	n/a	n/a	4096	n/a
-398.5125454545	n/a	99628.1364	show_circle	n/a	n/a	0	circle.bmp
-400.2125454545	n/a	100053.1364	show_cross	n/a	n/a	n/a	cross.bmp
-400.7780000000	n/a	100194.5	show_face	famous_face	delayed_repeat	7	f129.bmp
-401.4452727273	n/a	100361.3182	right_press	n/a	n/a	4096	n/a
-401.7470909091	n/a	100436.7727	show_circle	n/a	n/a	0	circle.bmp
-403.4470909091	n/a	100861.7727	show_cross	n/a	n/a	n/a	cross.bmp
-404.0016363636	n/a	101000.4091	show_face	famous_face	first_show	5	f049.bmp
-404.7207272727	n/a	101180.1818	left_press	n/a	n/a	256	n/a
-404.8643636364	n/a	101216.0909	show_circle	n/a	n/a	0	circle.bmp
-406.5643636364	n/a	101641.0909	show_cross	n/a	n/a	n/a	cross.bmp
-407.1425454545	n/a	101785.6364	show_face	famous_face	immediate_repeat	6	f049.bmp
-408.1152727273	n/a	102028.8182	show_circle	n/a	n/a	0	circle.bmp
-409.8152727273	n/a	102453.8182	show_cross	n/a	n/a	n/a	cross.bmp
-410.3834545455	n/a	102595.8636	show_face	unfamiliar_face	delayed_repeat	15	u051.bmp
-411.2134545455	n/a	102803.3636	show_circle	n/a	n/a	0	circle.bmp
-411.3543636364	n/a	102838.5909	right_press	n/a	n/a	4096	n/a
-412.9134545455	n/a	103228.3636	show_cross	n/a	n/a	n/a	cross.bmp
-413.5570909091	n/a	103389.2727	show_face	famous_face	first_show	5	f140.bmp
-414.3916363636	n/a	103597.9091	right_press	n/a	n/a	4096	n/a
-414.3934545455	n/a	103598.3636	show_circle	n/a	n/a	0	circle.bmp
-416.0934545455	n/a	104023.3636	show_cross	n/a	n/a	n/a	cross.bmp
-416.5643636364	n/a	104141.0909	show_face	unfamiliar_face	delayed_repeat	15	u140.bmp
-417.5289090909	n/a	104382.2273	show_circle	n/a	n/a	0	circle.bmp
-417.5652727273	n/a	104391.3182	right_press	n/a	n/a	4096	n/a
-419.2289090909	n/a	104807.2273	show_cross	n/a	n/a	n/a	cross.bmp
-419.8052727273	n/a	104951.3182	show_face	unfamiliar_face	first_show	13	u017.bmp
-420.4680000000	n/a	105117	left_press	n/a	n/a	256	n/a
-420.7070909091	n/a	105176.7727	show_circle	n/a	n/a	0	circle.bmp
-422.4070909091	n/a	105601.7727	show_cross	n/a	n/a	n/a	cross.bmp
-423.0125454545	n/a	105753.1364	show_face	unfamiliar_face	immediate_repeat	14	u017.bmp
-423.5407272727	n/a	105885.1818	left_press	n/a	n/a	256	n/a
-423.8843636364	n/a	105971.0909	show_circle	n/a	n/a	0	circle.bmp
-425.5843636364	n/a	106396.0909	show_cross	n/a	n/a	n/a	cross.bmp
-426.0525454545	n/a	106513.1364	show_face	famous_face	first_show	5	f033.bmp
-426.7316363636	n/a	106682.9091	right_press	n/a	n/a	4096	n/a
-426.9652727273	n/a	106741.3182	show_circle	n/a	n/a	0	circle.bmp
-428.6652727273	n/a	107166.3182	show_cross	n/a	n/a	n/a	cross.bmp
-429.1607272727	n/a	107290.1818	show_face	famous_face	immediate_repeat	6	f033.bmp
-429.7307272727	n/a	107432.6818	right_press	n/a	n/a	4096	n/a
-430.1461818182	n/a	107536.5455	show_circle	n/a	n/a	0	circle.bmp
-431.8461818182	n/a	107961.5455	show_cross	n/a	n/a	n/a	cross.bmp
-432.4170909091	n/a	108104.2727	show_face	famous_face	first_show	5	f060.bmp
-433.3125454545	n/a	108328.1364	show_circle	n/a	n/a	0	circle.bmp
-435.0125454545	n/a	108753.1364	show_cross	n/a	n/a	n/a	cross.bmp
-435.4907272727	n/a	108872.6818	show_face	famous_face	immediate_repeat	6	f060.bmp
-436.4743636364	n/a	109118.5909	show_circle	n/a	n/a	0	circle.bmp
-438.1743636364	n/a	109543.5909	show_cross	n/a	n/a	n/a	cross.bmp
-438.6816363636	n/a	109670.4091	show_face	scrambled_face	first_show	17	s098.bmp
-439.5698181818	n/a	109892.4545	show_circle	n/a	n/a	0	circle.bmp
-441.2698181818	n/a	110317.4545	show_cross	n/a	n/a	n/a	cross.bmp
-441.7725454545	n/a	110443.1364	show_face	scrambled_face	immediate_repeat	18	s098.bmp
-442.6261818182	n/a	110656.5455	show_circle	n/a	n/a	0	circle.bmp
-444.3261818182	n/a	111081.5455	show_cross	n/a	n/a	n/a	cross.bmp
-444.9298181818	n/a	111232.4545	show_face	scrambled_face	first_show	17	s110.bmp
-445.6761818182	n/a	111419.0455	right_press	n/a	n/a	4096	n/a
-445.8052727273	n/a	111451.3182	show_circle	n/a	n/a	0	circle.bmp
-447.5052727273	n/a	111876.3182	show_cross	n/a	n/a	n/a	cross.bmp
-448.1370909091	n/a	112034.2727	show_face	scrambled_face	immediate_repeat	18	s110.bmp
-448.8125454545	n/a	112203.1364	right_press	n/a	n/a	4096	n/a
-449.1498181818	n/a	112287.4545	show_circle	n/a	n/a	0	circle.bmp
-450.8498181818	n/a	112712.4545	show_cross	n/a	n/a	n/a	cross.bmp
-451.4107272727	n/a	112852.6818	show_face	famous_face	delayed_repeat	7	f140.bmp
-452.1016363636	n/a	113025.4091	right_press	n/a	n/a	4096	n/a
-452.2816363636	n/a	113070.4091	show_circle	n/a	n/a	0	circle.bmp
-453.9816363636	n/a	113495.4091	show_cross	n/a	n/a	n/a	cross.bmp
-454.5352727273	n/a	113633.8182	show_face	unfamiliar_face	first_show	13	u073.bmp
-455.4134545455	n/a	113853.3636	show_circle	n/a	n/a	0	circle.bmp
-457.1134545455	n/a	114278.3636	show_cross	n/a	n/a	n/a	cross.bmp
-457.6252727273	n/a	114406.3182	show_face	famous_face	first_show	5	f137.bmp
-458.5770909091	n/a	114644.2727	show_circle	n/a	n/a	0	circle.bmp
-460.2770909091	n/a	115069.2727	show_cross	n/a	n/a	n/a	cross.bmp
-460.7489090909	n/a	115187.2273	show_face	unfamiliar_face	first_show	13	u066.bmp
-461.6052727273	n/a	115401.3182	show_circle	n/a	n/a	0	circle.bmp
-463.3052727273	n/a	115826.3182	show_cross	n/a	n/a	n/a	cross.bmp
-463.9061818182	n/a	115976.5455	show_face	unfamiliar_face	first_show	13	u078.bmp
-464.5270909091	n/a	116131.7727	right_press	n/a	n/a	4096	n/a
-464.7789090909	n/a	116194.7273	show_circle	n/a	n/a	0	circle.bmp
-466.4789090909	n/a	116619.7273	show_cross	n/a	n/a	n/a	cross.bmp
-467.0970909091	n/a	116774.2727	show_face	unfamiliar_face	immediate_repeat	14	u078.bmp
-467.6443636364	n/a	116911.0909	right_press	n/a	n/a	4096	n/a
-467.9425454545	n/a	116985.6364	show_circle	n/a	n/a	0	circle.bmp
-469.6425454545	n/a	117410.6364	show_cross	n/a	n/a	n/a	cross.bmp
-470.1043636364	n/a	117526.0909	show_face	famous_face	first_show	5	f131.bmp
-470.9498181818	n/a	117737.4545	show_circle	n/a	n/a	0	circle.bmp
-471.0052727273	n/a	117751.3182	right_press	n/a	n/a	4096	n/a
-472.6498181818	n/a	118162.4545	show_cross	n/a	n/a	n/a	cross.bmp
-473.3116363636	n/a	118327.9091	show_face	unfamiliar_face	first_show	13	u105.bmp
-474.1380000000	n/a	118534.5	right_press	n/a	n/a	4096	n/a
-474.2725454545	n/a	118568.1364	show_circle	n/a	n/a	0	circle.bmp
-475.9725454545	n/a	118993.1364	show_cross	n/a	n/a	n/a	cross.bmp
-476.4352727273	n/a	119108.8182	show_face	unfamiliar_face	delayed_repeat	15	u073.bmp
-477.3598181818	n/a	119339.9545	show_circle	n/a	n/a	0	circle.bmp
-479.0598181818	n/a	119764.9545	show_cross	n/a	n/a	n/a	cross.bmp
-479.6598181818	n/a	119914.9545	show_face	unfamiliar_face	first_show	13	u132.bmp
-480.5425454545	n/a	120135.6364	show_circle	n/a	n/a	0	circle.bmp
-482.2425454545	n/a	120560.6364	show_cross	n/a	n/a	n/a	cross.bmp
-482.8670909091	n/a	120716.7727	show_face	famous_face	delayed_repeat	7	f137.bmp
-483.8407272727	n/a	120960.1818	show_circle	n/a	n/a	0	circle.bmp
-485.5407272727	n/a	121385.1818	show_cross	n/a	n/a	n/a	cross.bmp
+onset	duration	sample	event_type	face_type	repetition_type	trial	trial_lag	trigger	stim_file
+0.004	n/a	1.0	setup	n/a	n/a	n/a	n/a	n/a	n/a
+0.004	n/a	1.0	right_sym	n/a	n/a	n/a	n/a	n/a	n/a
+24.2098181818	n/a	6052.4545	show_face	unfamiliar_face	first_show	1	n/a	13	u032.bmp
+25.0352727273	n/a	6258.8182	show_circle	n/a	n/a	1	n/a	0	circle.bmp
+25.158	n/a	6289.5	left_press	n/a	n/a	1	n/a	256	n/a
+26.7352727273	n/a	6683.8182	show_cross	n/a	n/a	2	n/a	n/a	cross.bmp
+27.2498181818	n/a	6812.4545	show_face	unfamiliar_face	immediate_repeat	2	1	14	u032.bmp
+27.897090909099997	n/a	6974.2727	left_press	n/a	n/a	2	n/a	256	n/a
+28.0998181818	n/a	7024.9545	show_circle	n/a	n/a	2	n/a	0	circle.bmp
+29.7998181818	n/a	7449.9545	show_cross	n/a	n/a	3	n/a	n/a	cross.bmp
+30.3570909091	n/a	7589.2727	show_face	unfamiliar_face	first_show	3	n/a	13	u088.bmp
+31.188	n/a	7797.0	show_circle	n/a	n/a	3	n/a	0	circle.bmp
+32.888	n/a	8222.0	show_cross	n/a	n/a	4	n/a	n/a	cross.bmp
+33.3643636364	n/a	8341.0909	show_face	unfamiliar_face	first_show	4	n/a	13	u084.bmp
+34.368	n/a	8592.0	show_circle	n/a	n/a	4	n/a	0	circle.bmp
+36.068	n/a	9017.0	show_cross	n/a	n/a	5	n/a	n/a	cross.bmp
+36.5561818182	n/a	9139.0455	show_face	famous_face	first_show	5	n/a	5	f123.bmp
+37.3161818182	n/a	9329.0455	right_press	n/a	n/a	5	n/a	4096	n/a
+37.3825454545	n/a	9345.6364	show_circle	n/a	n/a	5	n/a	0	circle.bmp
+39.0825454545	n/a	9770.6364	show_cross	n/a	n/a	6	n/a	n/a	cross.bmp
+39.5789090909	n/a	9894.7273	show_face	unfamiliar_face	first_show	6	n/a	13	u022.bmp
+40.581636363600005	n/a	10145.4091	show_circle	n/a	n/a	6	n/a	0	circle.bmp
+42.2816363636	n/a	10570.4091	show_cross	n/a	n/a	7	n/a	n/a	cross.bmp
+42.8025454545	n/a	10700.6364	show_face	famous_face	first_show	7	n/a	5	f094.bmp
+43.548909090900004	n/a	10887.2273	right_press	n/a	n/a	7	n/a	4096	n/a
+43.7198181818	n/a	10929.9545	show_circle	n/a	n/a	7	n/a	0	circle.bmp
+45.419818181800004	n/a	11354.9545	show_cross	n/a	n/a	8	n/a	n/a	cross.bmp
+46.043454545500005	n/a	11510.8636	show_face	scrambled_face	first_show	8	n/a	17	s150.bmp
+46.95072727270001	n/a	11737.6818	show_circle	n/a	n/a	8	n/a	0	circle.bmp
+48.6507272727	n/a	12162.6818	show_cross	n/a	n/a	9	n/a	n/a	cross.bmp
+49.1343636364	n/a	12283.5909	show_face	unfamiliar_face	delayed_repeat	9	6	15	u088.bmp
+50.1352727273	n/a	12533.8182	show_circle	n/a	n/a	9	n/a	0	circle.bmp
+51.835272727299994	n/a	12958.8182	show_cross	n/a	n/a	10	n/a	n/a	cross.bmp
+52.3916363636	n/a	13097.9091	show_face	famous_face	first_show	10	n/a	5	f063.bmp
+53.100727272700006	n/a	13275.1818	right_press	n/a	n/a	10	n/a	4096	n/a
+53.2616363636	n/a	13315.4091	show_circle	n/a	n/a	10	n/a	0	circle.bmp
+54.96163636359999	n/a	13740.4091	show_cross	n/a	n/a	11	n/a	n/a	cross.bmp
+55.548909090900004	n/a	13887.2273	show_face	unfamiliar_face	delayed_repeat	11	7	15	u084.bmp
+56.5589090909	n/a	14139.7273	show_circle	n/a	n/a	11	n/a	0	circle.bmp
+58.258909090900005	n/a	14564.7273	show_cross	n/a	n/a	12	n/a	n/a	cross.bmp
+58.806181818199995	n/a	14701.5455	show_face	unfamiliar_face	first_show	12	n/a	13	u004.bmp
+59.5407272727	n/a	14885.1818	left_press	n/a	n/a	12	n/a	256	n/a
+59.7270909091	n/a	14931.7727	show_circle	n/a	n/a	12	n/a	0	circle.bmp
+61.427090909099995	n/a	15356.7727	show_cross	n/a	n/a	13	n/a	n/a	cross.bmp
+61.9134545455	n/a	15478.3636	show_face	unfamiliar_face	immediate_repeat	13	1	14	u004.bmp
+62.850727272700006	n/a	15712.6818	left_press	n/a	n/a	13	n/a	256	n/a
+62.8934545455	n/a	15723.3636	show_circle	n/a	n/a	13	n/a	0	circle.bmp
+64.5934545455	n/a	16148.3636	show_cross	n/a	n/a	14	n/a	n/a	cross.bmp
+65.10436363640001	n/a	16276.0909	show_face	famous_face	delayed_repeat	14	9	7	f123.bmp
+65.7989090909	n/a	16449.7273	right_press	n/a	n/a	14	n/a	4096	n/a
+66.10436363640001	n/a	16526.0909	show_circle	n/a	n/a	14	n/a	0	circle.bmp
+67.8043636364	n/a	16951.0909	show_cross	n/a	n/a	15	n/a	n/a	cross.bmp
+68.4289090909	n/a	17107.2273	show_face	famous_face	first_show	15	n/a	5	f006.bmp
+69.3470909091	n/a	17336.7727	right_press	n/a	n/a	15	n/a	4096	n/a
+69.3625454545	n/a	17340.6364	show_circle	n/a	n/a	15	n/a	0	circle.bmp
+71.0625454545	n/a	17765.6364	show_cross	n/a	n/a	16	n/a	n/a	cross.bmp
+71.6025454545	n/a	17900.6364	show_face	unfamiliar_face	delayed_repeat	16	10	15	u022.bmp
+72.32981818180001	n/a	18082.4545	right_press	n/a	n/a	16	n/a	4096	n/a
+72.5616363636	n/a	18140.4091	show_circle	n/a	n/a	16	n/a	0	circle.bmp
+74.26163636359999	n/a	18565.4091	show_cross	n/a	n/a	17	n/a	n/a	cross.bmp
+74.7598181818	n/a	18689.9545	show_face	scrambled_face	first_show	17	n/a	17	s043.bmp
+75.6989090909	n/a	18924.7273	left_press	n/a	n/a	17	n/a	256	n/a
+75.7334545455	n/a	18933.3636	show_circle	n/a	n/a	17	n/a	0	circle.bmp
+77.4334545455	n/a	19358.3636	show_cross	n/a	n/a	18	n/a	n/a	cross.bmp
+78.0670909091	n/a	19516.7727	show_face	scrambled_face	immediate_repeat	18	1	18	s043.bmp
+78.8107272727	n/a	19702.6818	left_press	n/a	n/a	18	n/a	256	n/a
+78.9434545455	n/a	19735.8636	show_circle	n/a	n/a	18	n/a	0	circle.bmp
+80.6434545455	n/a	20160.8636	show_cross	n/a	n/a	19	n/a	n/a	cross.bmp
+81.1916363636	n/a	20297.9091	show_face	famous_face	delayed_repeat	19	12	7	f094.bmp
+81.8416363636	n/a	20460.4091	right_press	n/a	n/a	19	n/a	4096	n/a
+82.1370909091	n/a	20534.2727	show_circle	n/a	n/a	19	n/a	0	circle.bmp
+83.8370909091	n/a	20959.2727	show_cross	n/a	n/a	20	n/a	n/a	cross.bmp
+84.4989090909	n/a	21124.7273	show_face	scrambled_face	first_show	20	n/a	17	s083.bmp
+85.43072727270001	n/a	21357.6818	show_circle	n/a	n/a	20	n/a	0	circle.bmp
+85.6189090909	n/a	21404.7273	left_press	n/a	n/a	20	n/a	256	n/a
+87.1307272727	n/a	21782.6818	show_cross	n/a	n/a	21	n/a	n/a	cross.bmp
+87.75618181819999	n/a	21939.0455	show_face	scrambled_face	immediate_repeat	21	1	18	s083.bmp
+88.6252727273	n/a	22156.3182	show_circle	n/a	n/a	21	n/a	0	circle.bmp
+90.32527272729999	n/a	22581.3182	show_cross	n/a	n/a	22	n/a	n/a	cross.bmp
+90.8970909091	n/a	22724.2727	show_face	scrambled_face	delayed_repeat	22	14	19	s150.bmp
+91.7243636364	n/a	22931.0909	show_circle	n/a	n/a	22	n/a	0	circle.bmp
+93.42436363639999	n/a	23356.0909	show_cross	n/a	n/a	23	n/a	n/a	cross.bmp
+93.8870909091	n/a	23471.7727	show_face	famous_face	first_show	23	n/a	5	f093.bmp
+94.7770909091	n/a	23694.2727	show_circle	n/a	n/a	23	n/a	0	circle.bmp
+94.8107272727	n/a	23702.6818	left_press	n/a	n/a	23	n/a	256	n/a
+96.4770909091	n/a	24119.2727	show_cross	n/a	n/a	24	n/a	n/a	cross.bmp
+97.078	n/a	24269.5	show_face	famous_face	delayed_repeat	24	14	7	f063.bmp
+97.668	n/a	24417.0	right_press	n/a	n/a	24	n/a	4096	n/a
+97.9389090909	n/a	24484.7273	show_circle	n/a	n/a	24	n/a	0	circle.bmp
+99.6389090909	n/a	24909.7273	show_cross	n/a	n/a	25	n/a	n/a	cross.bmp
+100.218	n/a	25054.5	show_face	famous_face	first_show	25	n/a	5	f143.bmp
+100.9407272727	n/a	25235.1818	right_press	n/a	n/a	25	n/a	4096	n/a
+101.21981818180001	n/a	25304.9545	show_circle	n/a	n/a	25	n/a	0	circle.bmp
+102.9198181818	n/a	25729.9545	show_cross	n/a	n/a	26	n/a	n/a	cross.bmp
+103.45890909090001	n/a	25864.7273	show_face	famous_face	immediate_repeat	26	1	6	f143.bmp
+104.0743636364	n/a	26018.5909	right_press	n/a	n/a	26	n/a	4096	n/a
+104.39254545450001	n/a	26098.1364	show_circle	n/a	n/a	26	n/a	0	circle.bmp
+106.09254545450001	n/a	26523.1364	show_cross	n/a	n/a	27	n/a	n/a	cross.bmp
+106.5661818182	n/a	26641.5455	show_face	scrambled_face	first_show	27	n/a	17	s142.bmp
+107.408	n/a	26852.0	show_circle	n/a	n/a	27	n/a	0	circle.bmp
+107.41345454549999	n/a	26853.3636	left_press	n/a	n/a	27	n/a	256	n/a
+109.108	n/a	27277.0	show_cross	n/a	n/a	28	n/a	n/a	cross.bmp
+109.7407272727	n/a	27435.1818	show_face	famous_face	delayed_repeat	28	13	7	f006.bmp
+110.52527272729999	n/a	27631.3182	left_press	n/a	n/a	28	n/a	256	n/a
+110.70890909090001	n/a	27677.2273	show_circle	n/a	n/a	28	n/a	0	circle.bmp
+112.4089090909	n/a	28102.2273	show_cross	n/a	n/a	29	n/a	n/a	cross.bmp
+112.998	n/a	28249.5	show_face	unfamiliar_face	first_show	29	n/a	13	u131.bmp
+113.7443636364	n/a	28436.0909	left_press	n/a	n/a	29	n/a	256	n/a
+113.9298181818	n/a	28482.4545	show_circle	n/a	n/a	29	n/a	0	circle.bmp
+115.6298181818	n/a	28907.4545	show_cross	n/a	n/a	30	n/a	n/a	cross.bmp
+116.138	n/a	29034.5	show_face	unfamiliar_face	first_show	30	n/a	13	u020.bmp
+117.1143636364	n/a	29278.5909	show_circle	n/a	n/a	30	n/a	0	circle.bmp
+118.81436363639999	n/a	29703.5909	show_cross	n/a	n/a	31	n/a	n/a	cross.bmp
+119.2789090909	n/a	29819.7273	show_face	unfamiliar_face	immediate_repeat	31	1	14	u020.bmp
+119.89436363639999	n/a	29973.5909	left_press	n/a	n/a	31	n/a	256	n/a
+120.1043636364	n/a	30026.0909	show_circle	n/a	n/a	31	n/a	0	circle.bmp
+121.8043636364	n/a	30451.0909	show_cross	n/a	n/a	32	n/a	n/a	cross.bmp
+122.3025454545	n/a	30575.6364	show_face	scrambled_face	first_show	32	n/a	17	s088.bmp
+123.1370909091	n/a	30784.2727	left_press	n/a	n/a	32	n/a	256	n/a
+123.20890909090001	n/a	30802.2273	show_circle	n/a	n/a	32	n/a	0	circle.bmp
+124.9089090909	n/a	31227.2273	show_cross	n/a	n/a	33	n/a	n/a	cross.bmp
+125.4098181818	n/a	31352.4545	show_face	famous_face	delayed_repeat	33	10	7	f093.bmp
+126.0852727273	n/a	31521.3182	right_press	n/a	n/a	33	n/a	4096	n/a
+126.3307272727	n/a	31582.6818	show_circle	n/a	n/a	33	n/a	0	circle.bmp
+128.0307272727	n/a	32007.6818	show_cross	n/a	n/a	34	n/a	n/a	cross.bmp
+128.5834545455	n/a	32145.8636	show_face	scrambled_face	first_show	34	n/a	17	s081.bmp
+129.5343636364	n/a	32383.5909	show_circle	n/a	n/a	34	n/a	0	circle.bmp
+129.778	n/a	32444.5	right_press	n/a	n/a	34	n/a	4096	n/a
+131.2343636364	n/a	32808.5909	show_cross	n/a	n/a	35	n/a	n/a	cross.bmp
+131.758	n/a	32939.5	show_face	scrambled_face	immediate_repeat	35	1	18	s081.bmp
+132.7398181818	n/a	33184.9545	show_circle	n/a	n/a	35	n/a	0	circle.bmp
+132.7798181818	n/a	33194.9545	left_press	n/a	n/a	35	n/a	256	n/a
+134.4398181818	n/a	33609.9545	show_cross	n/a	n/a	36	n/a	n/a	cross.bmp
+135.0816363636	n/a	33770.4091	show_face	unfamiliar_face	first_show	36	n/a	13	u077.bmp
+135.9107272727	n/a	33977.6818	show_circle	n/a	n/a	36	n/a	0	circle.bmp
+135.9407272727	n/a	33985.1818	right_press	n/a	n/a	36	n/a	4096	n/a
+137.61072727270002	n/a	34402.6818	show_cross	n/a	n/a	37	n/a	n/a	cross.bmp
+138.2061818182	n/a	34551.5455	show_face	unfamiliar_face	immediate_repeat	37	1	14	u077.bmp
+139.10618181819999	n/a	34776.5455	show_circle	n/a	n/a	37	n/a	0	circle.bmp
+139.12345454549998	n/a	34780.8636	right_press	n/a	n/a	37	n/a	4096	n/a
+140.8061818182	n/a	35201.5455	show_cross	n/a	n/a	38	n/a	n/a	cross.bmp
+141.4307272727	n/a	35357.6818	show_face	scrambled_face	delayed_repeat	38	11	19	s142.bmp
+142.2698181818	n/a	35567.4545	show_circle	n/a	n/a	38	n/a	0	circle.bmp
+142.32254545450002	n/a	35580.6364	left_press	n/a	n/a	38	n/a	256	n/a
+143.9698181818	n/a	35992.4545	show_cross	n/a	n/a	39	n/a	n/a	cross.bmp
+144.6207272727	n/a	36155.1818	show_face	scrambled_face	first_show	39	n/a	17	s034.bmp
+145.4498181818	n/a	36362.4545	right_press	n/a	n/a	39	n/a	4096	n/a
+145.478	n/a	36369.5	show_circle	n/a	n/a	39	n/a	0	circle.bmp
+147.178	n/a	36794.5	show_cross	n/a	n/a	40	n/a	n/a	cross.bmp
+147.74436363639998	n/a	36936.0909	show_face	scrambled_face	immediate_repeat	40	1	18	s034.bmp
+148.7343636364	n/a	37183.5909	show_circle	n/a	n/a	40	n/a	0	circle.bmp
+148.7452727273	n/a	37186.3182	right_press	n/a	n/a	40	n/a	4096	n/a
+150.4343636364	n/a	37608.5909	show_cross	n/a	n/a	41	n/a	n/a	cross.bmp
+150.9016363636	n/a	37725.4091	show_face	unfamiliar_face	delayed_repeat	41	12	15	u131.bmp
+151.868	n/a	37967.0	right_press	n/a	n/a	41	n/a	4096	n/a
+151.9189090909	n/a	37979.7273	show_circle	n/a	n/a	41	n/a	0	circle.bmp
+151.9752727273	n/a	37993.8182	double_press	n/a	n/a	41	n/a	4352	n/a
+153.6189090909	n/a	38404.7273	show_cross	n/a	n/a	42	n/a	n/a	cross.bmp
+154.2598181818	n/a	38564.9545	show_face	unfamiliar_face	first_show	42	n/a	13	u100.bmp
+155.0989090909	n/a	38774.7273	show_circle	n/a	n/a	42	n/a	0	circle.bmp
+155.1689090909	n/a	38792.2273	left_press	n/a	n/a	42	n/a	256	n/a
+156.7989090909	n/a	39199.7273	show_cross	n/a	n/a	43	n/a	n/a	cross.bmp
+157.43345454549998	n/a	39358.3636	show_face	unfamiliar_face	immediate_repeat	43	1	14	u100.bmp
+157.9898181818	n/a	39497.4545	left_press	n/a	n/a	43	n/a	256	n/a
+158.3389090909	n/a	39584.7273	show_circle	n/a	n/a	43	n/a	0	circle.bmp
+160.0389090909	n/a	40009.7273	show_cross	n/a	n/a	44	n/a	n/a	cross.bmp
+160.5070909091	n/a	40126.7727	show_face	scrambled_face	first_show	44	n/a	17	s087.bmp
+161.3289090909	n/a	40332.2273	left_press	n/a	n/a	44	n/a	256	n/a
+161.4152727273	n/a	40353.8182	show_circle	n/a	n/a	44	n/a	0	circle.bmp
+163.1152727273	n/a	40778.8182	show_cross	n/a	n/a	45	n/a	n/a	cross.bmp
+163.748	n/a	40937.0	show_face	scrambled_face	immediate_repeat	45	1	18	s087.bmp
+164.4807272727	n/a	41120.1818	right_press	n/a	n/a	45	n/a	4096	n/a
+164.7252727273	n/a	41181.3182	show_circle	n/a	n/a	45	n/a	0	circle.bmp
+166.42527272729998	n/a	41606.3182	show_cross	n/a	n/a	46	n/a	n/a	cross.bmp
+166.97254545450002	n/a	41743.1364	show_face	scrambled_face	delayed_repeat	46	14	19	s088.bmp
+167.9352727273	n/a	41983.8182	show_circle	n/a	n/a	46	n/a	0	circle.bmp
+168.1816363636	n/a	42045.4091	left_press	n/a	n/a	46	n/a	256	n/a
+169.6352727273	n/a	42408.8182	show_cross	n/a	n/a	47	n/a	n/a	cross.bmp
+170.2298181818	n/a	42557.4545	show_face	scrambled_face	first_show	47	n/a	17	s074.bmp
+171.0552727273	n/a	42763.8182	show_circle	n/a	n/a	47	n/a	0	circle.bmp
+171.398	n/a	42849.5	right_press	n/a	n/a	47	n/a	4096	n/a
+172.7552727273	n/a	43188.8182	show_cross	n/a	n/a	48	n/a	n/a	cross.bmp
+173.2534545455	n/a	43313.3636	show_face	unfamiliar_face	first_show	48	n/a	13	u058.bmp
+174.1370909091	n/a	43534.2727	right_press	n/a	n/a	48	n/a	4096	n/a
+174.1789090909	n/a	43544.7273	show_circle	n/a	n/a	48	n/a	0	circle.bmp
+175.8789090909	n/a	43969.7273	show_cross	n/a	n/a	49	n/a	n/a	cross.bmp
+176.49436363639998	n/a	44123.5909	show_face	unfamiliar_face	immediate_repeat	49	1	14	u058.bmp
+177.33436363639998	n/a	44333.5909	show_circle	n/a	n/a	49	n/a	0	circle.bmp
+177.4043636364	n/a	44351.0909	right_press	n/a	n/a	49	n/a	4096	n/a
+179.0343636364	n/a	44758.5909	show_cross	n/a	n/a	50	n/a	n/a	cross.bmp
+179.6343636364	n/a	44908.5909	show_face	famous_face	first_show	50	n/a	5	f038.bmp
+180.4970909091	n/a	45124.2727	show_circle	n/a	n/a	50	n/a	0	circle.bmp
+180.6652727273	n/a	45166.3182	left_press	n/a	n/a	50	n/a	256	n/a
+182.1970909091	n/a	45549.2727	show_cross	n/a	n/a	51	n/a	n/a	cross.bmp
+182.67527272729998	n/a	45668.8182	show_face	scrambled_face	first_show	51	n/a	17	s090.bmp
+183.4961818182	n/a	45874.0455	show_circle	n/a	n/a	51	n/a	0	circle.bmp
+183.4961818182	n/a	45874.0455	right_press	n/a	n/a	51	n/a	4096	n/a
+185.1961818182	n/a	46299.0455	show_cross	n/a	n/a	52	n/a	n/a	cross.bmp
+185.6652727273	n/a	46416.3182	show_face	famous_face	first_show	52	n/a	5	f020.bmp
+186.3670909091	n/a	46591.7727	right_press	n/a	n/a	52	n/a	4096	n/a
+186.6225454545	n/a	46655.6364	show_circle	n/a	n/a	52	n/a	0	circle.bmp
+188.32254545450002	n/a	47080.6364	show_cross	n/a	n/a	53	n/a	n/a	cross.bmp
+188.9225454545	n/a	47230.6364	show_face	unfamiliar_face	first_show	53	n/a	13	u114.bmp
+189.8616363636	n/a	47465.4091	left_press	n/a	n/a	53	n/a	256	n/a
+189.9234545455	n/a	47480.8636	show_circle	n/a	n/a	53	n/a	0	circle.bmp
+191.62345454549998	n/a	47905.8636	show_cross	n/a	n/a	54	n/a	n/a	cross.bmp
+192.2307272727	n/a	48057.6818	show_face	scrambled_face	delayed_repeat	54	7	19	s074.bmp
+192.9752727273	n/a	48243.8182	right_press	n/a	n/a	54	n/a	4096	n/a
+193.0698181818	n/a	48267.4545	show_circle	n/a	n/a	54	n/a	0	circle.bmp
+194.7698181818	n/a	48692.4545	show_cross	n/a	n/a	55	n/a	n/a	cross.bmp
+195.388	n/a	48847.0	show_face	scrambled_face	first_show	55	n/a	17	s065.bmp
+196.1743636364	n/a	49043.5909	right_press	n/a	n/a	55	n/a	4096	n/a
+196.3552727273	n/a	49088.8182	show_circle	n/a	n/a	55	n/a	0	circle.bmp
+198.0552727273	n/a	49513.8182	show_cross	n/a	n/a	56	n/a	n/a	cross.bmp
+198.6116363636	n/a	49652.9091	show_face	scrambled_face	immediate_repeat	56	1	18	s065.bmp
+199.5325454545	n/a	49883.1364	show_circle	n/a	n/a	56	n/a	0	circle.bmp
+199.5343636364	n/a	49883.5909	right_press	n/a	n/a	56	n/a	4096	n/a
+201.2325454545	n/a	50308.1364	show_cross	n/a	n/a	57	n/a	n/a	cross.bmp
+201.7025454545	n/a	50425.6364	show_face	famous_face	first_show	57	n/a	5	f040.bmp
+202.4389090909	n/a	50609.7273	right_press	n/a	n/a	57	n/a	4096	n/a
+202.5389090909	n/a	50634.7273	show_circle	n/a	n/a	57	n/a	0	circle.bmp
+204.2389090909	n/a	51059.7273	show_cross	n/a	n/a	58	n/a	n/a	cross.bmp
+204.7089090909	n/a	51177.2273	show_face	famous_face	immediate_repeat	58	1	6	f040.bmp
+205.308	n/a	51327.0	right_press	n/a	n/a	58	n/a	4096	n/a
+205.6398181818	n/a	51409.9545	show_circle	n/a	n/a	58	n/a	0	circle.bmp
+207.3398181818	n/a	51834.9545	show_cross	n/a	n/a	59	n/a	n/a	cross.bmp
+207.7998181818	n/a	51949.9545	show_face	famous_face	delayed_repeat	59	9	7	f038.bmp
+208.7607272727	n/a	52190.1818	left_press	n/a	n/a	59	n/a	256	n/a
+208.7634545455	n/a	52190.8636	show_circle	n/a	n/a	59	n/a	0	circle.bmp
+210.46345454549999	n/a	52615.8636	show_cross	n/a	n/a	60	n/a	n/a	cross.bmp
+211.0070909091	n/a	52751.7727	show_face	unfamiliar_face	first_show	60	n/a	13	u034.bmp
+211.7843636364	n/a	52946.0909	right_press	n/a	n/a	60	n/a	4096	n/a
+212.0107272727	n/a	53002.6818	show_circle	n/a	n/a	60	n/a	0	circle.bmp
+213.7107272727	n/a	53427.6818	show_cross	n/a	n/a	61	n/a	n/a	cross.bmp
+214.298	n/a	53574.5	show_face	unfamiliar_face	immediate_repeat	61	1	14	u034.bmp
+214.9061818182	n/a	53726.5455	right_press	n/a	n/a	61	n/a	4096	n/a
+215.1670909091	n/a	53791.7727	show_circle	n/a	n/a	61	n/a	0	circle.bmp
+216.8670909091	n/a	54216.7727	show_cross	n/a	n/a	62	n/a	n/a	cross.bmp
+217.4052727273	n/a	54351.3182	show_face	scrambled_face	delayed_repeat	62	11	19	s090.bmp
+218.2198181818	n/a	54554.9545	left_press	n/a	n/a	62	n/a	256	n/a
+218.348	n/a	54587.0	show_circle	n/a	n/a	62	n/a	0	circle.bmp
+220.048	n/a	55012.0	show_cross	n/a	n/a	63	n/a	n/a	cross.bmp
+220.5789090909	n/a	55144.7273	show_face	scrambled_face	first_show	63	n/a	17	s015.bmp
+221.4761818182	n/a	55369.0455	show_circle	n/a	n/a	63	n/a	0	circle.bmp
+221.4843636364	n/a	55371.0909	left_press	n/a	n/a	63	n/a	256	n/a
+223.1761818182	n/a	55794.0455	show_cross	n/a	n/a	64	n/a	n/a	cross.bmp
+223.7861818182	n/a	55946.5455	show_face	famous_face	delayed_repeat	64	12	7	f020.bmp
+224.4452727273	n/a	56111.3182	right_press	n/a	n/a	64	n/a	4096	n/a
+224.6198181818	n/a	56154.9545	show_circle	n/a	n/a	64	n/a	0	circle.bmp
+226.3198181818	n/a	56579.9545	show_cross	n/a	n/a	65	n/a	n/a	cross.bmp
+226.84345454549998	n/a	56710.8636	show_face	unfamiliar_face	first_show	65	n/a	13	u009.bmp
+227.588	n/a	56897.0	left_press	n/a	n/a	65	n/a	256	n/a
+227.6889090909	n/a	56922.2273	show_circle	n/a	n/a	65	n/a	0	circle.bmp
+229.3889090909	n/a	57347.2273	show_cross	n/a	n/a	66	n/a	n/a	cross.bmp
+229.9507272727	n/a	57487.6818	show_face	unfamiliar_face	immediate_repeat	66	1	14	u009.bmp
+230.52436363639998	n/a	57631.0909	left_press	n/a	n/a	66	n/a	256	n/a
+230.8816363636	n/a	57720.4091	show_circle	n/a	n/a	66	n/a	0	circle.bmp
+232.5816363636	n/a	58145.4091	show_cross	n/a	n/a	67	n/a	n/a	cross.bmp
+233.0743636364	n/a	58268.5909	show_face	unfamiliar_face	delayed_repeat	67	14	15	u114.bmp
+234.02890909090002	n/a	58507.2273	show_circle	n/a	n/a	67	n/a	0	circle.bmp
+235.7289090909	n/a	58932.2273	show_cross	n/a	n/a	68	n/a	n/a	cross.bmp
+236.198	n/a	59049.5	show_face	famous_face	first_show	68	n/a	5	f097.bmp
+237.048	n/a	59262.0	left_press	n/a	n/a	68	n/a	256	n/a
+237.08436363639998	n/a	59271.0909	show_circle	n/a	n/a	68	n/a	0	circle.bmp
+238.7843636364	n/a	59696.0909	show_cross	n/a	n/a	69	n/a	n/a	cross.bmp
+239.3389090909	n/a	59834.7273	show_face	scrambled_face	first_show	69	n/a	17	s023.bmp
+240.0216363636	n/a	60005.4091	left_press	n/a	n/a	69	n/a	256	n/a
+240.2307272727	n/a	60057.6818	show_circle	n/a	n/a	69	n/a	0	circle.bmp
+241.9307272727	n/a	60482.6818	show_cross	n/a	n/a	70	n/a	n/a	cross.bmp
+242.5961818182	n/a	60649.0455	show_face	famous_face	first_show	70	n/a	5	f048.bmp
+243.2434545455	n/a	60810.8636	right_press	n/a	n/a	70	n/a	4096	n/a
+243.5170909091	n/a	60879.2727	show_circle	n/a	n/a	70	n/a	0	circle.bmp
+245.2170909091	n/a	61304.2727	show_cross	n/a	n/a	71	n/a	n/a	cross.bmp
+245.7870909091	n/a	61446.7727	show_face	famous_face	first_show	71	n/a	5	f062.bmp
+246.41254545450002	n/a	61603.1364	left_press	n/a	n/a	71	n/a	256	n/a
+246.72254545450002	n/a	61680.6364	show_circle	n/a	n/a	71	n/a	0	circle.bmp
+248.4225454545	n/a	62105.6364	show_cross	n/a	n/a	72	n/a	n/a	cross.bmp
+248.878	n/a	62219.5	show_face	famous_face	immediate_repeat	72	1	6	f062.bmp
+249.6443636364	n/a	62411.0909	left_press	n/a	n/a	72	n/a	256	n/a
+249.88254545450002	n/a	62470.6364	show_circle	n/a	n/a	72	n/a	0	circle.bmp
+251.5825454545	n/a	62895.6364	show_cross	n/a	n/a	73	n/a	n/a	cross.bmp
+252.23527272729999	n/a	63058.8182	show_face	scrambled_face	delayed_repeat	73	10	19	s015.bmp
+253.088	n/a	63272.0	show_circle	n/a	n/a	73	n/a	0	circle.bmp
+254.788	n/a	63697.0	show_cross	n/a	n/a	74	n/a	n/a	cross.bmp
+255.3770909091	n/a	63844.2727	show_face	scrambled_face	first_show	74	n/a	17	s144.bmp
+256.1670909091	n/a	64041.7727	right_press	n/a	n/a	74	n/a	4096	n/a
+256.218	n/a	64054.5	show_circle	n/a	n/a	74	n/a	0	circle.bmp
+257.918	n/a	64479.5	show_cross	n/a	n/a	75	n/a	n/a	cross.bmp
+258.3825454545	n/a	64595.6364	show_face	scrambled_face	immediate_repeat	75	1	18	s144.bmp
+259.2298181818	n/a	64807.4545	show_circle	n/a	n/a	75	n/a	0	circle.bmp
+260.9298181818	n/a	65232.4545	show_cross	n/a	n/a	76	n/a	n/a	cross.bmp
+261.4398181818	n/a	65359.9545	show_face	unfamiliar_face	first_show	76	n/a	13	u086.bmp
+262.3125454545	n/a	65578.1364	show_circle	n/a	n/a	76	n/a	0	circle.bmp
+262.41436363639997	n/a	65603.5909	right_press	n/a	n/a	76	n/a	4096	n/a
+264.0125454545	n/a	66003.1364	show_cross	n/a	n/a	77	n/a	n/a	cross.bmp
+264.6134545455	n/a	66153.3636	show_face	famous_face	delayed_repeat	77	9	7	f097.bmp
+265.4907272727	n/a	66372.6818	show_circle	n/a	n/a	77	n/a	0	circle.bmp
+267.19072727270003	n/a	66797.6818	show_cross	n/a	n/a	78	n/a	n/a	cross.bmp
+267.6707272727	n/a	66917.6818	show_face	unfamiliar_face	first_show	78	n/a	13	u102.bmp
+268.3125454545	n/a	67078.1364	right_press	n/a	n/a	78	n/a	4096	n/a
+268.5470909091	n/a	67136.7727	show_circle	n/a	n/a	78	n/a	0	circle.bmp
+270.2470909091	n/a	67561.7727	show_cross	n/a	n/a	79	n/a	n/a	cross.bmp
+270.7443636364	n/a	67686.0909	show_face	unfamiliar_face	immediate_repeat	79	1	14	u102.bmp
+271.6707272727	n/a	67917.6818	show_circle	n/a	n/a	79	n/a	0	circle.bmp
+273.3707272727	n/a	68342.6818	show_cross	n/a	n/a	80	n/a	n/a	cross.bmp
+273.9689090909	n/a	68492.2273	show_face	scrambled_face	delayed_repeat	80	11	19	s023.bmp
+274.8243636364	n/a	68706.0909	show_circle	n/a	n/a	80	n/a	0	circle.bmp
+276.5243636364	n/a	69131.0909	show_cross	n/a	n/a	81	n/a	n/a	cross.bmp
+277.1925454545	n/a	69298.1364	show_face	scrambled_face	first_show	81	n/a	17	s114.bmp
+278.0370909091	n/a	69509.2727	right_press	n/a	n/a	81	n/a	4096	n/a
+278.118	n/a	69529.5	show_circle	n/a	n/a	81	n/a	0	circle.bmp
+279.818	n/a	69954.5	show_cross	n/a	n/a	82	n/a	n/a	cross.bmp
+280.3843636364	n/a	70096.0909	show_face	scrambled_face	immediate_repeat	82	1	18	s114.bmp
+281.1352727273	n/a	70283.8182	right_press	n/a	n/a	82	n/a	4096	n/a
+281.2107272727	n/a	70302.6818	show_circle	n/a	n/a	82	n/a	0	circle.bmp
+282.9107272727	n/a	70727.6818	show_cross	n/a	n/a	83	n/a	n/a	cross.bmp
+283.4243636364	n/a	70856.0909	show_face	famous_face	delayed_repeat	83	13	7	f048.bmp
+284.1570909091	n/a	71039.2727	right_press	n/a	n/a	83	n/a	4096	n/a
+284.368	n/a	71092.0	show_circle	n/a	n/a	83	n/a	0	circle.bmp
+286.068	n/a	71517.0	show_cross	n/a	n/a	84	n/a	n/a	cross.bmp
+286.5816363636	n/a	71645.4091	show_face	famous_face	first_show	84	n/a	5	f021.bmp
+287.3034545455	n/a	71825.8636	right_press	n/a	n/a	84	n/a	4096	n/a
+287.4507272727	n/a	71862.6818	show_circle	n/a	n/a	84	n/a	0	circle.bmp
+289.1507272727	n/a	72287.6818	show_cross	n/a	n/a	85	n/a	n/a	cross.bmp
+289.63890909090003	n/a	72409.7273	show_face	scrambled_face	first_show	85	n/a	17	s052.bmp
+290.5852727273	n/a	72646.3182	show_circle	n/a	n/a	85	n/a	0	circle.bmp
+292.28527272729997	n/a	73071.3182	show_cross	n/a	n/a	86	n/a	n/a	cross.bmp
+292.8961818182	n/a	73224.0455	show_face	scrambled_face	immediate_repeat	86	1	18	s052.bmp
+293.8325454545	n/a	73458.1364	show_circle	n/a	n/a	86	n/a	0	circle.bmp
+295.5325454545	n/a	73883.1364	show_cross	n/a	n/a	87	n/a	n/a	cross.bmp
+296.0361818182	n/a	74009.0455	show_face	scrambled_face	first_show	87	n/a	17	s055.bmp
+296.9389090909	n/a	74234.7273	show_circle	n/a	n/a	87	n/a	0	circle.bmp
+298.63890909090003	n/a	74659.7273	show_cross	n/a	n/a	88	n/a	n/a	cross.bmp
+299.1270909091	n/a	74781.7727	show_face	unfamiliar_face	delayed_repeat	88	12	15	u086.bmp
+300.1307272727	n/a	75032.6818	show_circle	n/a	n/a	88	n/a	0	circle.bmp
+301.8307272727	n/a	75457.6818	show_cross	n/a	n/a	89	n/a	n/a	cross.bmp
+302.4343636364	n/a	75608.5909	show_face	scrambled_face	first_show	89	n/a	17	s123.bmp
+303.1598181818	n/a	75789.9545	left_press	n/a	n/a	89	n/a	256	n/a
+303.2970909091	n/a	75824.2727	show_circle	n/a	n/a	89	n/a	0	circle.bmp
+304.9970909091	n/a	76249.2727	show_cross	n/a	n/a	90	n/a	n/a	cross.bmp
+305.5916363636	n/a	76397.9091	show_face	scrambled_face	immediate_repeat	90	1	18	s123.bmp
+306.22436363639997	n/a	76556.0909	left_press	n/a	n/a	90	n/a	256	n/a
+306.6070909091	n/a	76651.7727	show_circle	n/a	n/a	90	n/a	0	circle.bmp
+308.3070909091	n/a	77076.7727	show_cross	n/a	n/a	91	n/a	n/a	cross.bmp
+308.7652727273	n/a	77191.3182	show_face	famous_face	first_show	91	n/a	5	f013.bmp
+309.3834545455	n/a	77345.8636	right_press	n/a	n/a	91	n/a	4096	n/a
+309.7643636364	n/a	77441.0909	show_circle	n/a	n/a	91	n/a	0	circle.bmp
+311.4643636364	n/a	77866.0909	show_cross	n/a	n/a	92	n/a	n/a	cross.bmp
+312.0561818182	n/a	78014.0455	show_face	famous_face	immediate_repeat	92	1	6	f013.bmp
+312.6434545455	n/a	78160.8636	right_press	n/a	n/a	92	n/a	4096	n/a
+312.9843636364	n/a	78246.0909	show_circle	n/a	n/a	92	n/a	0	circle.bmp
+314.6843636364	n/a	78671.0909	show_cross	n/a	n/a	93	n/a	n/a	cross.bmp
+315.3143636364	n/a	78828.5909	show_face	famous_face	first_show	93	n/a	5	f026.bmp
+315.948	n/a	78987.0	right_press	n/a	n/a	93	n/a	4096	n/a
+316.2725454545	n/a	79068.1364	show_circle	n/a	n/a	93	n/a	0	circle.bmp
+317.9725454545	n/a	79493.1364	show_cross	n/a	n/a	94	n/a	n/a	cross.bmp
+318.5216363636	n/a	79630.4091	show_face	famous_face	delayed_repeat	94	10	7	f021.bmp
+319.2307272727	n/a	79807.6818	right_press	n/a	n/a	94	n/a	4096	n/a
+319.4316363636	n/a	79857.9091	show_circle	n/a	n/a	94	n/a	0	circle.bmp
+321.1316363636	n/a	80282.9091	show_cross	n/a	n/a	95	n/a	n/a	cross.bmp
+321.7125454545	n/a	80428.1364	show_face	famous_face	first_show	95	n/a	5	f128.bmp
+322.6325454545	n/a	80658.1364	show_circle	n/a	n/a	95	n/a	0	circle.bmp
+324.3325454545	n/a	81083.1364	show_cross	n/a	n/a	96	n/a	n/a	cross.bmp
+324.9025454545	n/a	81225.6364	show_face	famous_face	immediate_repeat	96	1	6	f128.bmp
+325.688	n/a	81422.0	right_press	n/a	n/a	96	n/a	4096	n/a
+325.72436363639997	n/a	81431.0909	show_circle	n/a	n/a	96	n/a	0	circle.bmp
+327.4243636364	n/a	81856.0909	show_cross	n/a	n/a	97	n/a	n/a	cross.bmp
+328.0770909091	n/a	82019.2727	show_face	scrambled_face	first_show	97	n/a	17	s102.bmp
+329.0807272727	n/a	82270.1818	show_circle	n/a	n/a	97	n/a	0	circle.bmp
+329.4961818182	n/a	82374.0455	right_press	n/a	n/a	97	n/a	4096	n/a
+330.7807272727	n/a	82695.1818	show_cross	n/a	n/a	98	n/a	n/a	cross.bmp
+331.418	n/a	82854.5	show_face	scrambled_face	delayed_repeat	98	11	19	s055.bmp
+332.3352727273	n/a	83083.8182	show_circle	n/a	n/a	98	n/a	0	circle.bmp
+334.03527272729997	n/a	83508.8182	show_cross	n/a	n/a	99	n/a	n/a	cross.bmp
+334.5916363636	n/a	83647.9091	show_face	scrambled_face	first_show	99	n/a	17	s136.bmp
+335.4243636364	n/a	83856.0909	show_circle	n/a	n/a	99	n/a	0	circle.bmp
+337.1243636364	n/a	84281.0909	show_cross	n/a	n/a	100	n/a	n/a	cross.bmp
+337.68254545450003	n/a	84420.6364	show_face	scrambled_face	immediate_repeat	100	1	18	s136.bmp
+338.5707272727	n/a	84642.6818	left_press	n/a	n/a	100	n/a	256	n/a
+338.6525454545	n/a	84663.1364	show_circle	n/a	n/a	100	n/a	0	circle.bmp
+340.3525454545	n/a	85088.1364	show_cross	n/a	n/a	101	n/a	n/a	cross.bmp
+340.9898181818	n/a	85247.4545	show_face	unfamiliar_face	first_show	101	n/a	13	u134.bmp
+341.6507272727	n/a	85412.6818	left_press	n/a	n/a	101	n/a	256	n/a
+341.8970909091	n/a	85474.2727	show_circle	n/a	n/a	101	n/a	0	circle.bmp
+343.5970909091	n/a	85899.2727	show_cross	n/a	n/a	102	n/a	n/a	cross.bmp
+344.16436363639997	n/a	86041.0909	show_face	scrambled_face	first_show	102	n/a	17	s010.bmp
+344.9489090909	n/a	86237.2273	right_press	n/a	n/a	102	n/a	4096	n/a
+345.15254545449994	n/a	86288.1364	show_circle	n/a	n/a	102	n/a	0	circle.bmp
+345.16345454550003	n/a	86290.8636	right_press	n/a	n/a	102	n/a	4096	n/a
+346.8525454545	n/a	86713.1364	show_cross	n/a	n/a	103	n/a	n/a	cross.bmp
+347.388	n/a	86847.0	show_face	famous_face	delayed_repeat	103	10	7	f026.bmp
+348.048	n/a	87012.0	right_press	n/a	n/a	103	n/a	4096	n/a
+348.238	n/a	87059.5	show_circle	n/a	n/a	103	n/a	0	circle.bmp
+349.938	n/a	87484.5	show_cross	n/a	n/a	104	n/a	n/a	cross.bmp
+350.4125454545	n/a	87603.1364	show_face	scrambled_face	first_show	104	n/a	17	s084.bmp
+351.2261818182	n/a	87806.5455	right_press	n/a	n/a	104	n/a	4096	n/a
+351.3634545455	n/a	87840.8636	show_circle	n/a	n/a	104	n/a	0	circle.bmp
+353.0634545455	n/a	88265.8636	show_cross	n/a	n/a	105	n/a	n/a	cross.bmp
+353.6025454545	n/a	88400.6364	show_face	famous_face	first_show	105	n/a	5	f009.bmp
+354.34890909089995	n/a	88587.2273	right_press	n/a	n/a	105	n/a	4096	n/a
+354.54890909089994	n/a	88637.2273	show_circle	n/a	n/a	105	n/a	0	circle.bmp
+356.2489090909	n/a	89062.2273	show_cross	n/a	n/a	106	n/a	n/a	cross.bmp
+356.7261818182	n/a	89181.5455	show_face	famous_face	immediate_repeat	106	1	6	f009.bmp
+357.44527272730005	n/a	89361.3182	right_press	n/a	n/a	106	n/a	4096	n/a
+357.6516363636	n/a	89412.9091	show_circle	n/a	n/a	106	n/a	0	circle.bmp
+359.3516363636	n/a	89837.9091	show_cross	n/a	n/a	107	n/a	n/a	cross.bmp
+359.9670909091	n/a	89991.7727	show_face	scrambled_face	delayed_repeat	107	10	19	s102.bmp
+360.83345454550005	n/a	90208.3636	left_press	n/a	n/a	107	n/a	256	n/a
+360.97436363639997	n/a	90243.5909	show_circle	n/a	n/a	107	n/a	0	circle.bmp
+362.6743636364	n/a	90668.5909	show_cross	n/a	n/a	108	n/a	n/a	cross.bmp
+363.2916363636	n/a	90822.9091	show_face	famous_face	first_show	108	n/a	5	f129.bmp
+364.0898181818	n/a	91022.4545	right_press	n/a	n/a	108	n/a	4096	n/a
+364.20072727269996	n/a	91050.1818	show_circle	n/a	n/a	108	n/a	0	circle.bmp
+365.90072727269995	n/a	91475.1818	show_cross	n/a	n/a	109	n/a	n/a	cross.bmp
+366.4152727273	n/a	91603.8182	show_face	unfamiliar_face	first_show	109	n/a	13	u051.bmp
+367.298	n/a	91824.5	left_press	n/a	n/a	109	n/a	256	n/a
+367.3789090909	n/a	91844.7273	show_circle	n/a	n/a	109	n/a	0	circle.bmp
+369.07890909089997	n/a	92269.7273	show_cross	n/a	n/a	110	n/a	n/a	cross.bmp
+369.6061818182	n/a	92401.5455	show_face	unfamiliar_face	delayed_repeat	110	9	15	u134.bmp
+370.2952727273	n/a	92573.8182	left_press	n/a	n/a	110	n/a	256	n/a
+370.52890909089996	n/a	92632.2273	show_circle	n/a	n/a	110	n/a	0	circle.bmp
+372.22890909089995	n/a	93057.2273	show_cross	n/a	n/a	111	n/a	n/a	cross.bmp
+372.76345454550005	n/a	93190.8636	show_face	unfamiliar_face	first_show	111	n/a	13	u140.bmp
+373.51709090910003	n/a	93379.2727	right_press	n/a	n/a	111	n/a	4096	n/a
+373.59890909089995	n/a	93399.7273	show_circle	n/a	n/a	111	n/a	0	circle.bmp
+375.29890909089994	n/a	93824.7273	show_cross	n/a	n/a	112	n/a	n/a	cross.bmp
+375.7534545455	n/a	93938.3636	show_face	scrambled_face	delayed_repeat	112	10	19	s010.bmp
+376.6016363636	n/a	94150.4091	show_circle	n/a	n/a	112	n/a	0	circle.bmp
+376.6034545455	n/a	94150.8636	left_press	n/a	n/a	112	n/a	256	n/a
+378.3016363636	n/a	94575.4091	show_cross	n/a	n/a	113	n/a	n/a	cross.bmp
+378.82709090910004	n/a	94706.7727	show_face	famous_face	first_show	113	n/a	5	f096.bmp
+379.538	n/a	94884.5	left_press	n/a	n/a	113	n/a	256	n/a
+379.7116363636	n/a	94927.9091	show_circle	n/a	n/a	113	n/a	0	circle.bmp
+381.4116363636	n/a	95352.9091	show_cross	n/a	n/a	114	n/a	n/a	cross.bmp
+382.0007272727	n/a	95500.1818	show_face	famous_face	immediate_repeat	114	1	6	f096.bmp
+382.4925454545	n/a	95623.1364	left_press	n/a	n/a	114	n/a	256	n/a
+382.9516363636	n/a	95737.9091	show_circle	n/a	n/a	114	n/a	0	circle.bmp
+384.6516363636	n/a	96162.9091	show_cross	n/a	n/a	115	n/a	n/a	cross.bmp
+385.10890909089994	n/a	96277.2273	show_face	scrambled_face	delayed_repeat	115	11	19	s084.bmp
+385.838	n/a	96459.5	right_press	n/a	n/a	115	n/a	4096	n/a
+386.01709090910003	n/a	96504.2727	show_circle	n/a	n/a	115	n/a	0	circle.bmp
+387.7170909091	n/a	96929.2727	show_cross	n/a	n/a	116	n/a	n/a	cross.bmp
+388.1816363636	n/a	97045.4091	show_face	unfamiliar_face	first_show	116	n/a	13	u139.bmp
+389.1398181818	n/a	97284.9545	show_circle	n/a	n/a	116	n/a	0	circle.bmp
+390.8398181818	n/a	97709.9545	show_cross	n/a	n/a	117	n/a	n/a	cross.bmp
+391.4225454545	n/a	97855.6364	show_face	unfamiliar_face	immediate_repeat	117	1	14	u139.bmp
+392.3016363636	n/a	98075.4091	show_circle	n/a	n/a	117	n/a	0	circle.bmp
+394.0016363636	n/a	98500.4091	show_cross	n/a	n/a	118	n/a	n/a	cross.bmp
+394.4798181818	n/a	98619.9545	show_face	scrambled_face	first_show	118	n/a	17	s140.bmp
+395.3098181818	n/a	98827.4545	show_circle	n/a	n/a	118	n/a	0	circle.bmp
+395.3525454545	n/a	98838.1364	right_press	n/a	n/a	118	n/a	4096	n/a
+397.00981818180003	n/a	99252.4545	show_cross	n/a	n/a	119	n/a	n/a	cross.bmp
+397.6034545455	n/a	99400.8636	show_face	scrambled_face	immediate_repeat	119	1	18	s140.bmp
+398.298	n/a	99574.5	right_press	n/a	n/a	119	n/a	4096	n/a
+398.51254545449996	n/a	99628.1364	show_circle	n/a	n/a	119	n/a	0	circle.bmp
+400.21254545449995	n/a	100053.1364	show_cross	n/a	n/a	120	n/a	n/a	cross.bmp
+400.778	n/a	100194.5	show_face	famous_face	delayed_repeat	120	12	7	f129.bmp
+401.44527272730005	n/a	100361.3182	right_press	n/a	n/a	120	n/a	4096	n/a
+401.74709090910005	n/a	100436.7727	show_circle	n/a	n/a	120	n/a	0	circle.bmp
+403.44709090910004	n/a	100861.7727	show_cross	n/a	n/a	121	n/a	n/a	cross.bmp
+404.0016363636	n/a	101000.4091	show_face	famous_face	first_show	121	n/a	5	f049.bmp
+404.72072727269995	n/a	101180.1818	left_press	n/a	n/a	121	n/a	256	n/a
+404.8643636364	n/a	101216.0909	show_circle	n/a	n/a	121	n/a	0	circle.bmp
+406.5643636364	n/a	101641.0909	show_cross	n/a	n/a	122	n/a	n/a	cross.bmp
+407.14254545449995	n/a	101785.6364	show_face	famous_face	immediate_repeat	122	1	6	f049.bmp
+408.1152727273	n/a	102028.8182	show_circle	n/a	n/a	122	n/a	0	circle.bmp
+409.81527272730006	n/a	102453.8182	show_cross	n/a	n/a	123	n/a	n/a	cross.bmp
+410.38345454550006	n/a	102595.8636	show_face	unfamiliar_face	delayed_repeat	123	14	15	u051.bmp
+411.21345454550004	n/a	102803.3636	show_circle	n/a	n/a	123	n/a	0	circle.bmp
+411.35436363639997	n/a	102838.5909	right_press	n/a	n/a	123	n/a	4096	n/a
+412.91345454550003	n/a	103228.3636	show_cross	n/a	n/a	124	n/a	n/a	cross.bmp
+413.55709090910005	n/a	103389.2727	show_face	famous_face	first_show	124	n/a	5	f140.bmp
+414.3916363636	n/a	103597.9091	right_press	n/a	n/a	124	n/a	4096	n/a
+414.39345454550005	n/a	103598.3636	show_circle	n/a	n/a	124	n/a	0	circle.bmp
+416.09345454550004	n/a	104023.3636	show_cross	n/a	n/a	125	n/a	n/a	cross.bmp
+416.5643636364	n/a	104141.0909	show_face	unfamiliar_face	delayed_repeat	125	14	15	u140.bmp
+417.52890909089996	n/a	104382.2273	show_circle	n/a	n/a	125	n/a	0	circle.bmp
+417.56527272730006	n/a	104391.3182	right_press	n/a	n/a	125	n/a	4096	n/a
+419.22890909089995	n/a	104807.2273	show_cross	n/a	n/a	126	n/a	n/a	cross.bmp
+419.8052727273	n/a	104951.3182	show_face	unfamiliar_face	first_show	126	n/a	13	u017.bmp
+420.468	n/a	105117.0	left_press	n/a	n/a	126	n/a	256	n/a
+420.70709090910003	n/a	105176.7727	show_circle	n/a	n/a	126	n/a	0	circle.bmp
+422.4070909091	n/a	105601.7727	show_cross	n/a	n/a	127	n/a	n/a	cross.bmp
+423.01254545449996	n/a	105753.1364	show_face	unfamiliar_face	immediate_repeat	127	1	14	u017.bmp
+423.54072727269994	n/a	105885.1818	left_press	n/a	n/a	127	n/a	256	n/a
+423.8843636364	n/a	105971.0909	show_circle	n/a	n/a	127	n/a	0	circle.bmp
+425.5843636364	n/a	106396.0909	show_cross	n/a	n/a	128	n/a	n/a	cross.bmp
+426.0525454545	n/a	106513.1364	show_face	famous_face	first_show	128	n/a	5	f033.bmp
+426.7316363636	n/a	106682.9091	right_press	n/a	n/a	128	n/a	4096	n/a
+426.96527272730003	n/a	106741.3182	show_circle	n/a	n/a	128	n/a	0	circle.bmp
+428.6652727273	n/a	107166.3182	show_cross	n/a	n/a	129	n/a	n/a	cross.bmp
+429.16072727269994	n/a	107290.1818	show_face	famous_face	immediate_repeat	129	1	6	f033.bmp
+429.7307272727	n/a	107432.6818	right_press	n/a	n/a	129	n/a	4096	n/a
+430.1461818182	n/a	107536.5455	show_circle	n/a	n/a	129	n/a	0	circle.bmp
+431.8461818182	n/a	107961.5455	show_cross	n/a	n/a	130	n/a	n/a	cross.bmp
+432.4170909091	n/a	108104.2727	show_face	famous_face	first_show	130	n/a	5	f060.bmp
+433.31254545449997	n/a	108328.1364	show_circle	n/a	n/a	130	n/a	0	circle.bmp
+435.01254545449996	n/a	108753.1364	show_cross	n/a	n/a	131	n/a	n/a	cross.bmp
+435.4907272727	n/a	108872.6818	show_face	famous_face	immediate_repeat	131	1	6	f060.bmp
+436.47436363639997	n/a	109118.5909	show_circle	n/a	n/a	131	n/a	0	circle.bmp
+438.1743636364	n/a	109543.5909	show_cross	n/a	n/a	132	n/a	n/a	cross.bmp
+438.6816363636	n/a	109670.4091	show_face	scrambled_face	first_show	132	n/a	17	s098.bmp
+439.56981818180003	n/a	109892.4545	show_circle	n/a	n/a	132	n/a	0	circle.bmp
+441.2698181818	n/a	110317.4545	show_cross	n/a	n/a	133	n/a	n/a	cross.bmp
+441.77254545449995	n/a	110443.1364	show_face	scrambled_face	immediate_repeat	133	1	18	s098.bmp
+442.6261818182	n/a	110656.5455	show_circle	n/a	n/a	133	n/a	0	circle.bmp
+444.3261818182	n/a	111081.5455	show_cross	n/a	n/a	134	n/a	n/a	cross.bmp
+444.9298181818	n/a	111232.4545	show_face	scrambled_face	first_show	134	n/a	17	s110.bmp
+445.6761818182	n/a	111419.0455	right_press	n/a	n/a	134	n/a	4096	n/a
+445.8052727273	n/a	111451.3182	show_circle	n/a	n/a	134	n/a	0	circle.bmp
+447.50527272730005	n/a	111876.3182	show_cross	n/a	n/a	135	n/a	n/a	cross.bmp
+448.13709090910004	n/a	112034.2727	show_face	scrambled_face	immediate_repeat	135	1	18	s110.bmp
+448.81254545449997	n/a	112203.1364	right_press	n/a	n/a	135	n/a	4096	n/a
+449.1498181818	n/a	112287.4545	show_circle	n/a	n/a	135	n/a	0	circle.bmp
+450.8498181818	n/a	112712.4545	show_cross	n/a	n/a	136	n/a	n/a	cross.bmp
+451.41072727269994	n/a	112852.6818	show_face	famous_face	delayed_repeat	136	12	7	f140.bmp
+452.1016363636	n/a	113025.4091	right_press	n/a	n/a	136	n/a	4096	n/a
+452.2816363636	n/a	113070.4091	show_circle	n/a	n/a	136	n/a	0	circle.bmp
+453.9816363636	n/a	113495.4091	show_cross	n/a	n/a	137	n/a	n/a	cross.bmp
+454.5352727273	n/a	113633.8182	show_face	unfamiliar_face	first_show	137	n/a	13	u073.bmp
+455.41345454550003	n/a	113853.3636	show_circle	n/a	n/a	137	n/a	0	circle.bmp
+457.1134545455	n/a	114278.3636	show_cross	n/a	n/a	138	n/a	n/a	cross.bmp
+457.62527272730006	n/a	114406.3182	show_face	famous_face	first_show	138	n/a	5	f137.bmp
+458.57709090910004	n/a	114644.2727	show_circle	n/a	n/a	138	n/a	0	circle.bmp
+460.2770909091	n/a	115069.2727	show_cross	n/a	n/a	139	n/a	n/a	cross.bmp
+460.7489090909	n/a	115187.2273	show_face	unfamiliar_face	first_show	139	n/a	13	u066.bmp
+461.6052727273	n/a	115401.3182	show_circle	n/a	n/a	139	n/a	0	circle.bmp
+463.3052727273	n/a	115826.3182	show_cross	n/a	n/a	140	n/a	n/a	cross.bmp
+463.9061818182	n/a	115976.5455	show_face	unfamiliar_face	first_show	140	n/a	13	u078.bmp
+464.5270909091	n/a	116131.7727	right_press	n/a	n/a	140	n/a	4096	n/a
+464.77890909089996	n/a	116194.7273	show_circle	n/a	n/a	140	n/a	0	circle.bmp
+466.47890909089995	n/a	116619.7273	show_cross	n/a	n/a	141	n/a	n/a	cross.bmp
+467.0970909091	n/a	116774.2727	show_face	unfamiliar_face	immediate_repeat	141	1	14	u078.bmp
+467.6443636364	n/a	116911.0909	right_press	n/a	n/a	141	n/a	4096	n/a
+467.94254545449996	n/a	116985.6364	show_circle	n/a	n/a	141	n/a	0	circle.bmp
+469.64254545449995	n/a	117410.6364	show_cross	n/a	n/a	142	n/a	n/a	cross.bmp
+470.10436363639997	n/a	117526.0909	show_face	famous_face	first_show	142	n/a	5	f131.bmp
+470.9498181818	n/a	117737.4545	show_circle	n/a	n/a	142	n/a	0	circle.bmp
+471.00527272730005	n/a	117751.3182	right_press	n/a	n/a	142	n/a	4096	n/a
+472.6498181818	n/a	118162.4545	show_cross	n/a	n/a	143	n/a	n/a	cross.bmp
+473.31163636360003	n/a	118327.9091	show_face	unfamiliar_face	first_show	143	n/a	13	u105.bmp
+474.138	n/a	118534.5	right_press	n/a	n/a	143	n/a	4096	n/a
+474.27254545449995	n/a	118568.1364	show_circle	n/a	n/a	143	n/a	0	circle.bmp
+475.9725454545	n/a	118993.1364	show_cross	n/a	n/a	144	n/a	n/a	cross.bmp
+476.43527272730006	n/a	119108.8182	show_face	unfamiliar_face	delayed_repeat	144	7	15	u073.bmp
+477.3598181818	n/a	119339.9545	show_circle	n/a	n/a	144	n/a	0	circle.bmp
+479.0598181818	n/a	119764.9545	show_cross	n/a	n/a	145	n/a	n/a	cross.bmp
+479.6598181818	n/a	119914.9545	show_face	unfamiliar_face	first_show	145	n/a	13	u132.bmp
+480.5425454545	n/a	120135.6364	show_circle	n/a	n/a	145	n/a	0	circle.bmp
+482.2425454545	n/a	120560.6364	show_cross	n/a	n/a	146	n/a	n/a	cross.bmp
+482.86709090910006	n/a	120716.7727	show_face	famous_face	delayed_repeat	146	8	7	f137.bmp
+483.84072727269995	n/a	120960.1818	show_circle	n/a	n/a	146	n/a	0	circle.bmp
+485.54072727269994	n/a	121385.1818	show_cross	n/a	n/a	147	n/a	n/a	cross.bmp

--- a/eeg_hed_small/sub-002/eeg/sub-002_task-FacePerception_run-2_events.tsv
+++ b/eeg_hed_small/sub-002/eeg/sub-002_task-FacePerception_run-2_events.tsv
@@ -1,518 +1,518 @@
-onset	duration	sample	event_type	face_type	repetition_type	trigger	stim_file
-0.0040000000	n/a	1	setup	n/a	n/a	n/a	n/a
-0.0040000000	n/a	1	right_sym	n/a	n/a	n/a	n/a
-25.6961818182	n/a	6424.0455	show_face	scrambled_face	first_show	17	s096.bmp
-26.5616363636	n/a	6640.4091	show_circle	n/a	n/a	0	circle.bmp
-28.2616363636	n/a	7065.4091	show_cross	n/a	n/a	n/a	cross.bmp
-28.8870909091	n/a	7221.7727	show_face	famous_face	first_show	5	f148.bmp
-29.7716363636	n/a	7442.9091	right_press	n/a	n/a	4096	n/a
-29.9052727273	n/a	7476.3182	show_circle	n/a	n/a	0	circle.bmp
-31.6052727273	n/a	7901.3182	show_cross	n/a	n/a	n/a	cross.bmp
-32.1943636364	n/a	8048.5909	show_face	famous_face	immediate_repeat	6	f148.bmp
-32.7898181818	n/a	8197.4545	right_press	n/a	n/a	4096	n/a
-33.0316363636	n/a	8257.9091	show_circle	n/a	n/a	0	circle.bmp
-34.7316363636	n/a	8682.9091	show_cross	n/a	n/a	n/a	cross.bmp
-35.1843636364	n/a	8796.0909	show_face	scrambled_face	first_show	17	s071.bmp
-36.0289090909	n/a	9007.2273	show_circle	n/a	n/a	0	circle.bmp
-36.1089090909	n/a	9027.2273	right_press	n/a	n/a	4096	n/a
-37.7289090909	n/a	9432.2273	show_cross	n/a	n/a	n/a	cross.bmp
-38.3589090909	n/a	9589.7273	show_face	scrambled_face	immediate_repeat	18	s071.bmp
-38.8270909091	n/a	9706.7727	right_press	n/a	n/a	4096	n/a
-39.3707272727	n/a	9842.6818	show_circle	n/a	n/a	0	circle.bmp
-41.0707272727	n/a	10267.6818	show_cross	n/a	n/a	n/a	cross.bmp
-41.6498181818	n/a	10412.4545	show_face	unfamiliar_face	first_show	13	u005.bmp
-42.5307272727	n/a	10632.6818	show_circle	n/a	n/a	0	circle.bmp
-44.2307272727	n/a	11057.6818	show_cross	n/a	n/a	n/a	cross.bmp
-44.7234545455	n/a	11180.8636	show_face	famous_face	first_show	5	f119.bmp
-45.4770909091	n/a	11369.2727	right_press	n/a	n/a	4096	n/a
-45.6080000000	n/a	11402	show_circle	n/a	n/a	0	circle.bmp
-47.3080000000	n/a	11827	show_cross	n/a	n/a	n/a	cross.bmp
-47.7970909091	n/a	11949.2727	show_face	famous_face	first_show	5	f145.bmp
-48.3907272727	n/a	12097.6818	right_press	n/a	n/a	4096	n/a
-48.7780000000	n/a	12194.5	show_circle	n/a	n/a	0	circle.bmp
-50.4780000000	n/a	12619.5	show_cross	n/a	n/a	n/a	cross.bmp
-50.9707272727	n/a	12742.6818	show_face	scrambled_face	delayed_repeat	19	s096.bmp
-51.9816363636	n/a	12995.4091	show_circle	n/a	n/a	0	circle.bmp
-53.6816363636	n/a	13420.4091	show_cross	n/a	n/a	n/a	cross.bmp
-54.2789090909	n/a	13569.7273	show_face	unfamiliar_face	first_show	13	u117.bmp
-55.0334545455	n/a	13758.3636	right_press	n/a	n/a	4096	n/a
-55.1334545455	n/a	13783.3636	show_circle	n/a	n/a	0	circle.bmp
-56.8334545455	n/a	14208.3636	show_cross	n/a	n/a	n/a	cross.bmp
-57.4025454545	n/a	14350.6364	show_face	unfamiliar_face	immediate_repeat	14	u117.bmp
-58.1198181818	n/a	14529.9545	right_press	n/a	n/a	4096	n/a
-58.2443636364	n/a	14561.0909	show_circle	n/a	n/a	0	circle.bmp
-59.9443636364	n/a	14986.0909	show_cross	n/a	n/a	n/a	cross.bmp
-60.5598181818	n/a	15139.9545	show_face	famous_face	first_show	5	f098.bmp
-61.4780000000	n/a	15369.5	show_circle	n/a	n/a	0	circle.bmp
-63.1780000000	n/a	15794.5	show_cross	n/a	n/a	n/a	cross.bmp
-63.7843636364	n/a	15946.0909	show_face	scrambled_face	first_show	17	s008.bmp
-64.4870909091	n/a	16121.7727	right_press	n/a	n/a	4096	n/a
-64.7952727273	n/a	16198.8182	show_circle	n/a	n/a	0	circle.bmp
-66.4952727273	n/a	16623.8182	show_cross	n/a	n/a	n/a	cross.bmp
-67.0416363636	n/a	16760.4091	show_face	scrambled_face	immediate_repeat	18	s008.bmp
-67.6807272727	n/a	16920.1818	right_press	n/a	n/a	4096	n/a
-67.9061818182	n/a	16976.5455	show_circle	n/a	n/a	0	circle.bmp
-69.6061818182	n/a	17401.5455	show_cross	n/a	n/a	n/a	cross.bmp
-70.2489090909	n/a	17562.2273	show_face	unfamiliar_face	delayed_repeat	15	u005.bmp
-71.1816363636	n/a	17795.4091	right_press	n/a	n/a	4096	n/a
-71.1889090909	n/a	17797.2273	show_circle	n/a	n/a	0	circle.bmp
-72.8889090909	n/a	18222.2273	show_cross	n/a	n/a	n/a	cross.bmp
-73.4398181818	n/a	18359.9545	show_face	famous_face	first_show	5	f139.bmp
-74.2616363636	n/a	18565.4091	right_press	n/a	n/a	4096	n/a
-74.3189090909	n/a	18579.7273	show_circle	n/a	n/a	0	circle.bmp
-76.0189090909	n/a	19004.7273	show_cross	n/a	n/a	n/a	cross.bmp
-76.6470909091	n/a	19161.7727	show_face	famous_face	immediate_repeat	6	f139.bmp
-77.3025454545	n/a	19325.6364	right_press	n/a	n/a	4096	n/a
-77.5889090909	n/a	19397.2273	show_circle	n/a	n/a	0	circle.bmp
-79.2889090909	n/a	19822.2273	show_cross	n/a	n/a	n/a	cross.bmp
-79.8707272727	n/a	19967.6818	show_face	famous_face	delayed_repeat	7	f119.bmp
-80.4789090909	n/a	20119.7273	right_press	n/a	n/a	4096	n/a
-80.7261818182	n/a	20181.5455	show_circle	n/a	n/a	0	circle.bmp
-82.4261818182	n/a	20606.5455	show_cross	n/a	n/a	n/a	cross.bmp
-82.9116363636	n/a	20727.9091	show_face	scrambled_face	first_show	17	s001.bmp
-83.4970909091	n/a	20874.2727	right_press	n/a	n/a	4096	n/a
-83.7943636364	n/a	20948.5909	show_circle	n/a	n/a	0	circle.bmp
-85.4943636364	n/a	21373.5909	show_cross	n/a	n/a	n/a	cross.bmp
-86.0852727273	n/a	21521.3182	show_face	scrambled_face	immediate_repeat	18	s001.bmp
-86.9752727273	n/a	21743.8182	right_press	n/a	n/a	4096	n/a
-87.1025454545	n/a	21775.6364	show_circle	n/a	n/a	0	circle.bmp
-88.8025454545	n/a	22200.6364	show_cross	n/a	n/a	n/a	cross.bmp
-89.3098181818	n/a	22327.4545	show_face	famous_face	delayed_repeat	7	f145.bmp
-89.9880000000	n/a	22497	right_press	n/a	n/a	4096	n/a
-90.2452727273	n/a	22561.3182	show_circle	n/a	n/a	0	circle.bmp
-91.9452727273	n/a	22986.3182	show_cross	n/a	n/a	n/a	cross.bmp
-92.4161818182	n/a	23104.0455	show_face	famous_face	first_show	5	f028.bmp
-93.0407272727	n/a	23260.1818	right_press	n/a	n/a	4096	n/a
-93.2761818182	n/a	23319.0455	show_circle	n/a	n/a	0	circle.bmp
-94.9761818182	n/a	23744.0455	show_cross	n/a	n/a	n/a	cross.bmp
-95.5234545455	n/a	23880.8636	show_face	unfamiliar_face	first_show	13	u095.bmp
-96.1661818182	n/a	24041.5455	right_press	n/a	n/a	4096	n/a
-96.5407272727	n/a	24135.1818	show_circle	n/a	n/a	0	circle.bmp
-98.2407272727	n/a	24560.1818	show_cross	n/a	n/a	n/a	cross.bmp
-98.6980000000	n/a	24674.5	show_face	famous_face	delayed_repeat	7	f098.bmp
-99.5389090909	n/a	24884.7273	show_circle	n/a	n/a	0	circle.bmp
-101.2389090909	n/a	25309.7273	show_cross	n/a	n/a	n/a	cross.bmp
-101.7216363636	n/a	25430.4091	show_face	scrambled_face	first_show	17	s037.bmp
-102.6689090909	n/a	25667.2273	show_circle	n/a	n/a	0	circle.bmp
-104.3689090909	n/a	26092.2273	show_cross	n/a	n/a	n/a	cross.bmp
-104.9789090909	n/a	26244.7273	show_face	scrambled_face	immediate_repeat	18	s037.bmp
-105.9925454545	n/a	26498.1364	show_circle	n/a	n/a	0	circle.bmp
-107.6925454545	n/a	26923.1364	show_cross	n/a	n/a	n/a	cross.bmp
-108.3198181818	n/a	27079.9545	show_face	famous_face	first_show	5	f089.bmp
-109.1943636364	n/a	27298.5909	show_circle	n/a	n/a	0	circle.bmp
-110.8943636364	n/a	27723.5909	show_cross	n/a	n/a	n/a	cross.bmp
-111.4107272727	n/a	27852.6818	show_face	famous_face	immediate_repeat	6	f089.bmp
-112.4234545455	n/a	28105.8636	show_circle	n/a	n/a	0	circle.bmp
-114.1234545455	n/a	28530.8636	show_cross	n/a	n/a	n/a	cross.bmp
-114.6680000000	n/a	28667	show_face	famous_face	first_show	5	f111.bmp
-115.5052727273	n/a	28876.3182	show_circle	n/a	n/a	0	circle.bmp
-117.2052727273	n/a	29301.3182	show_cross	n/a	n/a	n/a	cross.bmp
-117.6752727273	n/a	29418.8182	show_face	unfamiliar_face	first_show	13	u070.bmp
-118.5689090909	n/a	29642.2273	show_circle	n/a	n/a	0	circle.bmp
-120.2689090909	n/a	30067.2273	show_cross	n/a	n/a	n/a	cross.bmp
-120.8489090909	n/a	30212.2273	show_face	famous_face	delayed_repeat	7	f028.bmp
-121.4880000000	n/a	30372	right_press	n/a	n/a	4096	n/a
-121.7470909091	n/a	30436.7727	show_circle	n/a	n/a	0	circle.bmp
-123.4470909091	n/a	30861.7727	show_cross	n/a	n/a	n/a	cross.bmp
-123.9898181818	n/a	30997.4545	show_face	famous_face	first_show	5	f124.bmp
-124.9280000000	n/a	31232	show_circle	n/a	n/a	0	circle.bmp
-126.6280000000	n/a	31657	show_cross	n/a	n/a	n/a	cross.bmp
-127.2634545455	n/a	31815.8636	show_face	unfamiliar_face	delayed_repeat	15	u095.bmp
-127.9789090909	n/a	31994.7273	right_press	n/a	n/a	4096	n/a
-128.2070909091	n/a	32051.7727	show_circle	n/a	n/a	0	circle.bmp
-129.9070909091	n/a	32476.7727	show_cross	n/a	n/a	n/a	cross.bmp
-130.5543636364	n/a	32638.5909	show_face	unfamiliar_face	first_show	13	u048.bmp
-131.4325454545	n/a	32858.1364	show_circle	n/a	n/a	0	circle.bmp
-131.4334545455	n/a	32858.3636	right_press	n/a	n/a	4096	n/a
-133.1325454545	n/a	33283.1364	show_cross	n/a	n/a	n/a	cross.bmp
-133.6625454545	n/a	33415.6364	show_face	famous_face	first_show	5	f074.bmp
-134.5861818182	n/a	33646.5455	show_circle	n/a	n/a	0	circle.bmp
-136.2861818182	n/a	34071.5455	show_cross	n/a	n/a	n/a	cross.bmp
-136.9189090909	n/a	34229.7273	show_face	unfamiliar_face	first_show	13	u021.bmp
-137.7934545455	n/a	34448.3636	show_circle	n/a	n/a	0	circle.bmp
-139.4934545455	n/a	34873.3636	show_cross	n/a	n/a	n/a	cross.bmp
-140.1261818182	n/a	35031.5455	show_face	famous_face	delayed_repeat	7	f111.bmp
-141.0770909091	n/a	35269.2727	show_circle	n/a	n/a	0	circle.bmp
-142.7770909091	n/a	35694.2727	show_cross	n/a	n/a	n/a	cross.bmp
-143.4170909091	n/a	35854.2727	show_face	unfamiliar_face	first_show	13	u019.bmp
-144.2998181818	n/a	36074.9545	show_circle	n/a	n/a	0	circle.bmp
-145.9998181818	n/a	36499.9545	show_cross	n/a	n/a	n/a	cross.bmp
-146.5416363636	n/a	36635.4091	show_face	unfamiliar_face	immediate_repeat	14	u019.bmp
-147.5252727273	n/a	36881.3182	show_circle	n/a	n/a	0	circle.bmp
-149.2252727273	n/a	37306.3182	show_cross	n/a	n/a	n/a	cross.bmp
-149.8489090909	n/a	37462.2273	show_face	unfamiliar_face	delayed_repeat	15	u070.bmp
-150.5007272727	n/a	37625.1818	right_press	n/a	n/a	4096	n/a
-150.7134545455	n/a	37678.3636	show_circle	n/a	n/a	0	circle.bmp
-152.4134545455	n/a	38103.3636	show_cross	n/a	n/a	n/a	cross.bmp
-152.8889090909	n/a	38222.2273	show_face	scrambled_face	first_show	17	s026.bmp
-153.8552727273	n/a	38463.8182	show_circle	n/a	n/a	0	circle.bmp
-155.5552727273	n/a	38888.8182	show_cross	n/a	n/a	n/a	cross.bmp
-156.1798181818	n/a	39044.9545	show_face	scrambled_face	immediate_repeat	18	s026.bmp
-157.0334545455	n/a	39258.3636	show_circle	n/a	n/a	0	circle.bmp
-158.7334545455	n/a	39683.3636	show_cross	n/a	n/a	n/a	cross.bmp
-159.2543636364	n/a	39813.5909	show_face	famous_face	delayed_repeat	7	f124.bmp
-160.1107272727	n/a	40027.6818	show_circle	n/a	n/a	0	circle.bmp
-161.8107272727	n/a	40452.6818	show_cross	n/a	n/a	n/a	cross.bmp
-162.4616363636	n/a	40615.4091	show_face	scrambled_face	first_show	17	s086.bmp
-163.1352727273	n/a	40783.8182	right_press	n/a	n/a	4096	n/a
-163.4280000000	n/a	40857	show_circle	n/a	n/a	0	circle.bmp
-165.1280000000	n/a	41282	show_cross	n/a	n/a	n/a	cross.bmp
-165.6189090909	n/a	41404.7273	show_face	scrambled_face	immediate_repeat	18	s086.bmp
-166.3507272727	n/a	41587.6818	right_press	n/a	n/a	4096	n/a
-166.4552727273	n/a	41613.8182	show_circle	n/a	n/a	0	circle.bmp
-168.1552727273	n/a	42038.8182	show_cross	n/a	n/a	n/a	cross.bmp
-168.6589090909	n/a	42164.7273	show_face	unfamiliar_face	delayed_repeat	15	u048.bmp
-169.6407272727	n/a	42410.1818	show_circle	n/a	n/a	0	circle.bmp
-171.3407272727	n/a	42835.1818	show_cross	n/a	n/a	n/a	cross.bmp
-171.9661818182	n/a	42991.5455	show_face	famous_face	first_show	5	f132.bmp
-172.9125454545	n/a	43228.1364	show_circle	n/a	n/a	0	circle.bmp
-174.6125454545	n/a	43653.1364	show_cross	n/a	n/a	n/a	cross.bmp
-175.0734545455	n/a	43768.3636	show_face	famous_face	immediate_repeat	6	f132.bmp
-176.0470909091	n/a	44011.7727	show_circle	n/a	n/a	0	circle.bmp
-177.7470909091	n/a	44436.7727	show_cross	n/a	n/a	n/a	cross.bmp
-178.2307272727	n/a	44557.6818	show_face	famous_face	delayed_repeat	7	f074.bmp
-179.0580000000	n/a	44764.5	show_circle	n/a	n/a	0	circle.bmp
-180.7580000000	n/a	45189.5	show_cross	n/a	n/a	n/a	cross.bmp
-181.4216363636	n/a	45355.4091	show_face	famous_face	first_show	5	f010.bmp
-182.0661818182	n/a	45516.5455	right_press	n/a	n/a	4096	n/a
-182.3780000000	n/a	45594.5	show_circle	n/a	n/a	0	circle.bmp
-184.0780000000	n/a	46019.5	show_cross	n/a	n/a	n/a	cross.bmp
-184.7125454545	n/a	46178.1364	show_face	unfamiliar_face	delayed_repeat	15	u021.bmp
-185.7234545455	n/a	46430.8636	show_circle	n/a	n/a	0	circle.bmp
-187.4234545455	n/a	46855.8636	show_cross	n/a	n/a	n/a	cross.bmp
-188.0370909091	n/a	47009.2727	show_face	scrambled_face	first_show	17	s056.bmp
-188.8434545455	n/a	47210.8636	right_press	n/a	n/a	4096	n/a
-189.0534545455	n/a	47263.3636	show_circle	n/a	n/a	0	circle.bmp
-190.7534545455	n/a	47688.3636	show_cross	n/a	n/a	n/a	cross.bmp
-191.3780000000	n/a	47844.5	show_face	scrambled_face	immediate_repeat	18	s056.bmp
-192.1116363636	n/a	48027.9091	right_press	n/a	n/a	4096	n/a
-192.2780000000	n/a	48069.5	show_circle	n/a	n/a	0	circle.bmp
-193.9780000000	n/a	48494.5	show_cross	n/a	n/a	n/a	cross.bmp
-194.6025454545	n/a	48650.6364	show_face	famous_face	first_show	5	f104.bmp
-195.2843636364	n/a	48821.0909	right_press	n/a	n/a	4096	n/a
-195.6134545455	n/a	48903.3636	show_circle	n/a	n/a	0	circle.bmp
-197.3134545455	n/a	49328.3636	show_cross	n/a	n/a	n/a	cross.bmp
-197.7761818182	n/a	49444.0455	show_face	scrambled_face	first_show	17	s068.bmp
-198.7707272727	n/a	49692.6818	show_circle	n/a	n/a	0	circle.bmp
-200.4707272727	n/a	50117.6818	show_cross	n/a	n/a	n/a	cross.bmp
-200.9998181818	n/a	50249.9545	show_face	famous_face	first_show	5	f036.bmp
-201.9352727273	n/a	50483.8182	show_circle	n/a	n/a	0	circle.bmp
-203.6352727273	n/a	50908.8182	show_cross	n/a	n/a	n/a	cross.bmp
-204.1743636364	n/a	51043.5909	show_face	famous_face	immediate_repeat	6	f036.bmp
-205.0898181818	n/a	51272.4545	show_circle	n/a	n/a	0	circle.bmp
-206.7898181818	n/a	51697.4545	show_cross	n/a	n/a	n/a	cross.bmp
-207.2816363636	n/a	51820.4091	show_face	famous_face	first_show	5	f066.bmp
-208.2261818182	n/a	52056.5455	show_circle	n/a	n/a	0	circle.bmp
-209.9261818182	n/a	52481.5455	show_cross	n/a	n/a	n/a	cross.bmp
-210.4889090909	n/a	52622.2273	show_face	famous_face	delayed_repeat	7	f010.bmp
-211.1280000000	n/a	52782	right_press	n/a	n/a	4096	n/a
-211.4080000000	n/a	52852	show_circle	n/a	n/a	0	circle.bmp
-213.1080000000	n/a	53277	show_cross	n/a	n/a	n/a	cross.bmp
-213.7461818182	n/a	53436.5455	show_face	unfamiliar_face	first_show	13	u042.bmp
-214.6307272727	n/a	53657.6818	show_circle	n/a	n/a	0	circle.bmp
-216.3307272727	n/a	54082.6818	show_cross	n/a	n/a	n/a	cross.bmp
-216.7861818182	n/a	54196.5455	show_face	unfamiliar_face	immediate_repeat	14	u042.bmp
-217.7198181818	n/a	54429.9545	show_circle	n/a	n/a	0	circle.bmp
-219.4198181818	n/a	54854.9545	show_cross	n/a	n/a	n/a	cross.bmp
-219.9943636364	n/a	54998.5909	show_face	unfamiliar_face	first_show	13	u068.bmp
-220.9161818182	n/a	55229.0455	right_press	n/a	n/a	4096	n/a
-220.9916363636	n/a	55247.9091	show_circle	n/a	n/a	0	circle.bmp
-222.6916363636	n/a	55672.9091	show_cross	n/a	n/a	n/a	cross.bmp
-223.1343636364	n/a	55783.5909	show_face	famous_face	delayed_repeat	7	f104.bmp
-223.8034545455	n/a	55950.8636	right_press	n/a	n/a	4096	n/a
-224.0243636364	n/a	56006.0909	show_circle	n/a	n/a	0	circle.bmp
-225.7243636364	n/a	56431.0909	show_cross	n/a	n/a	n/a	cross.bmp
-226.2580000000	n/a	56564.5	show_face	scrambled_face	first_show	17	s109.bmp
-227.1907272727	n/a	56797.6818	show_circle	n/a	n/a	0	circle.bmp
-228.8907272727	n/a	57222.6818	show_cross	n/a	n/a	n/a	cross.bmp
-229.4152727273	n/a	57353.8182	show_face	scrambled_face	immediate_repeat	18	s109.bmp
-230.3670909091	n/a	57591.7727	show_circle	n/a	n/a	0	circle.bmp
-232.0670909091	n/a	58016.7727	show_cross	n/a	n/a	n/a	cross.bmp
-232.6734545455	n/a	58168.3636	show_face	scrambled_face	delayed_repeat	19	s068.bmp
-233.3098181818	n/a	58327.4545	right_press	n/a	n/a	4096	n/a
-233.5825454545	n/a	58395.6364	show_circle	n/a	n/a	0	circle.bmp
-235.2825454545	n/a	58820.6364	show_cross	n/a	n/a	n/a	cross.bmp
-235.7807272727	n/a	58945.1818	show_face	unfamiliar_face	first_show	13	u027.bmp
-236.6607272727	n/a	59165.1818	show_circle	n/a	n/a	0	circle.bmp
-236.6707272727	n/a	59167.6818	right_press	n/a	n/a	4096	n/a
-238.3607272727	n/a	59590.1818	show_cross	n/a	n/a	n/a	cross.bmp
-238.8370909091	n/a	59709.2727	show_face	unfamiliar_face	first_show	13	u116.bmp
-239.5016363636	n/a	59875.4091	right_press	n/a	n/a	4096	n/a
-239.7089090909	n/a	59927.2273	show_circle	n/a	n/a	0	circle.bmp
-241.4089090909	n/a	60352.2273	show_cross	n/a	n/a	n/a	cross.bmp
-242.0443636364	n/a	60511.0909	show_face	famous_face	delayed_repeat	7	f066.bmp
-242.9398181818	n/a	60734.9545	show_circle	n/a	n/a	0	circle.bmp
-244.6398181818	n/a	61159.9545	show_cross	n/a	n/a	n/a	cross.bmp
-245.1516363636	n/a	61287.9091	show_face	scrambled_face	first_show	17	s122.bmp
-245.7207272727	n/a	61430.1818	right_press	n/a	n/a	4096	n/a
-246.0043636364	n/a	61501.0909	show_circle	n/a	n/a	0	circle.bmp
-247.7043636364	n/a	61926.0909	show_cross	n/a	n/a	n/a	cross.bmp
-248.3425454545	n/a	62085.6364	show_face	scrambled_face	immediate_repeat	18	s122.bmp
-249.1943636364	n/a	62298.5909	right_press	n/a	n/a	4096	n/a
-249.2298181818	n/a	62307.4545	show_circle	n/a	n/a	0	circle.bmp
-250.9298181818	n/a	62732.4545	show_cross	n/a	n/a	n/a	cross.bmp
-251.4161818182	n/a	62854.0455	show_face	famous_face	first_show	5	f054.bmp
-252.3761818182	n/a	63094.0455	show_circle	n/a	n/a	0	circle.bmp
-254.0761818182	n/a	63519.0455	show_cross	n/a	n/a	n/a	cross.bmp
-254.6734545455	n/a	63668.3636	show_face	unfamiliar_face	delayed_repeat	15	u068.bmp
-255.3370909091	n/a	63834.2727	right_press	n/a	n/a	4096	n/a
-255.5452727273	n/a	63886.3182	show_circle	n/a	n/a	0	circle.bmp
-257.2452727273	n/a	64311.3182	show_cross	n/a	n/a	n/a	cross.bmp
-257.8480000000	n/a	64462	show_face	unfamiliar_face	first_show	13	u003.bmp
-258.6716363636	n/a	64667.9091	show_circle	n/a	n/a	0	circle.bmp
-260.3716363636	n/a	65092.9091	show_cross	n/a	n/a	n/a	cross.bmp
-260.8380000000	n/a	65209.5	show_face	unfamiliar_face	first_show	13	u138.bmp
-261.6534545455	n/a	65413.3636	right_press	n/a	n/a	4096	n/a
-261.8189090909	n/a	65454.7273	show_circle	n/a	n/a	0	circle.bmp
-263.5189090909	n/a	65879.7273	show_cross	n/a	n/a	n/a	cross.bmp
-263.9789090909	n/a	65994.7273	show_face	unfamiliar_face	delayed_repeat	15	u027.bmp
-264.6616363636	n/a	66165.4091	right_press	n/a	n/a	4096	n/a
-264.9225454545	n/a	66230.6364	show_circle	n/a	n/a	0	circle.bmp
-266.6225454545	n/a	66655.6364	show_cross	n/a	n/a	n/a	cross.bmp
-267.1861818182	n/a	66796.5455	show_face	famous_face	first_show	5	f100.bmp
-267.8752727273	n/a	66968.8182	right_press	n/a	n/a	4096	n/a
-268.0980000000	n/a	67024.5	show_circle	n/a	n/a	0	circle.bmp
-269.7980000000	n/a	67449.5	show_cross	n/a	n/a	n/a	cross.bmp
-270.4270909091	n/a	67606.7727	show_face	famous_face	immediate_repeat	6	f100.bmp
-271.0016363636	n/a	67750.4091	right_press	n/a	n/a	4096	n/a
-271.3861818182	n/a	67846.5455	show_circle	n/a	n/a	0	circle.bmp
-273.0861818182	n/a	68271.5455	show_cross	n/a	n/a	n/a	cross.bmp
-273.7343636364	n/a	68433.5909	show_face	unfamiliar_face	delayed_repeat	15	u116.bmp
-274.4216363636	n/a	68605.4091	right_press	n/a	n/a	4096	n/a
-274.6461818182	n/a	68661.5455	show_circle	n/a	n/a	0	circle.bmp
-276.3461818182	n/a	69086.5455	show_cross	n/a	n/a	n/a	cross.bmp
-276.9916363636	n/a	69247.9091	show_face	famous_face	first_show	5	f023.bmp
-277.9943636364	n/a	69498.5909	show_circle	n/a	n/a	0	circle.bmp
-279.6943636364	n/a	69923.5909	show_cross	n/a	n/a	n/a	cross.bmp
-280.2161818182	n/a	70054.0455	show_face	scrambled_face	first_show	17	s119.bmp
-281.0789090909	n/a	70269.7273	show_circle	n/a	n/a	0	circle.bmp
-282.7789090909	n/a	70694.7273	show_cross	n/a	n/a	n/a	cross.bmp
-283.3061818182	n/a	70826.5455	show_face	scrambled_face	immediate_repeat	18	s119.bmp
-284.1325454545	n/a	71033.1364	show_circle	n/a	n/a	0	circle.bmp
-285.8325454545	n/a	71458.1364	show_cross	n/a	n/a	n/a	cross.bmp
-286.2970909091	n/a	71574.2727	show_face	famous_face	delayed_repeat	7	f054.bmp
-287.2252727273	n/a	71806.3182	show_circle	n/a	n/a	0	circle.bmp
-288.9252727273	n/a	72231.3182	show_cross	n/a	n/a	n/a	cross.bmp
-289.4207272727	n/a	72355.1818	show_face	scrambled_face	first_show	17	s036.bmp
-290.3170909091	n/a	72579.2727	show_circle	n/a	n/a	0	circle.bmp
-292.0170909091	n/a	73004.2727	show_cross	n/a	n/a	n/a	cross.bmp
-292.4943636364	n/a	73123.5909	show_face	scrambled_face	immediate_repeat	18	s036.bmp
-293.3498181818	n/a	73337.4545	show_circle	n/a	n/a	0	circle.bmp
-295.0498181818	n/a	73762.4545	show_cross	n/a	n/a	n/a	cross.bmp
-295.5852727273	n/a	73896.3182	show_face	unfamiliar_face	delayed_repeat	15	u003.bmp
-296.4807272727	n/a	74120.1818	show_circle	n/a	n/a	0	circle.bmp
-298.1807272727	n/a	74545.1818	show_cross	n/a	n/a	n/a	cross.bmp
-298.7425454545	n/a	74685.6364	show_face	unfamiliar_face	first_show	13	u012.bmp
-299.6770909091	n/a	74919.2727	show_circle	n/a	n/a	0	circle.bmp
-301.3770909091	n/a	75344.2727	show_cross	n/a	n/a	n/a	cross.bmp
-302.0161818182	n/a	75504.0455	show_face	unfamiliar_face	immediate_repeat	14	u012.bmp
-302.9061818182	n/a	75726.5455	show_circle	n/a	n/a	0	circle.bmp
-304.6061818182	n/a	76151.5455	show_cross	n/a	n/a	n/a	cross.bmp
-305.2070909091	n/a	76301.7727	show_face	unfamiliar_face	delayed_repeat	15	u138.bmp
-305.9070909091	n/a	76476.7727	right_press	n/a	n/a	4096	n/a
-306.0734545455	n/a	76518.3636	show_circle	n/a	n/a	0	circle.bmp
-307.7734545455	n/a	76943.3636	show_cross	n/a	n/a	n/a	cross.bmp
-308.3307272727	n/a	77082.6818	show_face	scrambled_face	first_show	17	s027.bmp
-309.1898181818	n/a	77297.4545	show_circle	n/a	n/a	0	circle.bmp
-310.8898181818	n/a	77722.4545	show_cross	n/a	n/a	n/a	cross.bmp
-311.5052727273	n/a	77876.3182	show_face	scrambled_face	first_show	17	s092.bmp
-312.3861818182	n/a	78096.5455	show_circle	n/a	n/a	0	circle.bmp
-314.0861818182	n/a	78521.5455	show_cross	n/a	n/a	n/a	cross.bmp
-314.6452727273	n/a	78661.3182	show_face	scrambled_face	immediate_repeat	18	s092.bmp
-315.6370909091	n/a	78909.2727	show_circle	n/a	n/a	0	circle.bmp
-317.3370909091	n/a	79334.2727	show_cross	n/a	n/a	n/a	cross.bmp
-317.8361818182	n/a	79459.0455	show_face	famous_face	delayed_repeat	7	f023.bmp
-318.5325454545	n/a	79633.1364	right_press	n/a	n/a	4096	n/a
-318.8052727273	n/a	79701.3182	show_circle	n/a	n/a	0	circle.bmp
-320.5052727273	n/a	80126.3182	show_cross	n/a	n/a	n/a	cross.bmp
-321.1107272727	n/a	80277.6818	show_face	unfamiliar_face	first_show	13	u013.bmp
-322.1252727273	n/a	80531.3182	show_circle	n/a	n/a	0	circle.bmp
-323.8252727273	n/a	80956.3182	show_cross	n/a	n/a	n/a	cross.bmp
-324.4016363636	n/a	81100.4091	show_face	unfamiliar_face	immediate_repeat	14	u013.bmp
-325.3943636364	n/a	81348.5909	show_circle	n/a	n/a	0	circle.bmp
-327.0943636364	n/a	81773.5909	show_cross	n/a	n/a	n/a	cross.bmp
-327.5916363636	n/a	81897.9091	show_face	unfamiliar_face	first_show	13	u129.bmp
-328.4270909091	n/a	82106.7727	show_circle	n/a	n/a	0	circle.bmp
-330.1270909091	n/a	82531.7727	show_cross	n/a	n/a	n/a	cross.bmp
-330.7661818182	n/a	82691.5455	show_face	unfamiliar_face	immediate_repeat	14	u129.bmp
-331.7661818182	n/a	82941.5455	show_circle	n/a	n/a	0	circle.bmp
-333.4661818182	n/a	83366.5455	show_cross	n/a	n/a	n/a	cross.bmp
-333.9398181818	n/a	83484.9545	show_face	scrambled_face	first_show	17	s046.bmp
-334.8607272727	n/a	83715.1818	show_circle	n/a	n/a	0	circle.bmp
-336.5607272727	n/a	84140.1818	show_cross	n/a	n/a	n/a	cross.bmp
-337.0307272727	n/a	84257.6818	show_face	unfamiliar_face	first_show	13	u137.bmp
-338.0089090909	n/a	84502.2273	show_circle	n/a	n/a	0	circle.bmp
-339.7089090909	n/a	84927.2273	show_cross	n/a	n/a	n/a	cross.bmp
-340.3380000000	n/a	85084.5	show_face	scrambled_face	delayed_repeat	19	s027.bmp
-341.0961818182	n/a	85274.0455	right_press	n/a	n/a	4096	n/a
-341.3270909091	n/a	85331.7727	show_circle	n/a	n/a	0	circle.bmp
-343.0270909091	n/a	85756.7727	show_cross	n/a	n/a	n/a	cross.bmp
-343.6789090909	n/a	85919.7273	show_face	famous_face	first_show	5	f045.bmp
-344.3880000000	n/a	86097	right_press	n/a	n/a	4096	n/a
-344.6616363636	n/a	86165.4091	show_circle	n/a	n/a	0	circle.bmp
-346.3616363636	n/a	86590.4091	show_cross	n/a	n/a	n/a	cross.bmp
-347.0034545455	n/a	86750.8636	show_face	famous_face	immediate_repeat	6	f045.bmp
-347.7334545455	n/a	86933.3636	right_press	n/a	n/a	4096	n/a
-348.0098181818	n/a	87002.4545	show_circle	n/a	n/a	0	circle.bmp
-349.7098181818	n/a	87427.4545	show_cross	n/a	n/a	n/a	cross.bmp
-350.3107272727	n/a	87577.6818	show_face	famous_face	first_show	5	f077.bmp
-351.2070909091	n/a	87801.7727	show_circle	n/a	n/a	0	circle.bmp
-352.9070909091	n/a	88226.7727	show_cross	n/a	n/a	n/a	cross.bmp
-353.3680000000	n/a	88342	show_face	famous_face	immediate_repeat	6	f077.bmp
-354.3734545455	n/a	88593.3636	show_circle	n/a	n/a	0	circle.bmp
-354.3843636364	n/a	88596.0909	right_press	n/a	n/a	4096	n/a
-356.0734545455	n/a	89018.3636	show_cross	n/a	n/a	n/a	cross.bmp
-356.6589090909	n/a	89164.7273	show_face	unfamiliar_face	first_show	13	u141.bmp
-357.4789090909	n/a	89369.7273	right_press	n/a	n/a	4096	n/a
-357.4989090909	n/a	89374.7273	show_circle	n/a	n/a	0	circle.bmp
-359.1989090909	n/a	89799.7273	show_cross	n/a	n/a	n/a	cross.bmp
-359.6825454545	n/a	89920.6364	show_face	famous_face	first_show	5	f032.bmp
-360.3234545455	n/a	90080.8636	right_press	n/a	n/a	4096	n/a
-360.5652727273	n/a	90141.3182	show_circle	n/a	n/a	0	circle.bmp
-362.2652727273	n/a	90566.3182	show_cross	n/a	n/a	n/a	cross.bmp
-362.7398181818	n/a	90684.9545	show_face	famous_face	immediate_repeat	6	f032.bmp
-363.3334545455	n/a	90833.3636	right_press	n/a	n/a	4096	n/a
-363.7070909091	n/a	90926.7727	show_circle	n/a	n/a	0	circle.bmp
-365.4070909091	n/a	91351.7727	show_cross	n/a	n/a	n/a	cross.bmp
-365.8798181818	n/a	91469.9545	show_face	scrambled_face	delayed_repeat	19	s046.bmp
-366.7689090909	n/a	91692.2273	show_circle	n/a	n/a	0	circle.bmp
-368.4689090909	n/a	92117.2273	show_cross	n/a	n/a	n/a	cross.bmp
-368.9870909091	n/a	92246.7727	show_face	unfamiliar_face	first_show	13	u093.bmp
-369.7716363636	n/a	92442.9091	right_press	n/a	n/a	4096	n/a
-369.8734545455	n/a	92468.3636	show_circle	n/a	n/a	0	circle.bmp
-371.5734545455	n/a	92893.3636	show_cross	n/a	n/a	n/a	cross.bmp
-372.2116363636	n/a	93052.9091	show_face	unfamiliar_face	delayed_repeat	15	u137.bmp
-373.2152727273	n/a	93303.8182	show_circle	n/a	n/a	0	circle.bmp
-374.9152727273	n/a	93728.8182	show_cross	n/a	n/a	n/a	cross.bmp
-375.5525454545	n/a	93888.1364	show_face	scrambled_face	first_show	17	s039.bmp
-376.4580000000	n/a	94114.5	right_press	n/a	n/a	4096	n/a
-376.5680000000	n/a	94142	show_circle	n/a	n/a	0	circle.bmp
-378.2680000000	n/a	94567	show_cross	n/a	n/a	n/a	cross.bmp
-378.8934545455	n/a	94723.3636	show_face	famous_face	first_show	5	f112.bmp
-379.7052727273	n/a	94926.3182	right_press	n/a	n/a	4096	n/a
-379.8107272727	n/a	94952.6818	show_circle	n/a	n/a	0	circle.bmp
-381.5107272727	n/a	95377.6818	show_cross	n/a	n/a	n/a	cross.bmp
-382.1343636364	n/a	95533.5909	show_face	scrambled_face	first_show	17	s073.bmp
-382.9016363636	n/a	95725.4091	right_press	n/a	n/a	4096	n/a
-383.0498181818	n/a	95762.4545	show_circle	n/a	n/a	0	circle.bmp
-384.7498181818	n/a	96187.4545	show_cross	n/a	n/a	n/a	cross.bmp
-385.3416363636	n/a	96335.4091	show_face	scrambled_face	immediate_repeat	18	s073.bmp
-386.3043636364	n/a	96576.0909	show_circle	n/a	n/a	0	circle.bmp
-388.0043636364	n/a	97001.0909	show_cross	n/a	n/a	n/a	cross.bmp
-388.5489090909	n/a	97137.2273	show_face	unfamiliar_face	delayed_repeat	15	u141.bmp
-389.4907272727	n/a	97372.6818	show_circle	n/a	n/a	0	circle.bmp
-391.1907272727	n/a	97797.6818	show_cross	n/a	n/a	n/a	cross.bmp
-391.6725454545	n/a	97918.1364	show_face	famous_face	first_show	5	f065.bmp
-392.5843636364	n/a	98146.0909	show_circle	n/a	n/a	0	circle.bmp
-394.2843636364	n/a	98571.0909	show_cross	n/a	n/a	n/a	cross.bmp
-394.7970909091	n/a	98699.2727	show_face	famous_face	immediate_repeat	6	f065.bmp
-395.6761818182	n/a	98919.0455	show_circle	n/a	n/a	0	circle.bmp
-397.3761818182	n/a	99344.0455	show_cross	n/a	n/a	n/a	cross.bmp
-397.9707272727	n/a	99492.6818	show_face	scrambled_face	first_show	17	s025.bmp
-398.9243636364	n/a	99731.0909	show_circle	n/a	n/a	0	circle.bmp
-400.6243636364	n/a	100156.0909	show_cross	n/a	n/a	n/a	cross.bmp
-401.2616363636	n/a	100315.4091	show_face	unfamiliar_face	delayed_repeat	15	u093.bmp
-402.0898181818	n/a	100522.4545	show_circle	n/a	n/a	0	circle.bmp
-402.1407272727	n/a	100535.1818	right_press	n/a	n/a	4096	n/a
-403.7898181818	n/a	100947.4545	show_cross	n/a	n/a	n/a	cross.bmp
-404.4352727273	n/a	101108.8182	show_face	unfamiliar_face	first_show	13	u083.bmp
-405.3370909091	n/a	101334.2727	show_circle	n/a	n/a	0	circle.bmp
-407.0370909091	n/a	101759.2727	show_cross	n/a	n/a	n/a	cross.bmp
-407.6098181818	n/a	101902.4545	show_face	unfamiliar_face	immediate_repeat	14	u083.bmp
-408.4434545455	n/a	102110.8636	show_circle	n/a	n/a	0	circle.bmp
-410.1434545455	n/a	102535.8636	show_cross	n/a	n/a	n/a	cross.bmp
-410.6161818182	n/a	102654.0455	show_face	scrambled_face	delayed_repeat	19	s039.bmp
-411.5716363636	n/a	102892.9091	show_circle	n/a	n/a	0	circle.bmp
-413.2716363636	n/a	103317.9091	show_cross	n/a	n/a	n/a	cross.bmp
-413.7234545455	n/a	103430.8636	show_face	unfamiliar_face	first_show	13	u010.bmp
-414.5852727273	n/a	103646.3182	show_circle	n/a	n/a	0	circle.bmp
-416.2852727273	n/a	104071.3182	show_cross	n/a	n/a	n/a	cross.bmp
-416.7816363636	n/a	104195.4091	show_face	famous_face	delayed_repeat	7	f112.bmp
-417.5643636364	n/a	104391.0909	right_press	n/a	n/a	4096	n/a
-417.7980000000	n/a	104449.5	show_circle	n/a	n/a	0	circle.bmp
-419.4980000000	n/a	104874.5	show_cross	n/a	n/a	n/a	cross.bmp
-420.1052727273	n/a	105026.3182	show_face	scrambled_face	first_show	17	s028.bmp
-421.0316363636	n/a	105257.9091	right_press	n/a	n/a	4096	n/a
-421.1234545455	n/a	105280.8636	show_circle	n/a	n/a	0	circle.bmp
-422.8234545455	n/a	105705.8636	show_cross	n/a	n/a	n/a	cross.bmp
-423.4125454545	n/a	105853.1364	show_face	unfamiliar_face	first_show	13	u118.bmp
-424.1334545455	n/a	106033.3636	right_press	n/a	n/a	4096	n/a
-424.3016363636	n/a	106075.4091	show_circle	n/a	n/a	0	circle.bmp
-426.0016363636	n/a	106500.4091	show_cross	n/a	n/a	n/a	cross.bmp
-426.6370909091	n/a	106659.2727	show_face	scrambled_face	first_show	17	s116.bmp
-427.5225454545	n/a	106880.6364	right_press	n/a	n/a	4096	n/a
-427.6207272727	n/a	106905.1818	show_circle	n/a	n/a	0	circle.bmp
-429.3207272727	n/a	107330.1818	show_cross	n/a	n/a	n/a	cross.bmp
-429.8943636364	n/a	107473.5909	show_face	scrambled_face	immediate_repeat	18	s116.bmp
-430.6734545455	n/a	107668.3636	right_press	n/a	n/a	4096	n/a
-430.8361818182	n/a	107709.0455	show_circle	n/a	n/a	0	circle.bmp
-432.5361818182	n/a	108134.0455	show_cross	n/a	n/a	n/a	cross.bmp
-433.0680000000	n/a	108267	show_face	scrambled_face	delayed_repeat	19	s025.bmp
-433.9880000000	n/a	108497	show_circle	n/a	n/a	0	circle.bmp
-435.6880000000	n/a	108922	show_cross	n/a	n/a	n/a	cross.bmp
-436.3089090909	n/a	109077.2273	show_face	unfamiliar_face	first_show	13	u081.bmp
-437.2434545455	n/a	109310.8636	show_circle	n/a	n/a	0	circle.bmp
-438.9434545455	n/a	109735.8636	show_cross	n/a	n/a	n/a	cross.bmp
-439.4334545455	n/a	109858.3636	show_face	unfamiliar_face	immediate_repeat	14	u081.bmp
-440.3161818182	n/a	110079.0455	show_circle	n/a	n/a	0	circle.bmp
-442.0161818182	n/a	110504.0455	show_cross	n/a	n/a	n/a	cross.bmp
-442.5398181818	n/a	110634.9545	show_face	unfamiliar_face	first_show	13	u008.bmp
-443.5570909091	n/a	110889.2727	show_circle	n/a	n/a	0	circle.bmp
-445.2570909091	n/a	111314.2727	show_cross	n/a	n/a	n/a	cross.bmp
-445.8643636364	n/a	111466.0909	show_face	unfamiliar_face	delayed_repeat	15	u010.bmp
-446.8152727273	n/a	111703.8182	show_circle	n/a	n/a	0	circle.bmp
-448.5152727273	n/a	112128.8182	show_cross	n/a	n/a	n/a	cross.bmp
-449.1389090909	n/a	112284.7273	show_face	famous_face	first_show	5	f057.bmp
-449.9116363636	n/a	112477.9091	right_press	n/a	n/a	4096	n/a
-449.9652727273	n/a	112491.3182	show_circle	n/a	n/a	0	circle.bmp
-451.6652727273	n/a	112916.3182	show_cross	n/a	n/a	n/a	cross.bmp
-452.2289090909	n/a	113057.2273	show_face	famous_face	immediate_repeat	6	f057.bmp
-452.8380000000	n/a	113209.5	right_press	n/a	n/a	4096	n/a
-453.1916363636	n/a	113297.9091	show_circle	n/a	n/a	0	circle.bmp
-454.8916363636	n/a	113722.9091	show_cross	n/a	n/a	n/a	cross.bmp
-455.4870909091	n/a	113871.7727	show_face	scrambled_face	delayed_repeat	19	s028.bmp
-456.3216363636	n/a	114080.4091	show_circle	n/a	n/a	0	circle.bmp
-456.3707272727	n/a	114092.6818	right_press	n/a	n/a	4096	n/a
-458.0216363636	n/a	114505.4091	show_cross	n/a	n/a	n/a	cross.bmp
-458.6770909091	n/a	114669.2727	show_face	scrambled_face	first_show	17	s020.bmp
-459.6425454545	n/a	114910.6364	show_circle	n/a	n/a	0	circle.bmp
-461.3425454545	n/a	115335.6364	show_cross	n/a	n/a	n/a	cross.bmp
-461.9016363636	n/a	115475.4091	show_face	unfamiliar_face	delayed_repeat	15	u118.bmp
-462.7434545455	n/a	115685.8636	show_circle	n/a	n/a	0	circle.bmp
-462.7570909091	n/a	115689.2727	right_press	n/a	n/a	4096	n/a
-464.4434545455	n/a	116110.8636	show_cross	n/a	n/a	n/a	cross.bmp
-464.9925454545	n/a	116248.1364	show_face	famous_face	first_show	5	f034.bmp
-465.6080000000	n/a	116402	right_press	n/a	n/a	4096	n/a
-465.9470909091	n/a	116486.7727	show_circle	n/a	n/a	0	circle.bmp
-467.6470909091	n/a	116911.7727	show_cross	n/a	n/a	n/a	cross.bmp
-468.2161818182	n/a	117054.0455	show_face	scrambled_face	first_show	17	s149.bmp
-468.9661818182	n/a	117241.5455	right_press	n/a	n/a	4096	n/a
-469.1843636364	n/a	117296.0909	show_circle	n/a	n/a	0	circle.bmp
-470.8843636364	n/a	117721.0909	show_cross	n/a	n/a	n/a	cross.bmp
-471.3734545455	n/a	117843.3636	show_face	scrambled_face	immediate_repeat	18	s149.bmp
-472.3180000000	n/a	118079.5	show_circle	n/a	n/a	0	circle.bmp
-472.3570909091	n/a	118089.2727	right_press	n/a	n/a	4096	n/a
-474.0180000000	n/a	118504.5	show_cross	n/a	n/a	n/a	cross.bmp
-474.6307272727	n/a	118657.6818	show_face	scrambled_face	first_show	17	s040.bmp
-475.4680000000	n/a	118867	right_press	n/a	n/a	4096	n/a
-475.6089090909	n/a	118902.2273	show_circle	n/a	n/a	0	circle.bmp
-477.3089090909	n/a	119327.2273	show_cross	n/a	n/a	n/a	cross.bmp
-477.8716363636	n/a	119467.9091	show_face	scrambled_face	immediate_repeat	18	s040.bmp
-478.8770909091	n/a	119719.2727	show_circle	n/a	n/a	0	circle.bmp
-480.5770909091	n/a	120144.2727	show_cross	n/a	n/a	n/a	cross.bmp
-481.1961818182	n/a	120299.0455	show_face	unfamiliar_face	delayed_repeat	15	u008.bmp
-482.1107272727	n/a	120527.6818	show_circle	n/a	n/a	0	circle.bmp
-483.8107272727	n/a	120952.6818	show_cross	n/a	n/a	n/a	cross.bmp
-484.3198181818	n/a	121079.9545	show_face	unfamiliar_face	first_show	13	u125.bmp
-485.2243636364	n/a	121306.0909	show_circle	n/a	n/a	0	circle.bmp
-486.9243636364	n/a	121731.0909	show_cross	n/a	n/a	n/a	cross.bmp
-487.4934545455	n/a	121873.3636	show_face	scrambled_face	first_show	17	s138.bmp
-488.3325454545	n/a	122083.1364	show_circle	n/a	n/a	0	circle.bmp
-490.0325454545	n/a	122508.1364	show_cross	n/a	n/a	n/a	cross.bmp
-490.6007272727	n/a	122650.1818	show_face	scrambled_face	immediate_repeat	18	s138.bmp
-491.4761818182	n/a	122869.0455	show_circle	n/a	n/a	0	circle.bmp
-493.1761818182	n/a	123294.0455	show_cross	n/a	n/a	n/a	cross.bmp
-493.6580000000	n/a	123414.5	show_face	scrambled_face	delayed_repeat	19	s020.bmp
-494.4880000000	n/a	123622	right_press	n/a	n/a	4096	n/a
-494.6152727273	n/a	123653.8182	show_circle	n/a	n/a	0	circle.bmp
-496.3152727273	n/a	124078.8182	show_cross	n/a	n/a	n/a	cross.bmp
+onset	duration	sample	event_type	face_type	repetition_type	trial	trial_lag	trigger	stim_file
+0.004	n/a	1.0	setup	n/a	n/a	n/a	n/a	n/a	n/a
+0.004	n/a	1.0	right_sym	n/a	n/a	n/a	n/a	n/a	n/a
+25.696181818200003	n/a	6424.0455	show_face	scrambled_face	first_show	1	n/a	17	s096.bmp
+26.5616363636	n/a	6640.4091	show_circle	n/a	n/a	1	n/a	0	circle.bmp
+28.2616363636	n/a	7065.4091	show_cross	n/a	n/a	2	n/a	n/a	cross.bmp
+28.8870909091	n/a	7221.7727	show_face	famous_face	first_show	2	n/a	5	f148.bmp
+29.771636363600003	n/a	7442.9091	right_press	n/a	n/a	2	n/a	4096	n/a
+29.9052727273	n/a	7476.3182	show_circle	n/a	n/a	2	n/a	0	circle.bmp
+31.6052727273	n/a	7901.3182	show_cross	n/a	n/a	3	n/a	n/a	cross.bmp
+32.1943636364	n/a	8048.5909	show_face	famous_face	immediate_repeat	3	1	6	f148.bmp
+32.7898181818	n/a	8197.4545	right_press	n/a	n/a	3	n/a	4096	n/a
+33.0316363636	n/a	8257.9091	show_circle	n/a	n/a	3	n/a	0	circle.bmp
+34.7316363636	n/a	8682.9091	show_cross	n/a	n/a	4	n/a	n/a	cross.bmp
+35.1843636364	n/a	8796.0909	show_face	scrambled_face	first_show	4	n/a	17	s071.bmp
+36.0289090909	n/a	9007.2273	show_circle	n/a	n/a	4	n/a	0	circle.bmp
+36.1089090909	n/a	9027.2273	right_press	n/a	n/a	4	n/a	4096	n/a
+37.728909090900004	n/a	9432.2273	show_cross	n/a	n/a	5	n/a	n/a	cross.bmp
+38.3589090909	n/a	9589.7273	show_face	scrambled_face	immediate_repeat	5	1	18	s071.bmp
+38.8270909091	n/a	9706.7727	right_press	n/a	n/a	5	n/a	4096	n/a
+39.3707272727	n/a	9842.6818	show_circle	n/a	n/a	5	n/a	0	circle.bmp
+41.0707272727	n/a	10267.6818	show_cross	n/a	n/a	6	n/a	n/a	cross.bmp
+41.6498181818	n/a	10412.4545	show_face	unfamiliar_face	first_show	6	n/a	13	u005.bmp
+42.5307272727	n/a	10632.6818	show_circle	n/a	n/a	6	n/a	0	circle.bmp
+44.2307272727	n/a	11057.6818	show_cross	n/a	n/a	7	n/a	n/a	cross.bmp
+44.723454545500005	n/a	11180.8636	show_face	famous_face	first_show	7	n/a	5	f119.bmp
+45.4770909091	n/a	11369.2727	right_press	n/a	n/a	7	n/a	4096	n/a
+45.608	n/a	11402.0	show_circle	n/a	n/a	7	n/a	0	circle.bmp
+47.308	n/a	11827.0	show_cross	n/a	n/a	8	n/a	n/a	cross.bmp
+47.7970909091	n/a	11949.2727	show_face	famous_face	first_show	8	n/a	5	f145.bmp
+48.390727272700005	n/a	12097.6818	right_press	n/a	n/a	8	n/a	4096	n/a
+48.778	n/a	12194.5	show_circle	n/a	n/a	8	n/a	0	circle.bmp
+50.478	n/a	12619.5	show_cross	n/a	n/a	9	n/a	n/a	cross.bmp
+50.9707272727	n/a	12742.6818	show_face	scrambled_face	delayed_repeat	9	8	19	s096.bmp
+51.981636363599996	n/a	12995.4091	show_circle	n/a	n/a	9	n/a	0	circle.bmp
+53.6816363636	n/a	13420.4091	show_cross	n/a	n/a	10	n/a	n/a	cross.bmp
+54.2789090909	n/a	13569.7273	show_face	unfamiliar_face	first_show	10	n/a	13	u117.bmp
+55.0334545455	n/a	13758.3636	right_press	n/a	n/a	10	n/a	4096	n/a
+55.1334545455	n/a	13783.3636	show_circle	n/a	n/a	10	n/a	0	circle.bmp
+56.833454545500004	n/a	14208.3636	show_cross	n/a	n/a	11	n/a	n/a	cross.bmp
+57.4025454545	n/a	14350.6364	show_face	unfamiliar_face	immediate_repeat	11	1	14	u117.bmp
+58.11981818180001	n/a	14529.9545	right_press	n/a	n/a	11	n/a	4096	n/a
+58.2443636364	n/a	14561.0909	show_circle	n/a	n/a	11	n/a	0	circle.bmp
+59.944363636400006	n/a	14986.0909	show_cross	n/a	n/a	12	n/a	n/a	cross.bmp
+60.559818181800004	n/a	15139.9545	show_face	famous_face	first_show	12	n/a	5	f098.bmp
+61.478	n/a	15369.5	show_circle	n/a	n/a	12	n/a	0	circle.bmp
+63.178	n/a	15794.5	show_cross	n/a	n/a	13	n/a	n/a	cross.bmp
+63.7843636364	n/a	15946.0909	show_face	scrambled_face	first_show	13	n/a	17	s008.bmp
+64.4870909091	n/a	16121.7727	right_press	n/a	n/a	13	n/a	4096	n/a
+64.7952727273	n/a	16198.8182	show_circle	n/a	n/a	13	n/a	0	circle.bmp
+66.49527272729999	n/a	16623.8182	show_cross	n/a	n/a	14	n/a	n/a	cross.bmp
+67.04163636359999	n/a	16760.4091	show_face	scrambled_face	immediate_repeat	14	1	18	s008.bmp
+67.68072727270001	n/a	16920.1818	right_press	n/a	n/a	14	n/a	4096	n/a
+67.9061818182	n/a	16976.5455	show_circle	n/a	n/a	14	n/a	0	circle.bmp
+69.6061818182	n/a	17401.5455	show_cross	n/a	n/a	15	n/a	n/a	cross.bmp
+70.2489090909	n/a	17562.2273	show_face	unfamiliar_face	delayed_repeat	15	9	15	u005.bmp
+71.18163636359999	n/a	17795.4091	right_press	n/a	n/a	15	n/a	4096	n/a
+71.1889090909	n/a	17797.2273	show_circle	n/a	n/a	15	n/a	0	circle.bmp
+72.8889090909	n/a	18222.2273	show_cross	n/a	n/a	16	n/a	n/a	cross.bmp
+73.4398181818	n/a	18359.9545	show_face	famous_face	first_show	16	n/a	5	f139.bmp
+74.26163636359999	n/a	18565.4091	right_press	n/a	n/a	16	n/a	4096	n/a
+74.31890909090001	n/a	18579.7273	show_circle	n/a	n/a	16	n/a	0	circle.bmp
+76.0189090909	n/a	19004.7273	show_cross	n/a	n/a	17	n/a	n/a	cross.bmp
+76.6470909091	n/a	19161.7727	show_face	famous_face	immediate_repeat	17	1	6	f139.bmp
+77.30254545449999	n/a	19325.6364	right_press	n/a	n/a	17	n/a	4096	n/a
+77.5889090909	n/a	19397.2273	show_circle	n/a	n/a	17	n/a	0	circle.bmp
+79.2889090909	n/a	19822.2273	show_cross	n/a	n/a	18	n/a	n/a	cross.bmp
+79.87072727270001	n/a	19967.6818	show_face	famous_face	delayed_repeat	18	11	7	f119.bmp
+80.4789090909	n/a	20119.7273	right_press	n/a	n/a	18	n/a	4096	n/a
+80.72618181819999	n/a	20181.5455	show_circle	n/a	n/a	18	n/a	0	circle.bmp
+82.42618181819999	n/a	20606.5455	show_cross	n/a	n/a	19	n/a	n/a	cross.bmp
+82.9116363636	n/a	20727.9091	show_face	scrambled_face	first_show	19	n/a	17	s001.bmp
+83.4970909091	n/a	20874.2727	right_press	n/a	n/a	19	n/a	4096	n/a
+83.7943636364	n/a	20948.5909	show_circle	n/a	n/a	19	n/a	0	circle.bmp
+85.49436363640001	n/a	21373.5909	show_cross	n/a	n/a	20	n/a	n/a	cross.bmp
+86.0852727273	n/a	21521.3182	show_face	scrambled_face	immediate_repeat	20	1	18	s001.bmp
+86.9752727273	n/a	21743.8182	right_press	n/a	n/a	20	n/a	4096	n/a
+87.1025454545	n/a	21775.6364	show_circle	n/a	n/a	20	n/a	0	circle.bmp
+88.8025454545	n/a	22200.6364	show_cross	n/a	n/a	21	n/a	n/a	cross.bmp
+89.3098181818	n/a	22327.4545	show_face	famous_face	delayed_repeat	21	13	7	f145.bmp
+89.988	n/a	22497.0	right_press	n/a	n/a	21	n/a	4096	n/a
+90.24527272729999	n/a	22561.3182	show_circle	n/a	n/a	21	n/a	0	circle.bmp
+91.9452727273	n/a	22986.3182	show_cross	n/a	n/a	22	n/a	n/a	cross.bmp
+92.4161818182	n/a	23104.0455	show_face	famous_face	first_show	22	n/a	5	f028.bmp
+93.04072727270001	n/a	23260.1818	right_press	n/a	n/a	22	n/a	4096	n/a
+93.2761818182	n/a	23319.0455	show_circle	n/a	n/a	22	n/a	0	circle.bmp
+94.97618181819999	n/a	23744.0455	show_cross	n/a	n/a	23	n/a	n/a	cross.bmp
+95.52345454549999	n/a	23880.8636	show_face	unfamiliar_face	first_show	23	n/a	13	u095.bmp
+96.1661818182	n/a	24041.5455	right_press	n/a	n/a	23	n/a	4096	n/a
+96.54072727270001	n/a	24135.1818	show_circle	n/a	n/a	23	n/a	0	circle.bmp
+98.2407272727	n/a	24560.1818	show_cross	n/a	n/a	24	n/a	n/a	cross.bmp
+98.698	n/a	24674.5	show_face	famous_face	delayed_repeat	24	12	7	f098.bmp
+99.5389090909	n/a	24884.7273	show_circle	n/a	n/a	24	n/a	0	circle.bmp
+101.2389090909	n/a	25309.7273	show_cross	n/a	n/a	25	n/a	n/a	cross.bmp
+101.72163636360001	n/a	25430.4091	show_face	scrambled_face	first_show	25	n/a	17	s037.bmp
+102.6689090909	n/a	25667.2273	show_circle	n/a	n/a	25	n/a	0	circle.bmp
+104.3689090909	n/a	26092.2273	show_cross	n/a	n/a	26	n/a	n/a	cross.bmp
+104.9789090909	n/a	26244.7273	show_face	scrambled_face	immediate_repeat	26	1	18	s037.bmp
+105.9925454545	n/a	26498.1364	show_circle	n/a	n/a	26	n/a	0	circle.bmp
+107.6925454545	n/a	26923.1364	show_cross	n/a	n/a	27	n/a	n/a	cross.bmp
+108.3198181818	n/a	27079.9545	show_face	famous_face	first_show	27	n/a	5	f089.bmp
+109.1943636364	n/a	27298.5909	show_circle	n/a	n/a	27	n/a	0	circle.bmp
+110.89436363639999	n/a	27723.5909	show_cross	n/a	n/a	28	n/a	n/a	cross.bmp
+111.4107272727	n/a	27852.6818	show_face	famous_face	immediate_repeat	28	1	6	f089.bmp
+112.4234545455	n/a	28105.8636	show_circle	n/a	n/a	28	n/a	0	circle.bmp
+114.1234545455	n/a	28530.8636	show_cross	n/a	n/a	29	n/a	n/a	cross.bmp
+114.668	n/a	28667.0	show_face	famous_face	first_show	29	n/a	5	f111.bmp
+115.5052727273	n/a	28876.3182	show_circle	n/a	n/a	29	n/a	0	circle.bmp
+117.2052727273	n/a	29301.3182	show_cross	n/a	n/a	30	n/a	n/a	cross.bmp
+117.6752727273	n/a	29418.8182	show_face	unfamiliar_face	first_show	30	n/a	13	u070.bmp
+118.56890909090001	n/a	29642.2273	show_circle	n/a	n/a	30	n/a	0	circle.bmp
+120.2689090909	n/a	30067.2273	show_cross	n/a	n/a	31	n/a	n/a	cross.bmp
+120.84890909090001	n/a	30212.2273	show_face	famous_face	delayed_repeat	31	9	7	f028.bmp
+121.488	n/a	30372.0	right_press	n/a	n/a	31	n/a	4096	n/a
+121.7470909091	n/a	30436.7727	show_circle	n/a	n/a	31	n/a	0	circle.bmp
+123.4470909091	n/a	30861.7727	show_cross	n/a	n/a	32	n/a	n/a	cross.bmp
+123.9898181818	n/a	30997.4545	show_face	famous_face	first_show	32	n/a	5	f124.bmp
+124.928	n/a	31232.0	show_circle	n/a	n/a	32	n/a	0	circle.bmp
+126.628	n/a	31657.0	show_cross	n/a	n/a	33	n/a	n/a	cross.bmp
+127.2634545455	n/a	31815.8636	show_face	unfamiliar_face	delayed_repeat	33	10	15	u095.bmp
+127.9789090909	n/a	31994.7273	right_press	n/a	n/a	33	n/a	4096	n/a
+128.2070909091	n/a	32051.7727	show_circle	n/a	n/a	33	n/a	0	circle.bmp
+129.9070909091	n/a	32476.7727	show_cross	n/a	n/a	34	n/a	n/a	cross.bmp
+130.55436363639998	n/a	32638.5909	show_face	unfamiliar_face	first_show	34	n/a	13	u048.bmp
+131.4325454545	n/a	32858.1364	show_circle	n/a	n/a	34	n/a	0	circle.bmp
+131.43345454549998	n/a	32858.3636	right_press	n/a	n/a	34	n/a	4096	n/a
+133.13254545450002	n/a	33283.1364	show_cross	n/a	n/a	35	n/a	n/a	cross.bmp
+133.66254545450002	n/a	33415.6364	show_face	famous_face	first_show	35	n/a	5	f074.bmp
+134.5861818182	n/a	33646.5455	show_circle	n/a	n/a	35	n/a	0	circle.bmp
+136.2861818182	n/a	34071.5455	show_cross	n/a	n/a	36	n/a	n/a	cross.bmp
+136.9189090909	n/a	34229.7273	show_face	unfamiliar_face	first_show	36	n/a	13	u021.bmp
+137.7934545455	n/a	34448.3636	show_circle	n/a	n/a	36	n/a	0	circle.bmp
+139.4934545455	n/a	34873.3636	show_cross	n/a	n/a	37	n/a	n/a	cross.bmp
+140.1261818182	n/a	35031.5455	show_face	famous_face	delayed_repeat	37	8	7	f111.bmp
+141.0770909091	n/a	35269.2727	show_circle	n/a	n/a	37	n/a	0	circle.bmp
+142.7770909091	n/a	35694.2727	show_cross	n/a	n/a	38	n/a	n/a	cross.bmp
+143.4170909091	n/a	35854.2727	show_face	unfamiliar_face	first_show	38	n/a	13	u019.bmp
+144.2998181818	n/a	36074.9545	show_circle	n/a	n/a	38	n/a	0	circle.bmp
+145.9998181818	n/a	36499.9545	show_cross	n/a	n/a	39	n/a	n/a	cross.bmp
+146.54163636360002	n/a	36635.4091	show_face	unfamiliar_face	immediate_repeat	39	1	14	u019.bmp
+147.5252727273	n/a	36881.3182	show_circle	n/a	n/a	39	n/a	0	circle.bmp
+149.2252727273	n/a	37306.3182	show_cross	n/a	n/a	40	n/a	n/a	cross.bmp
+149.8489090909	n/a	37462.2273	show_face	unfamiliar_face	delayed_repeat	40	10	15	u070.bmp
+150.5007272727	n/a	37625.1818	right_press	n/a	n/a	40	n/a	4096	n/a
+150.71345454549999	n/a	37678.3636	show_circle	n/a	n/a	40	n/a	0	circle.bmp
+152.4134545455	n/a	38103.3636	show_cross	n/a	n/a	41	n/a	n/a	cross.bmp
+152.8889090909	n/a	38222.2273	show_face	scrambled_face	first_show	41	n/a	17	s026.bmp
+153.8552727273	n/a	38463.8182	show_circle	n/a	n/a	41	n/a	0	circle.bmp
+155.5552727273	n/a	38888.8182	show_cross	n/a	n/a	42	n/a	n/a	cross.bmp
+156.17981818180002	n/a	39044.9545	show_face	scrambled_face	immediate_repeat	42	1	18	s026.bmp
+157.03345454549998	n/a	39258.3636	show_circle	n/a	n/a	42	n/a	0	circle.bmp
+158.7334545455	n/a	39683.3636	show_cross	n/a	n/a	43	n/a	n/a	cross.bmp
+159.2543636364	n/a	39813.5909	show_face	famous_face	delayed_repeat	43	11	7	f124.bmp
+160.11072727270002	n/a	40027.6818	show_circle	n/a	n/a	43	n/a	0	circle.bmp
+161.8107272727	n/a	40452.6818	show_cross	n/a	n/a	44	n/a	n/a	cross.bmp
+162.4616363636	n/a	40615.4091	show_face	scrambled_face	first_show	44	n/a	17	s086.bmp
+163.1352727273	n/a	40783.8182	right_press	n/a	n/a	44	n/a	4096	n/a
+163.428	n/a	40857.0	show_circle	n/a	n/a	44	n/a	0	circle.bmp
+165.128	n/a	41282.0	show_cross	n/a	n/a	45	n/a	n/a	cross.bmp
+165.6189090909	n/a	41404.7273	show_face	scrambled_face	immediate_repeat	45	1	18	s086.bmp
+166.3507272727	n/a	41587.6818	right_press	n/a	n/a	45	n/a	4096	n/a
+166.45527272729998	n/a	41613.8182	show_circle	n/a	n/a	45	n/a	0	circle.bmp
+168.1552727273	n/a	42038.8182	show_cross	n/a	n/a	46	n/a	n/a	cross.bmp
+168.6589090909	n/a	42164.7273	show_face	unfamiliar_face	delayed_repeat	46	12	15	u048.bmp
+169.6407272727	n/a	42410.1818	show_circle	n/a	n/a	46	n/a	0	circle.bmp
+171.3407272727	n/a	42835.1818	show_cross	n/a	n/a	47	n/a	n/a	cross.bmp
+171.9661818182	n/a	42991.5455	show_face	famous_face	first_show	47	n/a	5	f132.bmp
+172.91254545450002	n/a	43228.1364	show_circle	n/a	n/a	47	n/a	0	circle.bmp
+174.6125454545	n/a	43653.1364	show_cross	n/a	n/a	48	n/a	n/a	cross.bmp
+175.0734545455	n/a	43768.3636	show_face	famous_face	immediate_repeat	48	1	6	f132.bmp
+176.0470909091	n/a	44011.7727	show_circle	n/a	n/a	48	n/a	0	circle.bmp
+177.7470909091	n/a	44436.7727	show_cross	n/a	n/a	49	n/a	n/a	cross.bmp
+178.2307272727	n/a	44557.6818	show_face	famous_face	delayed_repeat	49	14	7	f074.bmp
+179.058	n/a	44764.5	show_circle	n/a	n/a	49	n/a	0	circle.bmp
+180.758	n/a	45189.5	show_cross	n/a	n/a	50	n/a	n/a	cross.bmp
+181.42163636360002	n/a	45355.4091	show_face	famous_face	first_show	50	n/a	5	f010.bmp
+182.0661818182	n/a	45516.5455	right_press	n/a	n/a	50	n/a	4096	n/a
+182.378	n/a	45594.5	show_circle	n/a	n/a	50	n/a	0	circle.bmp
+184.078	n/a	46019.5	show_cross	n/a	n/a	51	n/a	n/a	cross.bmp
+184.7125454545	n/a	46178.1364	show_face	unfamiliar_face	delayed_repeat	51	15	15	u021.bmp
+185.7234545455	n/a	46430.8636	show_circle	n/a	n/a	51	n/a	0	circle.bmp
+187.4234545455	n/a	46855.8636	show_cross	n/a	n/a	52	n/a	n/a	cross.bmp
+188.0370909091	n/a	47009.2727	show_face	scrambled_face	first_show	52	n/a	17	s056.bmp
+188.84345454549998	n/a	47210.8636	right_press	n/a	n/a	52	n/a	4096	n/a
+189.0534545455	n/a	47263.3636	show_circle	n/a	n/a	52	n/a	0	circle.bmp
+190.7534545455	n/a	47688.3636	show_cross	n/a	n/a	53	n/a	n/a	cross.bmp
+191.378	n/a	47844.5	show_face	scrambled_face	immediate_repeat	53	1	18	s056.bmp
+192.1116363636	n/a	48027.9091	right_press	n/a	n/a	53	n/a	4096	n/a
+192.278	n/a	48069.5	show_circle	n/a	n/a	53	n/a	0	circle.bmp
+193.978	n/a	48494.5	show_cross	n/a	n/a	54	n/a	n/a	cross.bmp
+194.60254545450002	n/a	48650.6364	show_face	famous_face	first_show	54	n/a	5	f104.bmp
+195.2843636364	n/a	48821.0909	right_press	n/a	n/a	54	n/a	4096	n/a
+195.6134545455	n/a	48903.3636	show_circle	n/a	n/a	54	n/a	0	circle.bmp
+197.31345454549998	n/a	49328.3636	show_cross	n/a	n/a	55	n/a	n/a	cross.bmp
+197.7761818182	n/a	49444.0455	show_face	scrambled_face	first_show	55	n/a	17	s068.bmp
+198.77072727270001	n/a	49692.6818	show_circle	n/a	n/a	55	n/a	0	circle.bmp
+200.4707272727	n/a	50117.6818	show_cross	n/a	n/a	56	n/a	n/a	cross.bmp
+200.9998181818	n/a	50249.9545	show_face	famous_face	first_show	56	n/a	5	f036.bmp
+201.9352727273	n/a	50483.8182	show_circle	n/a	n/a	56	n/a	0	circle.bmp
+203.6352727273	n/a	50908.8182	show_cross	n/a	n/a	57	n/a	n/a	cross.bmp
+204.1743636364	n/a	51043.5909	show_face	famous_face	immediate_repeat	57	1	6	f036.bmp
+205.0898181818	n/a	51272.4545	show_circle	n/a	n/a	57	n/a	0	circle.bmp
+206.7898181818	n/a	51697.4545	show_cross	n/a	n/a	58	n/a	n/a	cross.bmp
+207.2816363636	n/a	51820.4091	show_face	famous_face	first_show	58	n/a	5	f066.bmp
+208.2261818182	n/a	52056.5455	show_circle	n/a	n/a	58	n/a	0	circle.bmp
+209.9261818182	n/a	52481.5455	show_cross	n/a	n/a	59	n/a	n/a	cross.bmp
+210.4889090909	n/a	52622.2273	show_face	famous_face	delayed_repeat	59	9	7	f010.bmp
+211.128	n/a	52782.0	right_press	n/a	n/a	59	n/a	4096	n/a
+211.408	n/a	52852.0	show_circle	n/a	n/a	59	n/a	0	circle.bmp
+213.108	n/a	53277.0	show_cross	n/a	n/a	60	n/a	n/a	cross.bmp
+213.7461818182	n/a	53436.5455	show_face	unfamiliar_face	first_show	60	n/a	13	u042.bmp
+214.6307272727	n/a	53657.6818	show_circle	n/a	n/a	60	n/a	0	circle.bmp
+216.33072727270002	n/a	54082.6818	show_cross	n/a	n/a	61	n/a	n/a	cross.bmp
+216.7861818182	n/a	54196.5455	show_face	unfamiliar_face	immediate_repeat	61	1	14	u042.bmp
+217.7198181818	n/a	54429.9545	show_circle	n/a	n/a	61	n/a	0	circle.bmp
+219.4198181818	n/a	54854.9545	show_cross	n/a	n/a	62	n/a	n/a	cross.bmp
+219.99436363639998	n/a	54998.5909	show_face	unfamiliar_face	first_show	62	n/a	13	u068.bmp
+220.9161818182	n/a	55229.0455	right_press	n/a	n/a	62	n/a	4096	n/a
+220.9916363636	n/a	55247.9091	show_circle	n/a	n/a	62	n/a	0	circle.bmp
+222.6916363636	n/a	55672.9091	show_cross	n/a	n/a	63	n/a	n/a	cross.bmp
+223.1343636364	n/a	55783.5909	show_face	famous_face	delayed_repeat	63	9	7	f104.bmp
+223.8034545455	n/a	55950.8636	right_press	n/a	n/a	63	n/a	4096	n/a
+224.02436363639998	n/a	56006.0909	show_circle	n/a	n/a	63	n/a	0	circle.bmp
+225.7243636364	n/a	56431.0909	show_cross	n/a	n/a	64	n/a	n/a	cross.bmp
+226.258	n/a	56564.5	show_face	scrambled_face	first_show	64	n/a	17	s109.bmp
+227.1907272727	n/a	56797.6818	show_circle	n/a	n/a	64	n/a	0	circle.bmp
+228.8907272727	n/a	57222.6818	show_cross	n/a	n/a	65	n/a	n/a	cross.bmp
+229.4152727273	n/a	57353.8182	show_face	scrambled_face	immediate_repeat	65	1	18	s109.bmp
+230.3670909091	n/a	57591.7727	show_circle	n/a	n/a	65	n/a	0	circle.bmp
+232.0670909091	n/a	58016.7727	show_cross	n/a	n/a	66	n/a	n/a	cross.bmp
+232.6734545455	n/a	58168.3636	show_face	scrambled_face	delayed_repeat	66	11	19	s068.bmp
+233.3098181818	n/a	58327.4545	right_press	n/a	n/a	66	n/a	4096	n/a
+233.5825454545	n/a	58395.6364	show_circle	n/a	n/a	66	n/a	0	circle.bmp
+235.2825454545	n/a	58820.6364	show_cross	n/a	n/a	67	n/a	n/a	cross.bmp
+235.7807272727	n/a	58945.1818	show_face	unfamiliar_face	first_show	67	n/a	13	u027.bmp
+236.6607272727	n/a	59165.1818	show_circle	n/a	n/a	67	n/a	0	circle.bmp
+236.6707272727	n/a	59167.6818	right_press	n/a	n/a	67	n/a	4096	n/a
+238.36072727270002	n/a	59590.1818	show_cross	n/a	n/a	68	n/a	n/a	cross.bmp
+238.8370909091	n/a	59709.2727	show_face	unfamiliar_face	first_show	68	n/a	13	u116.bmp
+239.5016363636	n/a	59875.4091	right_press	n/a	n/a	68	n/a	4096	n/a
+239.7089090909	n/a	59927.2273	show_circle	n/a	n/a	68	n/a	0	circle.bmp
+241.4089090909	n/a	60352.2273	show_cross	n/a	n/a	69	n/a	n/a	cross.bmp
+242.0443636364	n/a	60511.0909	show_face	famous_face	delayed_repeat	69	11	7	f066.bmp
+242.9398181818	n/a	60734.9545	show_circle	n/a	n/a	69	n/a	0	circle.bmp
+244.6398181818	n/a	61159.9545	show_cross	n/a	n/a	70	n/a	n/a	cross.bmp
+245.1516363636	n/a	61287.9091	show_face	scrambled_face	first_show	70	n/a	17	s122.bmp
+245.7207272727	n/a	61430.1818	right_press	n/a	n/a	70	n/a	4096	n/a
+246.0043636364	n/a	61501.0909	show_circle	n/a	n/a	70	n/a	0	circle.bmp
+247.7043636364	n/a	61926.0909	show_cross	n/a	n/a	71	n/a	n/a	cross.bmp
+248.3425454545	n/a	62085.6364	show_face	scrambled_face	immediate_repeat	71	1	18	s122.bmp
+249.1943636364	n/a	62298.5909	right_press	n/a	n/a	71	n/a	4096	n/a
+249.2298181818	n/a	62307.4545	show_circle	n/a	n/a	71	n/a	0	circle.bmp
+250.92981818180002	n/a	62732.4545	show_cross	n/a	n/a	72	n/a	n/a	cross.bmp
+251.4161818182	n/a	62854.0455	show_face	famous_face	first_show	72	n/a	5	f054.bmp
+252.3761818182	n/a	63094.0455	show_circle	n/a	n/a	72	n/a	0	circle.bmp
+254.07618181819998	n/a	63519.0455	show_cross	n/a	n/a	73	n/a	n/a	cross.bmp
+254.6734545455	n/a	63668.3636	show_face	unfamiliar_face	delayed_repeat	73	11	15	u068.bmp
+255.3370909091	n/a	63834.2727	right_press	n/a	n/a	73	n/a	4096	n/a
+255.5452727273	n/a	63886.3182	show_circle	n/a	n/a	73	n/a	0	circle.bmp
+257.2452727273	n/a	64311.3182	show_cross	n/a	n/a	74	n/a	n/a	cross.bmp
+257.848	n/a	64462.0	show_face	unfamiliar_face	first_show	74	n/a	13	u003.bmp
+258.6716363636	n/a	64667.9091	show_circle	n/a	n/a	74	n/a	0	circle.bmp
+260.37163636360003	n/a	65092.9091	show_cross	n/a	n/a	75	n/a	n/a	cross.bmp
+260.838	n/a	65209.5	show_face	unfamiliar_face	first_show	75	n/a	13	u138.bmp
+261.6534545455	n/a	65413.3636	right_press	n/a	n/a	75	n/a	4096	n/a
+261.8189090909	n/a	65454.7273	show_circle	n/a	n/a	75	n/a	0	circle.bmp
+263.5189090909	n/a	65879.7273	show_cross	n/a	n/a	76	n/a	n/a	cross.bmp
+263.9789090909	n/a	65994.7273	show_face	unfamiliar_face	delayed_repeat	76	9	15	u027.bmp
+264.6616363636	n/a	66165.4091	right_press	n/a	n/a	76	n/a	4096	n/a
+264.9225454545	n/a	66230.6364	show_circle	n/a	n/a	76	n/a	0	circle.bmp
+266.6225454545	n/a	66655.6364	show_cross	n/a	n/a	77	n/a	n/a	cross.bmp
+267.1861818182	n/a	66796.5455	show_face	famous_face	first_show	77	n/a	5	f100.bmp
+267.8752727273	n/a	66968.8182	right_press	n/a	n/a	77	n/a	4096	n/a
+268.098	n/a	67024.5	show_circle	n/a	n/a	77	n/a	0	circle.bmp
+269.798	n/a	67449.5	show_cross	n/a	n/a	78	n/a	n/a	cross.bmp
+270.4270909091	n/a	67606.7727	show_face	famous_face	immediate_repeat	78	1	6	f100.bmp
+271.0016363636	n/a	67750.4091	right_press	n/a	n/a	78	n/a	4096	n/a
+271.3861818182	n/a	67846.5455	show_circle	n/a	n/a	78	n/a	0	circle.bmp
+273.0861818182	n/a	68271.5455	show_cross	n/a	n/a	79	n/a	n/a	cross.bmp
+273.7343636364	n/a	68433.5909	show_face	unfamiliar_face	delayed_repeat	79	11	15	u116.bmp
+274.4216363636	n/a	68605.4091	right_press	n/a	n/a	79	n/a	4096	n/a
+274.6461818182	n/a	68661.5455	show_circle	n/a	n/a	79	n/a	0	circle.bmp
+276.3461818182	n/a	69086.5455	show_cross	n/a	n/a	80	n/a	n/a	cross.bmp
+276.9916363636	n/a	69247.9091	show_face	famous_face	first_show	80	n/a	5	f023.bmp
+277.9943636364	n/a	69498.5909	show_circle	n/a	n/a	80	n/a	0	circle.bmp
+279.6943636364	n/a	69923.5909	show_cross	n/a	n/a	81	n/a	n/a	cross.bmp
+280.21618181819997	n/a	70054.0455	show_face	scrambled_face	first_show	81	n/a	17	s119.bmp
+281.0789090909	n/a	70269.7273	show_circle	n/a	n/a	81	n/a	0	circle.bmp
+282.7789090909	n/a	70694.7273	show_cross	n/a	n/a	82	n/a	n/a	cross.bmp
+283.3061818182	n/a	70826.5455	show_face	scrambled_face	immediate_repeat	82	1	18	s119.bmp
+284.1325454545	n/a	71033.1364	show_circle	n/a	n/a	82	n/a	0	circle.bmp
+285.8325454545	n/a	71458.1364	show_cross	n/a	n/a	83	n/a	n/a	cross.bmp
+286.2970909091	n/a	71574.2727	show_face	famous_face	delayed_repeat	83	11	7	f054.bmp
+287.2252727273	n/a	71806.3182	show_circle	n/a	n/a	83	n/a	0	circle.bmp
+288.9252727273	n/a	72231.3182	show_cross	n/a	n/a	84	n/a	n/a	cross.bmp
+289.4207272727	n/a	72355.1818	show_face	scrambled_face	first_show	84	n/a	17	s036.bmp
+290.3170909091	n/a	72579.2727	show_circle	n/a	n/a	84	n/a	0	circle.bmp
+292.0170909091	n/a	73004.2727	show_cross	n/a	n/a	85	n/a	n/a	cross.bmp
+292.4943636364	n/a	73123.5909	show_face	scrambled_face	immediate_repeat	85	1	18	s036.bmp
+293.3498181818	n/a	73337.4545	show_circle	n/a	n/a	85	n/a	0	circle.bmp
+295.0498181818	n/a	73762.4545	show_cross	n/a	n/a	86	n/a	n/a	cross.bmp
+295.5852727273	n/a	73896.3182	show_face	unfamiliar_face	delayed_repeat	86	12	15	u003.bmp
+296.4807272727	n/a	74120.1818	show_circle	n/a	n/a	86	n/a	0	circle.bmp
+298.1807272727	n/a	74545.1818	show_cross	n/a	n/a	87	n/a	n/a	cross.bmp
+298.74254545450003	n/a	74685.6364	show_face	unfamiliar_face	first_show	87	n/a	13	u012.bmp
+299.6770909091	n/a	74919.2727	show_circle	n/a	n/a	87	n/a	0	circle.bmp
+301.3770909091	n/a	75344.2727	show_cross	n/a	n/a	88	n/a	n/a	cross.bmp
+302.0161818182	n/a	75504.0455	show_face	unfamiliar_face	immediate_repeat	88	1	14	u012.bmp
+302.9061818182	n/a	75726.5455	show_circle	n/a	n/a	88	n/a	0	circle.bmp
+304.6061818182	n/a	76151.5455	show_cross	n/a	n/a	89	n/a	n/a	cross.bmp
+305.2070909091	n/a	76301.7727	show_face	unfamiliar_face	delayed_repeat	89	14	15	u138.bmp
+305.9070909091	n/a	76476.7727	right_press	n/a	n/a	89	n/a	4096	n/a
+306.0734545455	n/a	76518.3636	show_circle	n/a	n/a	89	n/a	0	circle.bmp
+307.7734545455	n/a	76943.3636	show_cross	n/a	n/a	90	n/a	n/a	cross.bmp
+308.3307272727	n/a	77082.6818	show_face	scrambled_face	first_show	90	n/a	17	s027.bmp
+309.1898181818	n/a	77297.4545	show_circle	n/a	n/a	90	n/a	0	circle.bmp
+310.8898181818	n/a	77722.4545	show_cross	n/a	n/a	91	n/a	n/a	cross.bmp
+311.5052727273	n/a	77876.3182	show_face	scrambled_face	first_show	91	n/a	17	s092.bmp
+312.3861818182	n/a	78096.5455	show_circle	n/a	n/a	91	n/a	0	circle.bmp
+314.0861818182	n/a	78521.5455	show_cross	n/a	n/a	92	n/a	n/a	cross.bmp
+314.6452727273	n/a	78661.3182	show_face	scrambled_face	immediate_repeat	92	1	18	s092.bmp
+315.6370909091	n/a	78909.2727	show_circle	n/a	n/a	92	n/a	0	circle.bmp
+317.33709090909997	n/a	79334.2727	show_cross	n/a	n/a	93	n/a	n/a	cross.bmp
+317.8361818182	n/a	79459.0455	show_face	famous_face	delayed_repeat	93	13	7	f023.bmp
+318.5325454545	n/a	79633.1364	right_press	n/a	n/a	93	n/a	4096	n/a
+318.8052727273	n/a	79701.3182	show_circle	n/a	n/a	93	n/a	0	circle.bmp
+320.5052727273	n/a	80126.3182	show_cross	n/a	n/a	94	n/a	n/a	cross.bmp
+321.1107272727	n/a	80277.6818	show_face	unfamiliar_face	first_show	94	n/a	13	u013.bmp
+322.1252727273	n/a	80531.3182	show_circle	n/a	n/a	94	n/a	0	circle.bmp
+323.8252727273	n/a	80956.3182	show_cross	n/a	n/a	95	n/a	n/a	cross.bmp
+324.4016363636	n/a	81100.4091	show_face	unfamiliar_face	immediate_repeat	95	1	14	u013.bmp
+325.3943636364	n/a	81348.5909	show_circle	n/a	n/a	95	n/a	0	circle.bmp
+327.0943636364	n/a	81773.5909	show_cross	n/a	n/a	96	n/a	n/a	cross.bmp
+327.5916363636	n/a	81897.9091	show_face	unfamiliar_face	first_show	96	n/a	13	u129.bmp
+328.4270909091	n/a	82106.7727	show_circle	n/a	n/a	96	n/a	0	circle.bmp
+330.1270909091	n/a	82531.7727	show_cross	n/a	n/a	97	n/a	n/a	cross.bmp
+330.7661818182	n/a	82691.5455	show_face	unfamiliar_face	immediate_repeat	97	1	14	u129.bmp
+331.7661818182	n/a	82941.5455	show_circle	n/a	n/a	97	n/a	0	circle.bmp
+333.46618181819997	n/a	83366.5455	show_cross	n/a	n/a	98	n/a	n/a	cross.bmp
+333.9398181818	n/a	83484.9545	show_face	scrambled_face	first_show	98	n/a	17	s046.bmp
+334.8607272727	n/a	83715.1818	show_circle	n/a	n/a	98	n/a	0	circle.bmp
+336.5607272727	n/a	84140.1818	show_cross	n/a	n/a	99	n/a	n/a	cross.bmp
+337.0307272727	n/a	84257.6818	show_face	unfamiliar_face	first_show	99	n/a	13	u137.bmp
+338.0089090909	n/a	84502.2273	show_circle	n/a	n/a	99	n/a	0	circle.bmp
+339.7089090909	n/a	84927.2273	show_cross	n/a	n/a	100	n/a	n/a	cross.bmp
+340.338	n/a	85084.5	show_face	scrambled_face	delayed_repeat	100	10	19	s027.bmp
+341.0961818182	n/a	85274.0455	right_press	n/a	n/a	100	n/a	4096	n/a
+341.3270909091	n/a	85331.7727	show_circle	n/a	n/a	100	n/a	0	circle.bmp
+343.0270909091	n/a	85756.7727	show_cross	n/a	n/a	101	n/a	n/a	cross.bmp
+343.67890909089994	n/a	85919.7273	show_face	famous_face	first_show	101	n/a	5	f045.bmp
+344.388	n/a	86097.0	right_press	n/a	n/a	101	n/a	4096	n/a
+344.6616363636	n/a	86165.4091	show_circle	n/a	n/a	101	n/a	0	circle.bmp
+346.3616363636	n/a	86590.4091	show_cross	n/a	n/a	102	n/a	n/a	cross.bmp
+347.0034545455	n/a	86750.8636	show_face	famous_face	immediate_repeat	102	1	6	f045.bmp
+347.7334545455	n/a	86933.3636	right_press	n/a	n/a	102	n/a	4096	n/a
+348.00981818180003	n/a	87002.4545	show_circle	n/a	n/a	102	n/a	0	circle.bmp
+349.7098181818	n/a	87427.4545	show_cross	n/a	n/a	103	n/a	n/a	cross.bmp
+350.3107272727	n/a	87577.6818	show_face	famous_face	first_show	103	n/a	5	f077.bmp
+351.20709090910003	n/a	87801.7727	show_circle	n/a	n/a	103	n/a	0	circle.bmp
+352.9070909091	n/a	88226.7727	show_cross	n/a	n/a	104	n/a	n/a	cross.bmp
+353.368	n/a	88342.0	show_face	famous_face	immediate_repeat	104	1	6	f077.bmp
+354.3734545455	n/a	88593.3636	show_circle	n/a	n/a	104	n/a	0	circle.bmp
+354.3843636364	n/a	88596.0909	right_press	n/a	n/a	104	n/a	4096	n/a
+356.07345454550006	n/a	89018.3636	show_cross	n/a	n/a	105	n/a	n/a	cross.bmp
+356.65890909089995	n/a	89164.7273	show_face	unfamiliar_face	first_show	105	n/a	13	u141.bmp
+357.47890909089995	n/a	89369.7273	right_press	n/a	n/a	105	n/a	4096	n/a
+357.4989090909	n/a	89374.7273	show_circle	n/a	n/a	105	n/a	0	circle.bmp
+359.1989090909	n/a	89799.7273	show_cross	n/a	n/a	106	n/a	n/a	cross.bmp
+359.6825454545	n/a	89920.6364	show_face	famous_face	first_show	106	n/a	5	f032.bmp
+360.32345454550006	n/a	90080.8636	right_press	n/a	n/a	106	n/a	4096	n/a
+360.56527272730006	n/a	90141.3182	show_circle	n/a	n/a	106	n/a	0	circle.bmp
+362.26527272730004	n/a	90566.3182	show_cross	n/a	n/a	107	n/a	n/a	cross.bmp
+362.7398181818	n/a	90684.9545	show_face	famous_face	immediate_repeat	107	1	6	f032.bmp
+363.33345454550005	n/a	90833.3636	right_press	n/a	n/a	107	n/a	4096	n/a
+363.70709090910003	n/a	90926.7727	show_circle	n/a	n/a	107	n/a	0	circle.bmp
+365.4070909091	n/a	91351.7727	show_cross	n/a	n/a	108	n/a	n/a	cross.bmp
+365.8798181818	n/a	91469.9545	show_face	scrambled_face	delayed_repeat	108	10	19	s046.bmp
+366.76890909089997	n/a	91692.2273	show_circle	n/a	n/a	108	n/a	0	circle.bmp
+368.46890909089996	n/a	92117.2273	show_cross	n/a	n/a	109	n/a	n/a	cross.bmp
+368.98709090910006	n/a	92246.7727	show_face	unfamiliar_face	first_show	109	n/a	13	u093.bmp
+369.7716363636	n/a	92442.9091	right_press	n/a	n/a	109	n/a	4096	n/a
+369.8734545455	n/a	92468.3636	show_circle	n/a	n/a	109	n/a	0	circle.bmp
+371.57345454550006	n/a	92893.3636	show_cross	n/a	n/a	110	n/a	n/a	cross.bmp
+372.2116363636	n/a	93052.9091	show_face	unfamiliar_face	delayed_repeat	110	11	15	u137.bmp
+373.21527272730003	n/a	93303.8182	show_circle	n/a	n/a	110	n/a	0	circle.bmp
+374.9152727273	n/a	93728.8182	show_cross	n/a	n/a	111	n/a	n/a	cross.bmp
+375.5525454545	n/a	93888.1364	show_face	scrambled_face	first_show	111	n/a	17	s039.bmp
+376.458	n/a	94114.5	right_press	n/a	n/a	111	n/a	4096	n/a
+376.568	n/a	94142.0	show_circle	n/a	n/a	111	n/a	0	circle.bmp
+378.268	n/a	94567.0	show_cross	n/a	n/a	112	n/a	n/a	cross.bmp
+378.89345454550005	n/a	94723.3636	show_face	famous_face	first_show	112	n/a	5	f112.bmp
+379.70527272730004	n/a	94926.3182	right_press	n/a	n/a	112	n/a	4096	n/a
+379.8107272727	n/a	94952.6818	show_circle	n/a	n/a	112	n/a	0	circle.bmp
+381.51072727269997	n/a	95377.6818	show_cross	n/a	n/a	113	n/a	n/a	cross.bmp
+382.1343636364	n/a	95533.5909	show_face	scrambled_face	first_show	113	n/a	17	s073.bmp
+382.9016363636	n/a	95725.4091	right_press	n/a	n/a	113	n/a	4096	n/a
+383.0498181818	n/a	95762.4545	show_circle	n/a	n/a	113	n/a	0	circle.bmp
+384.7498181818	n/a	96187.4545	show_cross	n/a	n/a	114	n/a	n/a	cross.bmp
+385.3416363636	n/a	96335.4091	show_face	scrambled_face	immediate_repeat	114	1	18	s073.bmp
+386.3043636364	n/a	96576.0909	show_circle	n/a	n/a	114	n/a	0	circle.bmp
+388.0043636364	n/a	97001.0909	show_cross	n/a	n/a	115	n/a	n/a	cross.bmp
+388.54890909089994	n/a	97137.2273	show_face	unfamiliar_face	delayed_repeat	115	10	15	u141.bmp
+389.4907272727	n/a	97372.6818	show_circle	n/a	n/a	115	n/a	0	circle.bmp
+391.1907272727	n/a	97797.6818	show_cross	n/a	n/a	116	n/a	n/a	cross.bmp
+391.6725454545	n/a	97918.1364	show_face	famous_face	first_show	116	n/a	5	f065.bmp
+392.5843636364	n/a	98146.0909	show_circle	n/a	n/a	116	n/a	0	circle.bmp
+394.2843636364	n/a	98571.0909	show_cross	n/a	n/a	117	n/a	n/a	cross.bmp
+394.79709090910006	n/a	98699.2727	show_face	famous_face	immediate_repeat	117	1	6	f065.bmp
+395.6761818182	n/a	98919.0455	show_circle	n/a	n/a	117	n/a	0	circle.bmp
+397.3761818182	n/a	99344.0455	show_cross	n/a	n/a	118	n/a	n/a	cross.bmp
+397.97072727269995	n/a	99492.6818	show_face	scrambled_face	first_show	118	n/a	17	s025.bmp
+398.9243636364	n/a	99731.0909	show_circle	n/a	n/a	118	n/a	0	circle.bmp
+400.6243636364	n/a	100156.0909	show_cross	n/a	n/a	119	n/a	n/a	cross.bmp
+401.2616363636	n/a	100315.4091	show_face	unfamiliar_face	delayed_repeat	119	10	15	u093.bmp
+402.0898181818	n/a	100522.4545	show_circle	n/a	n/a	119	n/a	0	circle.bmp
+402.14072727269996	n/a	100535.1818	right_press	n/a	n/a	119	n/a	4096	n/a
+403.7898181818	n/a	100947.4545	show_cross	n/a	n/a	120	n/a	n/a	cross.bmp
+404.43527272730006	n/a	101108.8182	show_face	unfamiliar_face	first_show	120	n/a	13	u083.bmp
+405.3370909091	n/a	101334.2727	show_circle	n/a	n/a	120	n/a	0	circle.bmp
+407.0370909091	n/a	101759.2727	show_cross	n/a	n/a	121	n/a	n/a	cross.bmp
+407.6098181818	n/a	101902.4545	show_face	unfamiliar_face	immediate_repeat	121	1	14	u083.bmp
+408.4434545455	n/a	102110.8636	show_circle	n/a	n/a	121	n/a	0	circle.bmp
+410.14345454550005	n/a	102535.8636	show_cross	n/a	n/a	122	n/a	n/a	cross.bmp
+410.6161818182	n/a	102654.0455	show_face	scrambled_face	delayed_repeat	122	11	19	s039.bmp
+411.5716363636	n/a	102892.9091	show_circle	n/a	n/a	122	n/a	0	circle.bmp
+413.2716363636	n/a	103317.9091	show_cross	n/a	n/a	123	n/a	n/a	cross.bmp
+413.72345454550003	n/a	103430.8636	show_face	unfamiliar_face	first_show	123	n/a	13	u010.bmp
+414.58527272730004	n/a	103646.3182	show_circle	n/a	n/a	123	n/a	0	circle.bmp
+416.2852727273	n/a	104071.3182	show_cross	n/a	n/a	124	n/a	n/a	cross.bmp
+416.7816363636	n/a	104195.4091	show_face	famous_face	delayed_repeat	124	12	7	f112.bmp
+417.5643636364	n/a	104391.0909	right_press	n/a	n/a	124	n/a	4096	n/a
+417.798	n/a	104449.5	show_circle	n/a	n/a	124	n/a	0	circle.bmp
+419.498	n/a	104874.5	show_cross	n/a	n/a	125	n/a	n/a	cross.bmp
+420.1052727273	n/a	105026.3182	show_face	scrambled_face	first_show	125	n/a	17	s028.bmp
+421.0316363636	n/a	105257.9091	right_press	n/a	n/a	125	n/a	4096	n/a
+421.1234545455	n/a	105280.8636	show_circle	n/a	n/a	125	n/a	0	circle.bmp
+422.82345454550006	n/a	105705.8636	show_cross	n/a	n/a	126	n/a	n/a	cross.bmp
+423.4125454545	n/a	105853.1364	show_face	unfamiliar_face	first_show	126	n/a	13	u118.bmp
+424.13345454550006	n/a	106033.3636	right_press	n/a	n/a	126	n/a	4096	n/a
+424.3016363636	n/a	106075.4091	show_circle	n/a	n/a	126	n/a	0	circle.bmp
+426.0016363636	n/a	106500.4091	show_cross	n/a	n/a	127	n/a	n/a	cross.bmp
+426.63709090910004	n/a	106659.2727	show_face	scrambled_face	first_show	127	n/a	17	s116.bmp
+427.52254545449995	n/a	106880.6364	right_press	n/a	n/a	127	n/a	4096	n/a
+427.6207272727	n/a	106905.1818	show_circle	n/a	n/a	127	n/a	0	circle.bmp
+429.32072727269997	n/a	107330.1818	show_cross	n/a	n/a	128	n/a	n/a	cross.bmp
+429.8943636364	n/a	107473.5909	show_face	scrambled_face	immediate_repeat	128	1	18	s116.bmp
+430.6734545455	n/a	107668.3636	right_press	n/a	n/a	128	n/a	4096	n/a
+430.8361818182	n/a	107709.0455	show_circle	n/a	n/a	128	n/a	0	circle.bmp
+432.5361818182	n/a	108134.0455	show_cross	n/a	n/a	129	n/a	n/a	cross.bmp
+433.068	n/a	108267.0	show_face	scrambled_face	delayed_repeat	129	11	19	s025.bmp
+433.988	n/a	108497.0	show_circle	n/a	n/a	129	n/a	0	circle.bmp
+435.688	n/a	108922.0	show_cross	n/a	n/a	130	n/a	n/a	cross.bmp
+436.3089090909	n/a	109077.2273	show_face	unfamiliar_face	first_show	130	n/a	13	u081.bmp
+437.2434545455	n/a	109310.8636	show_circle	n/a	n/a	130	n/a	0	circle.bmp
+438.9434545455	n/a	109735.8636	show_cross	n/a	n/a	131	n/a	n/a	cross.bmp
+439.4334545455	n/a	109858.3636	show_face	unfamiliar_face	immediate_repeat	131	1	14	u081.bmp
+440.3161818182	n/a	110079.0455	show_circle	n/a	n/a	131	n/a	0	circle.bmp
+442.0161818182	n/a	110504.0455	show_cross	n/a	n/a	132	n/a	n/a	cross.bmp
+442.5398181818	n/a	110634.9545	show_face	unfamiliar_face	first_show	132	n/a	13	u008.bmp
+443.55709090910005	n/a	110889.2727	show_circle	n/a	n/a	132	n/a	0	circle.bmp
+445.25709090910004	n/a	111314.2727	show_cross	n/a	n/a	133	n/a	n/a	cross.bmp
+445.8643636364	n/a	111466.0909	show_face	unfamiliar_face	delayed_repeat	133	10	15	u010.bmp
+446.81527272730006	n/a	111703.8182	show_circle	n/a	n/a	133	n/a	0	circle.bmp
+448.51527272730004	n/a	112128.8182	show_cross	n/a	n/a	134	n/a	n/a	cross.bmp
+449.1389090909	n/a	112284.7273	show_face	famous_face	first_show	134	n/a	5	f057.bmp
+449.9116363636	n/a	112477.9091	right_press	n/a	n/a	134	n/a	4096	n/a
+449.96527272730003	n/a	112491.3182	show_circle	n/a	n/a	134	n/a	0	circle.bmp
+451.6652727273	n/a	112916.3182	show_cross	n/a	n/a	135	n/a	n/a	cross.bmp
+452.22890909089995	n/a	113057.2273	show_face	famous_face	immediate_repeat	135	1	6	f057.bmp
+452.838	n/a	113209.5	right_press	n/a	n/a	135	n/a	4096	n/a
+453.1916363636	n/a	113297.9091	show_circle	n/a	n/a	135	n/a	0	circle.bmp
+454.8916363636	n/a	113722.9091	show_cross	n/a	n/a	136	n/a	n/a	cross.bmp
+455.48709090910006	n/a	113871.7727	show_face	scrambled_face	delayed_repeat	136	11	19	s028.bmp
+456.3216363636	n/a	114080.4091	show_circle	n/a	n/a	136	n/a	0	circle.bmp
+456.3707272727	n/a	114092.6818	right_press	n/a	n/a	136	n/a	4096	n/a
+458.0216363636	n/a	114505.4091	show_cross	n/a	n/a	137	n/a	n/a	cross.bmp
+458.67709090910006	n/a	114669.2727	show_face	scrambled_face	first_show	137	n/a	17	s020.bmp
+459.64254545449995	n/a	114910.6364	show_circle	n/a	n/a	137	n/a	0	circle.bmp
+461.34254545449994	n/a	115335.6364	show_cross	n/a	n/a	138	n/a	n/a	cross.bmp
+461.9016363636	n/a	115475.4091	show_face	unfamiliar_face	delayed_repeat	138	12	15	u118.bmp
+462.7434545455	n/a	115685.8636	show_circle	n/a	n/a	138	n/a	0	circle.bmp
+462.75709090910004	n/a	115689.2727	right_press	n/a	n/a	138	n/a	4096	n/a
+464.4434545455	n/a	116110.8636	show_cross	n/a	n/a	139	n/a	n/a	cross.bmp
+464.9925454545	n/a	116248.1364	show_face	famous_face	first_show	139	n/a	5	f034.bmp
+465.608	n/a	116402.0	right_press	n/a	n/a	139	n/a	4096	n/a
+465.94709090910004	n/a	116486.7727	show_circle	n/a	n/a	139	n/a	0	circle.bmp
+467.64709090910003	n/a	116911.7727	show_cross	n/a	n/a	140	n/a	n/a	cross.bmp
+468.21618181819997	n/a	117054.0455	show_face	scrambled_face	first_show	140	n/a	17	s149.bmp
+468.96618181819997	n/a	117241.5455	right_press	n/a	n/a	140	n/a	4096	n/a
+469.1843636364	n/a	117296.0909	show_circle	n/a	n/a	140	n/a	0	circle.bmp
+470.8843636364	n/a	117721.0909	show_cross	n/a	n/a	141	n/a	n/a	cross.bmp
+471.3734545455	n/a	117843.3636	show_face	scrambled_face	immediate_repeat	141	1	18	s149.bmp
+472.318	n/a	118079.5	show_circle	n/a	n/a	141	n/a	0	circle.bmp
+472.3570909091	n/a	118089.2727	right_press	n/a	n/a	141	n/a	4096	n/a
+474.018	n/a	118504.5	show_cross	n/a	n/a	142	n/a	n/a	cross.bmp
+474.63072727269997	n/a	118657.6818	show_face	scrambled_face	first_show	142	n/a	17	s040.bmp
+475.468	n/a	118867.0	right_press	n/a	n/a	142	n/a	4096	n/a
+475.60890909089994	n/a	118902.2273	show_circle	n/a	n/a	142	n/a	0	circle.bmp
+477.3089090909	n/a	119327.2273	show_cross	n/a	n/a	143	n/a	n/a	cross.bmp
+477.87163636360003	n/a	119467.9091	show_face	scrambled_face	immediate_repeat	143	1	18	s040.bmp
+478.87709090910005	n/a	119719.2727	show_circle	n/a	n/a	143	n/a	0	circle.bmp
+480.57709090910004	n/a	120144.2727	show_cross	n/a	n/a	144	n/a	n/a	cross.bmp
+481.1961818182	n/a	120299.0455	show_face	unfamiliar_face	delayed_repeat	144	12	15	u008.bmp
+482.1107272727	n/a	120527.6818	show_circle	n/a	n/a	144	n/a	0	circle.bmp
+483.8107272727	n/a	120952.6818	show_cross	n/a	n/a	145	n/a	n/a	cross.bmp
+484.31981818180003	n/a	121079.9545	show_face	unfamiliar_face	first_show	145	n/a	13	u125.bmp
+485.22436363639997	n/a	121306.0909	show_circle	n/a	n/a	145	n/a	0	circle.bmp
+486.9243636364	n/a	121731.0909	show_cross	n/a	n/a	146	n/a	n/a	cross.bmp
+487.4934545455	n/a	121873.3636	show_face	scrambled_face	first_show	146	n/a	17	s138.bmp
+488.33254545449995	n/a	122083.1364	show_circle	n/a	n/a	146	n/a	0	circle.bmp
+490.0325454545	n/a	122508.1364	show_cross	n/a	n/a	147	n/a	n/a	cross.bmp
+490.60072727269994	n/a	122650.1818	show_face	scrambled_face	immediate_repeat	147	1	18	s138.bmp
+491.4761818182	n/a	122869.0455	show_circle	n/a	n/a	147	n/a	0	circle.bmp
+493.1761818182	n/a	123294.0455	show_cross	n/a	n/a	148	n/a	n/a	cross.bmp
+493.658	n/a	123414.5	show_face	scrambled_face	delayed_repeat	148	11	19	s020.bmp
+494.488	n/a	123622.0	right_press	n/a	n/a	148	n/a	4096	n/a
+494.6152727273	n/a	123653.8182	show_circle	n/a	n/a	148	n/a	0	circle.bmp
+496.31527272730006	n/a	124078.8182	show_cross	n/a	n/a	149	n/a	n/a	cross.bmp

--- a/eeg_hed_small/sub-002/eeg/sub-002_task-FacePerception_run-3_events.tsv
+++ b/eeg_hed_small/sub-002/eeg/sub-002_task-FacePerception_run-3_events.tsv
@@ -1,535 +1,535 @@
-onset	duration	sample	event_type	face_type	repetition_type	trigger	stim_file
-0.0040000000	n/a	1	setup	n/a	n/a	n/a	n/a
-0.0040000000	n/a	1	right_sym	n/a	n/a	n/a	n/a
-24.5989090909	n/a	6149.7273	show_face	unfamiliar_face	first_show	13	u097.bmp
-25.3198181818	n/a	6329.9545	right_press	n/a	n/a	4096	n/a
-25.4325454545	n/a	6358.1364	show_circle	n/a	n/a	0	circle.bmp
-27.1325454545	n/a	6783.1364	show_cross	n/a	n/a	n/a	cross.bmp
-27.6225454545	n/a	6905.6364	show_face	unfamiliar_face	immediate_repeat	14	u097.bmp
-28.1198181818	n/a	7029.9545	right_press	n/a	n/a	4096	n/a
-28.5952727273	n/a	7148.8182	show_circle	n/a	n/a	0	circle.bmp
-30.2952727273	n/a	7573.8182	show_cross	n/a	n/a	n/a	cross.bmp
-30.8798181818	n/a	7719.9545	show_face	famous_face	first_show	5	f103.bmp
-31.5625454545	n/a	7890.6364	right_press	n/a	n/a	4096	n/a
-31.8161818182	n/a	7954.0455	show_circle	n/a	n/a	0	circle.bmp
-33.5161818182	n/a	8379.0455	show_cross	n/a	n/a	n/a	cross.bmp
-34.0543636364	n/a	8513.5909	show_face	famous_face	immediate_repeat	6	f103.bmp
-34.6689090909	n/a	8667.2273	right_press	n/a	n/a	4096	n/a
-34.9870909091	n/a	8746.7727	show_circle	n/a	n/a	0	circle.bmp
-36.6870909091	n/a	9171.7727	show_cross	n/a	n/a	n/a	cross.bmp
-37.3116363636	n/a	9327.9091	show_face	unfamiliar_face	first_show	13	u112.bmp
-38.2052727273	n/a	9551.3182	show_circle	n/a	n/a	0	circle.bmp
-39.9052727273	n/a	9976.3182	show_cross	n/a	n/a	n/a	cross.bmp
-40.3689090909	n/a	10092.2273	show_face	famous_face	first_show	5	f130.bmp
-40.9825454545	n/a	10245.6364	right_press	n/a	n/a	4096	n/a
-41.3807272727	n/a	10345.1818	show_circle	n/a	n/a	0	circle.bmp
-43.0807272727	n/a	10770.1818	show_cross	n/a	n/a	n/a	cross.bmp
-43.5589090909	n/a	10889.7273	show_face	famous_face	first_show	5	f004.bmp
-44.5580000000	n/a	11139.5	show_circle	n/a	n/a	0	circle.bmp
-46.2580000000	n/a	11564.5	show_cross	n/a	n/a	n/a	cross.bmp
-46.8670909091	n/a	11716.7727	show_face	famous_face	immediate_repeat	6	f004.bmp
-47.7807272727	n/a	11945.1818	show_circle	n/a	n/a	0	circle.bmp
-49.4807272727	n/a	12370.1818	show_cross	n/a	n/a	n/a	cross.bmp
-49.9570909091	n/a	12489.2727	show_face	unfamiliar_face	first_show	13	u111.bmp
-50.5534545455	n/a	12638.3636	right_press	n/a	n/a	4096	n/a
-50.9643636364	n/a	12741.0909	show_circle	n/a	n/a	0	circle.bmp
-52.6643636364	n/a	13166.0909	show_cross	n/a	n/a	n/a	cross.bmp
-53.2652727273	n/a	13316.3182	show_face	unfamiliar_face	immediate_repeat	14	u111.bmp
-53.8561818182	n/a	13464.0455	right_press	n/a	n/a	4096	n/a
-54.2161818182	n/a	13554.0455	show_circle	n/a	n/a	0	circle.bmp
-55.9161818182	n/a	13979.0455	show_cross	n/a	n/a	n/a	cross.bmp
-56.5225454545	n/a	14130.6364	show_face	famous_face	first_show	5	f025.bmp
-57.4852727273	n/a	14371.3182	show_circle	n/a	n/a	0	circle.bmp
-59.1852727273	n/a	14796.3182	show_cross	n/a	n/a	n/a	cross.bmp
-59.8298181818	n/a	14957.4545	show_face	scrambled_face	first_show	17	s111.bmp
-60.7116363636	n/a	15177.9091	show_circle	n/a	n/a	0	circle.bmp
-62.4116363636	n/a	15602.9091	show_cross	n/a	n/a	n/a	cross.bmp
-63.0043636364	n/a	15751.0909	show_face	scrambled_face	immediate_repeat	18	s111.bmp
-63.9534545455	n/a	15988.3636	show_circle	n/a	n/a	0	circle.bmp
-65.6534545455	n/a	16413.3636	show_cross	n/a	n/a	n/a	cross.bmp
-66.2116363636	n/a	16552.9091	show_face	unfamiliar_face	delayed_repeat	15	u112.bmp
-67.1134545455	n/a	16778.3636	show_circle	n/a	n/a	0	circle.bmp
-68.8134545455	n/a	17203.3636	show_cross	n/a	n/a	n/a	cross.bmp
-69.2852727273	n/a	17321.3182	show_face	scrambled_face	first_show	17	s112.bmp
-70.2516363636	n/a	17562.9091	show_circle	n/a	n/a	0	circle.bmp
-71.9516363636	n/a	17987.9091	show_cross	n/a	n/a	n/a	cross.bmp
-72.5425454545	n/a	18135.6364	show_face	famous_face	delayed_repeat	7	f130.bmp
-73.0834545455	n/a	18270.8636	right_press	n/a	n/a	4096	n/a
-73.4534545455	n/a	18363.3636	show_circle	n/a	n/a	0	circle.bmp
-75.1534545455	n/a	18788.3636	show_cross	n/a	n/a	n/a	cross.bmp
-75.7498181818	n/a	18937.4545	show_face	scrambled_face	first_show	17	s115.bmp
-76.7543636364	n/a	19188.5909	show_circle	n/a	n/a	0	circle.bmp
-76.8561818182	n/a	19214.0455	right_press	n/a	n/a	4096	n/a
-78.4543636364	n/a	19613.5909	show_cross	n/a	n/a	n/a	cross.bmp
-78.9407272727	n/a	19735.1818	show_face	unfamiliar_face	first_show	13	u123.bmp
-79.8252727273	n/a	19956.3182	show_circle	n/a	n/a	0	circle.bmp
-81.5252727273	n/a	20381.3182	show_cross	n/a	n/a	n/a	cross.bmp
-82.0316363636	n/a	20507.9091	show_face	scrambled_face	first_show	17	s005.bmp
-82.7080000000	n/a	20677	right_press	n/a	n/a	4096	n/a
-82.9961818182	n/a	20749.0455	show_circle	n/a	n/a	0	circle.bmp
-84.6961818182	n/a	21174.0455	show_cross	n/a	n/a	n/a	cross.bmp
-85.1716363636	n/a	21292.9091	show_face	scrambled_face	immediate_repeat	18	s005.bmp
-85.7807272727	n/a	21445.1818	right_press	n/a	n/a	4096	n/a
-86.0989090909	n/a	21524.7273	show_circle	n/a	n/a	0	circle.bmp
-87.7989090909	n/a	21949.7273	show_cross	n/a	n/a	n/a	cross.bmp
-88.2952727273	n/a	22073.8182	show_face	famous_face	delayed_repeat	7	f025.bmp
-89.1589090909	n/a	22289.7273	show_circle	n/a	n/a	0	circle.bmp
-90.8589090909	n/a	22714.7273	show_cross	n/a	n/a	n/a	cross.bmp
-91.5034545455	n/a	22875.8636	show_face	unfamiliar_face	first_show	13	u045.bmp
-92.3852727273	n/a	23096.3182	show_circle	n/a	n/a	0	circle.bmp
-94.0852727273	n/a	23521.3182	show_cross	n/a	n/a	n/a	cross.bmp
-94.6270909091	n/a	23656.7727	show_face	unfamiliar_face	immediate_repeat	14	u045.bmp
-95.5707272727	n/a	23892.6818	show_circle	n/a	n/a	0	circle.bmp
-97.2707272727	n/a	24317.6818	show_cross	n/a	n/a	n/a	cross.bmp
-97.8180000000	n/a	24454.5	show_face	famous_face	first_show	5	f059.bmp
-98.5089090909	n/a	24627.2273	right_press	n/a	n/a	4096	n/a
-98.7143636364	n/a	24678.5909	show_circle	n/a	n/a	0	circle.bmp
-100.4143636364	n/a	25103.5909	show_cross	n/a	n/a	n/a	cross.bmp
-100.9416363636	n/a	25235.4091	show_face	famous_face	immediate_repeat	6	f059.bmp
-101.5970909091	n/a	25399.2727	right_press	n/a	n/a	4096	n/a
-101.9198181818	n/a	25479.9545	show_circle	n/a	n/a	0	circle.bmp
-103.6198181818	n/a	25904.9545	show_cross	n/a	n/a	n/a	cross.bmp
-104.2325454545	n/a	26058.1364	show_face	scrambled_face	delayed_repeat	19	s112.bmp
-104.8325454545	n/a	26208.1364	right_press	n/a	n/a	4096	n/a
-105.1680000000	n/a	26292	show_circle	n/a	n/a	0	circle.bmp
-106.8680000000	n/a	26717	show_cross	n/a	n/a	n/a	cross.bmp
-107.4734545455	n/a	26868.3636	show_face	famous_face	first_show	5	f041.bmp
-108.1889090909	n/a	27047.2273	right_press	n/a	n/a	4096	n/a
-108.4498181818	n/a	27112.4545	show_circle	n/a	n/a	0	circle.bmp
-110.1498181818	n/a	27537.4545	show_cross	n/a	n/a	n/a	cross.bmp
-110.5970909091	n/a	27649.2727	show_face	scrambled_face	delayed_repeat	19	s115.bmp
-111.2870909091	n/a	27821.7727	right_press	n/a	n/a	4096	n/a
-111.4352727273	n/a	27858.8182	show_circle	n/a	n/a	0	circle.bmp
-113.1352727273	n/a	28283.8182	show_cross	n/a	n/a	n/a	cross.bmp
-113.7380000000	n/a	28434.5	show_face	scrambled_face	first_show	17	s139.bmp
-114.4461818182	n/a	28611.5455	right_press	n/a	n/a	4096	n/a
-114.7461818182	n/a	28686.5455	show_circle	n/a	n/a	0	circle.bmp
-116.4461818182	n/a	29111.5455	show_cross	n/a	n/a	n/a	cross.bmp
-117.0952727273	n/a	29273.8182	show_face	scrambled_face	immediate_repeat	18	s139.bmp
-118.0598181818	n/a	29514.9545	show_circle	n/a	n/a	0	circle.bmp
-119.7598181818	n/a	29939.9545	show_cross	n/a	n/a	n/a	cross.bmp
-120.2698181818	n/a	30067.4545	show_face	unfamiliar_face	delayed_repeat	15	u123.bmp
-121.1243636364	n/a	30281.0909	show_circle	n/a	n/a	0	circle.bmp
-122.8243636364	n/a	30706.0909	show_cross	n/a	n/a	n/a	cross.bmp
-123.3761818182	n/a	30844.0455	show_face	scrambled_face	first_show	17	s076.bmp
-124.1452727273	n/a	31036.3182	right_press	n/a	n/a	4096	n/a
-124.2580000000	n/a	31064.5	show_circle	n/a	n/a	0	circle.bmp
-125.9580000000	n/a	31489.5	show_cross	n/a	n/a	n/a	cross.bmp
-126.5334545455	n/a	31633.3636	show_face	famous_face	first_show	5	f081.bmp
-127.4098181818	n/a	31852.4545	show_circle	n/a	n/a	0	circle.bmp
-127.4189090909	n/a	31854.7273	right_press	n/a	n/a	4096	n/a
-129.1098181818	n/a	32277.4545	show_cross	n/a	n/a	n/a	cross.bmp
-129.6907272727	n/a	32422.6818	show_face	famous_face	immediate_repeat	6	f081.bmp
-130.1834545455	n/a	32545.8636	right_press	n/a	n/a	4096	n/a
-130.5543636364	n/a	32638.5909	show_circle	n/a	n/a	0	circle.bmp
-132.2543636364	n/a	33063.5909	show_cross	n/a	n/a	n/a	cross.bmp
-132.7316363636	n/a	33182.9091	show_face	famous_face	first_show	5	f141.bmp
-133.4816363636	n/a	33370.4091	right_press	n/a	n/a	4096	n/a
-133.6643636364	n/a	33416.0909	show_circle	n/a	n/a	0	circle.bmp
-135.3643636364	n/a	33841.0909	show_cross	n/a	n/a	n/a	cross.bmp
-136.0052727273	n/a	34001.3182	show_face	scrambled_face	first_show	17	s137.bmp
-136.9125454545	n/a	34228.1364	right_press	n/a	n/a	4096	n/a
-136.9370909091	n/a	34234.2727	show_circle	n/a	n/a	0	circle.bmp
-138.6370909091	n/a	34659.2727	show_cross	n/a	n/a	n/a	cross.bmp
-139.1125454545	n/a	34778.1364	show_face	famous_face	delayed_repeat	7	f041.bmp
-139.8934545455	n/a	34973.3636	right_press	n/a	n/a	4096	n/a
-140.0870909091	n/a	35021.7727	show_circle	n/a	n/a	0	circle.bmp
-141.7870909091	n/a	35446.7727	show_cross	n/a	n/a	n/a	cross.bmp
-142.4534545455	n/a	35613.3636	show_face	unfamiliar_face	first_show	13	u120.bmp
-143.4307272727	n/a	35857.6818	show_circle	n/a	n/a	0	circle.bmp
-145.1307272727	n/a	36282.6818	show_cross	n/a	n/a	n/a	cross.bmp
-145.7443636364	n/a	36436.0909	show_face	unfamiliar_face	first_show	13	u002.bmp
-146.7252727273	n/a	36681.3182	show_circle	n/a	n/a	0	circle.bmp
-148.4252727273	n/a	37106.3182	show_cross	n/a	n/a	n/a	cross.bmp
-149.0352727273	n/a	37258.8182	show_face	scrambled_face	delayed_repeat	19	s076.bmp
-149.8570909091	n/a	37464.2727	show_circle	n/a	n/a	0	circle.bmp
-151.5570909091	n/a	37889.2727	show_cross	n/a	n/a	n/a	cross.bmp
-152.1261818182	n/a	38031.5455	show_face	famous_face	first_show	5	f121.bmp
-153.0743636364	n/a	38268.5909	show_circle	n/a	n/a	0	circle.bmp
-154.7743636364	n/a	38693.5909	show_cross	n/a	n/a	n/a	cross.bmp
-155.4007272727	n/a	38850.1818	show_face	famous_face	immediate_repeat	6	f121.bmp
-156.3989090909	n/a	39099.7273	show_circle	n/a	n/a	0	circle.bmp
-158.0989090909	n/a	39524.7273	show_cross	n/a	n/a	n/a	cross.bmp
-158.7416363636	n/a	39685.4091	show_face	unfamiliar_face	first_show	13	u018.bmp
-159.6480000000	n/a	39912	show_circle	n/a	n/a	0	circle.bmp
-159.7498181818	n/a	39937.4545	right_press	n/a	n/a	4096	n/a
-161.3480000000	n/a	40337	show_cross	n/a	n/a	n/a	cross.bmp
-161.9661818182	n/a	40491.5455	show_face	famous_face	delayed_repeat	7	f141.bmp
-162.8325454545	n/a	40708.1364	show_circle	n/a	n/a	0	circle.bmp
-162.8370909091	n/a	40709.2727	right_press	n/a	n/a	4096	n/a
-164.5325454545	n/a	41133.1364	show_cross	n/a	n/a	n/a	cross.bmp
-165.1725454545	n/a	41293.1364	show_face	unfamiliar_face	first_show	13	u014.bmp
-166.1261818182	n/a	41531.5455	show_circle	n/a	n/a	0	circle.bmp
-167.8261818182	n/a	41956.5455	show_cross	n/a	n/a	n/a	cross.bmp
-168.4480000000	n/a	42112	show_face	unfamiliar_face	immediate_repeat	14	u014.bmp
-169.3125454545	n/a	42328.1364	show_circle	n/a	n/a	0	circle.bmp
-171.0125454545	n/a	42753.1364	show_cross	n/a	n/a	n/a	cross.bmp
-171.5216363636	n/a	42880.4091	show_face	scrambled_face	delayed_repeat	19	s137.bmp
-172.2180000000	n/a	43054.5	right_press	n/a	n/a	4096	n/a
-172.5052727273	n/a	43126.3182	show_circle	n/a	n/a	0	circle.bmp
-174.2052727273	n/a	43551.3182	show_cross	n/a	n/a	n/a	cross.bmp
-174.7280000000	n/a	43682	show_face	unfamiliar_face	first_show	13	u023.bmp
-175.5625454545	n/a	43890.6364	show_circle	n/a	n/a	0	circle.bmp
-177.2625454545	n/a	44315.6364	show_cross	n/a	n/a	n/a	cross.bmp
-177.8016363636	n/a	44450.4091	show_face	unfamiliar_face	delayed_repeat	15	u120.bmp
-178.7734545455	n/a	44693.3636	show_circle	n/a	n/a	0	circle.bmp
-180.4734545455	n/a	45118.3636	show_cross	n/a	n/a	n/a	cross.bmp
-181.0761818182	n/a	45269.0455	show_face	unfamiliar_face	first_show	13	u041.bmp
-181.7389090909	n/a	45434.7273	right_press	n/a	n/a	4096	n/a
-182.0270909091	n/a	45506.7727	show_circle	n/a	n/a	0	circle.bmp
-183.7270909091	n/a	45931.7727	show_cross	n/a	n/a	n/a	cross.bmp
-184.1834545455	n/a	46045.8636	show_face	unfamiliar_face	delayed_repeat	15	u002.bmp
-185.1525454545	n/a	46288.1364	show_circle	n/a	n/a	0	circle.bmp
-186.8525454545	n/a	46713.1364	show_cross	n/a	n/a	n/a	cross.bmp
-187.4580000000	n/a	46864.5	show_face	scrambled_face	first_show	17	s125.bmp
-188.3852727273	n/a	47096.3182	show_circle	n/a	n/a	0	circle.bmp
-190.0852727273	n/a	47521.3182	show_cross	n/a	n/a	n/a	cross.bmp
-190.6652727273	n/a	47666.3182	show_face	scrambled_face	immediate_repeat	18	s125.bmp
-191.6407272727	n/a	47910.1818	show_circle	n/a	n/a	0	circle.bmp
-193.3407272727	n/a	48335.1818	show_cross	n/a	n/a	n/a	cross.bmp
-193.9225454545	n/a	48480.6364	show_face	famous_face	first_show	5	f146.bmp
-194.8325454545	n/a	48708.1364	show_circle	n/a	n/a	0	circle.bmp
-196.5325454545	n/a	49133.1364	show_cross	n/a	n/a	n/a	cross.bmp
-197.0125454545	n/a	49253.1364	show_face	unfamiliar_face	delayed_repeat	15	u018.bmp
-197.9580000000	n/a	49489.5	show_circle	n/a	n/a	0	circle.bmp
-199.6580000000	n/a	49914.5	show_cross	n/a	n/a	n/a	cross.bmp
-200.3034545455	n/a	50075.8636	show_face	famous_face	first_show	5	f058.bmp
-201.1316363636	n/a	50282.9091	right_press	n/a	n/a	4096	n/a
-201.1870909091	n/a	50296.7727	show_circle	n/a	n/a	0	circle.bmp
-202.8870909091	n/a	50721.7727	show_cross	n/a	n/a	n/a	cross.bmp
-203.4607272727	n/a	50865.1818	show_face	famous_face	immediate_repeat	6	f058.bmp
-204.1461818182	n/a	51036.5455	right_press	n/a	n/a	4096	n/a
-204.4789090909	n/a	51119.7273	show_circle	n/a	n/a	0	circle.bmp
-206.1789090909	n/a	51544.7273	show_cross	n/a	n/a	n/a	cross.bmp
-206.8189090909	n/a	51704.7273	show_face	unfamiliar_face	first_show	13	u146.bmp
-207.6316363636	n/a	51907.9091	right_press	n/a	n/a	4096	n/a
-207.7343636364	n/a	51933.5909	show_circle	n/a	n/a	0	circle.bmp
-209.4343636364	n/a	52358.5909	show_cross	n/a	n/a	n/a	cross.bmp
-209.9598181818	n/a	52489.9545	show_face	unfamiliar_face	delayed_repeat	15	u023.bmp
-210.9516363636	n/a	52737.9091	show_circle	n/a	n/a	0	circle.bmp
-212.6516363636	n/a	53162.9091	show_cross	n/a	n/a	n/a	cross.bmp
-213.1670909091	n/a	53291.7727	show_face	scrambled_face	first_show	17	s143.bmp
-213.8752727273	n/a	53468.8182	right_press	n/a	n/a	4096	n/a
-214.0361818182	n/a	53509.0455	show_circle	n/a	n/a	0	circle.bmp
-215.7361818182	n/a	53934.0455	show_cross	n/a	n/a	n/a	cross.bmp
-216.3743636364	n/a	54093.5909	show_face	scrambled_face	immediate_repeat	18	s143.bmp
-216.9480000000	n/a	54237	right_press	n/a	n/a	4096	n/a
-217.2252727273	n/a	54306.3182	show_circle	n/a	n/a	0	circle.bmp
-218.9252727273	n/a	54731.3182	show_cross	n/a	n/a	n/a	cross.bmp
-219.4816363636	n/a	54870.4091	show_face	unfamiliar_face	delayed_repeat	15	u041.bmp
-220.3507272727	n/a	55087.6818	right_press	n/a	n/a	4096	n/a
-220.4880000000	n/a	55122	show_circle	n/a	n/a	0	circle.bmp
-222.1880000000	n/a	55547	show_cross	n/a	n/a	n/a	cross.bmp
-222.7889090909	n/a	55697.2273	show_face	famous_face	first_show	5	f067.bmp
-223.7816363636	n/a	55945.4091	show_circle	n/a	n/a	0	circle.bmp
-225.4816363636	n/a	56370.4091	show_cross	n/a	n/a	n/a	cross.bmp
-226.0298181818	n/a	56507.4545	show_face	famous_face	first_show	5	f073.bmp
-227.0207272727	n/a	56755.1818	right_press	n/a	n/a	4096	n/a
-227.0243636364	n/a	56756.0909	show_circle	n/a	n/a	0	circle.bmp
-228.7243636364	n/a	57181.0909	show_cross	n/a	n/a	n/a	cross.bmp
-229.2370909091	n/a	57309.2727	show_face	famous_face	immediate_repeat	6	f073.bmp
-230.1698181818	n/a	57542.4545	show_circle	n/a	n/a	0	circle.bmp
-231.8698181818	n/a	57967.4545	show_cross	n/a	n/a	n/a	cross.bmp
-232.4943636364	n/a	58123.5909	show_face	famous_face	delayed_repeat	7	f146.bmp
-233.4525454545	n/a	58363.1364	show_circle	n/a	n/a	0	circle.bmp
-235.1525454545	n/a	58788.1364	show_cross	n/a	n/a	n/a	cross.bmp
-235.6352727273	n/a	58908.8182	show_face	scrambled_face	first_show	17	s057.bmp
-236.4252727273	n/a	59106.3182	right_press	n/a	n/a	4096	n/a
-236.4598181818	n/a	59114.9545	show_circle	n/a	n/a	0	circle.bmp
-238.1598181818	n/a	59539.9545	show_cross	n/a	n/a	n/a	cross.bmp
-238.6752727273	n/a	59668.8182	show_face	scrambled_face	first_show	17	s077.bmp
-239.5370909091	n/a	59884.2727	right_press	n/a	n/a	4096	n/a
-239.6689090909	n/a	59917.2273	show_circle	n/a	n/a	0	circle.bmp
-241.3689090909	n/a	60342.2273	show_cross	n/a	n/a	n/a	cross.bmp
-241.9161818182	n/a	60479.0455	show_face	unfamiliar_face	delayed_repeat	15	u146.bmp
-242.7816363636	n/a	60695.4091	right_press	n/a	n/a	4096	n/a
-242.9280000000	n/a	60732	show_circle	n/a	n/a	0	circle.bmp
-244.6280000000	n/a	61157	show_cross	n/a	n/a	n/a	cross.bmp
-245.2743636364	n/a	61318.5909	show_face	famous_face	first_show	5	f055.bmp
-246.0552727273	n/a	61513.8182	right_press	n/a	n/a	4096	n/a
-246.1489090909	n/a	61537.2273	show_circle	n/a	n/a	0	circle.bmp
-247.8489090909	n/a	61962.2273	show_cross	n/a	n/a	n/a	cross.bmp
-248.4652727273	n/a	62116.3182	show_face	famous_face	immediate_repeat	6	f055.bmp
-249.0325454545	n/a	62258.1364	right_press	n/a	n/a	4096	n/a
-249.4380000000	n/a	62359.5	show_circle	n/a	n/a	0	circle.bmp
-251.1380000000	n/a	62784.5	show_cross	n/a	n/a	n/a	cross.bmp
-251.6225454545	n/a	62905.6364	show_face	famous_face	first_show	5	f068.bmp
-252.5261818182	n/a	63131.5455	show_circle	n/a	n/a	0	circle.bmp
-254.2261818182	n/a	63556.5455	show_cross	n/a	n/a	n/a	cross.bmp
-254.6961818182	n/a	63674.0455	show_face	famous_face	delayed_repeat	7	f067.bmp
-255.5243636364	n/a	63881.0909	show_circle	n/a	n/a	0	circle.bmp
-257.2243636364	n/a	64306.0909	show_cross	n/a	n/a	n/a	cross.bmp
-257.7361818182	n/a	64434.0455	show_face	scrambled_face	first_show	17	s009.bmp
-258.3698181818	n/a	64592.4545	right_press	n/a	n/a	4096	n/a
-258.7316363636	n/a	64682.9091	show_circle	n/a	n/a	0	circle.bmp
-260.4316363636	n/a	65107.9091	show_cross	n/a	n/a	n/a	cross.bmp
-261.0770909091	n/a	65269.2727	show_face	scrambled_face	immediate_repeat	18	s009.bmp
-261.9652727273	n/a	65491.3182	show_circle	n/a	n/a	0	circle.bmp
-263.6652727273	n/a	65916.3182	show_cross	n/a	n/a	n/a	cross.bmp
-264.3180000000	n/a	66079.5	show_face	scrambled_face	first_show	17	s031.bmp
-265.1716363636	n/a	66292.9091	show_circle	n/a	n/a	0	circle.bmp
-266.8716363636	n/a	66717.9091	show_cross	n/a	n/a	n/a	cross.bmp
-267.4416363636	n/a	66860.4091	show_face	scrambled_face	delayed_repeat	19	s057.bmp
-268.2425454545	n/a	67060.6364	right_press	n/a	n/a	4096	n/a
-268.3580000000	n/a	67089.5	show_circle	n/a	n/a	0	circle.bmp
-270.0580000000	n/a	67514.5	show_cross	n/a	n/a	n/a	cross.bmp
-270.5152727273	n/a	67628.8182	show_face	scrambled_face	first_show	17	s021.bmp
-271.4134545455	n/a	67853.3636	right_press	n/a	n/a	4096	n/a
-271.4834545455	n/a	67870.8636	show_circle	n/a	n/a	0	circle.bmp
-273.1834545455	n/a	68295.8636	show_cross	n/a	n/a	n/a	cross.bmp
-273.7561818182	n/a	68439.0455	show_face	scrambled_face	delayed_repeat	19	s077.bmp
-274.7398181818	n/a	68684.9545	show_circle	n/a	n/a	0	circle.bmp
-274.8552727273	n/a	68713.8182	right_press	n/a	n/a	4096	n/a
-276.4398181818	n/a	69109.9545	show_cross	n/a	n/a	n/a	cross.bmp
-276.9970909091	n/a	69249.2727	show_face	unfamiliar_face	first_show	13	u063.bmp
-277.8761818182	n/a	69469.0455	show_circle	n/a	n/a	0	circle.bmp
-279.5761818182	n/a	69894.0455	show_cross	n/a	n/a	n/a	cross.bmp
-280.2043636364	n/a	70051.0909	show_face	unfamiliar_face	first_show	13	u149.bmp
-281.1325454545	n/a	70283.1364	show_circle	n/a	n/a	0	circle.bmp
-282.8325454545	n/a	70708.1364	show_cross	n/a	n/a	n/a	cross.bmp
-283.3289090909	n/a	70832.2273	show_face	famous_face	delayed_repeat	7	f068.bmp
-284.2452727273	n/a	71061.3182	show_circle	n/a	n/a	0	circle.bmp
-285.9452727273	n/a	71486.3182	show_cross	n/a	n/a	n/a	cross.bmp
-286.5689090909	n/a	71642.2273	show_face	famous_face	first_show	5	f015.bmp
-287.2134545455	n/a	71803.3636	right_press	n/a	n/a	4096	n/a
-287.5125454545	n/a	71878.1364	show_circle	n/a	n/a	0	circle.bmp
-289.2125454545	n/a	72303.1364	show_cross	n/a	n/a	n/a	cross.bmp
-289.8434545455	n/a	72460.8636	show_face	famous_face	first_show	5	f031.bmp
-290.4725454545	n/a	72618.1364	right_press	n/a	n/a	4096	n/a
-290.7770909091	n/a	72694.2727	show_circle	n/a	n/a	0	circle.bmp
-292.4770909091	n/a	73119.2727	show_cross	n/a	n/a	n/a	cross.bmp
-292.9507272727	n/a	73237.6818	show_face	famous_face	immediate_repeat	6	f031.bmp
-293.5480000000	n/a	73387	right_press	n/a	n/a	4096	n/a
-293.9425454545	n/a	73485.6364	show_circle	n/a	n/a	0	circle.bmp
-295.6425454545	n/a	73910.6364	show_cross	n/a	n/a	n/a	cross.bmp
-296.1080000000	n/a	74027	show_face	scrambled_face	delayed_repeat	19	s031.bmp
-297.0907272727	n/a	74272.6818	show_circle	n/a	n/a	0	circle.bmp
-298.7907272727	n/a	74697.6818	show_cross	n/a	n/a	n/a	cross.bmp
-299.3489090909	n/a	74837.2273	show_face	unfamiliar_face	first_show	13	u099.bmp
-300.3116363636	n/a	75077.9091	right_press	n/a	n/a	4096	n/a
-300.3561818182	n/a	75089.0455	show_circle	n/a	n/a	0	circle.bmp
-302.0561818182	n/a	75514.0455	show_cross	n/a	n/a	n/a	cross.bmp
-302.5561818182	n/a	75639.0455	show_face	unfamiliar_face	immediate_repeat	14	u099.bmp
-303.4189090909	n/a	75854.7273	show_circle	n/a	n/a	0	circle.bmp
-303.4652727273	n/a	75866.3182	right_press	n/a	n/a	4096	n/a
-305.1189090909	n/a	76279.7273	show_cross	n/a	n/a	n/a	cross.bmp
-305.6798181818	n/a	76419.9545	show_face	scrambled_face	delayed_repeat	19	s021.bmp
-306.5734545455	n/a	76643.3636	show_circle	n/a	n/a	0	circle.bmp
-308.2734545455	n/a	77068.3636	show_cross	n/a	n/a	n/a	cross.bmp
-308.8034545455	n/a	77200.8636	show_face	famous_face	first_show	5	f024.bmp
-309.6943636364	n/a	77423.5909	show_circle	n/a	n/a	0	circle.bmp
-311.3943636364	n/a	77848.5909	show_cross	n/a	n/a	n/a	cross.bmp
-311.9107272727	n/a	77977.6818	show_face	famous_face	immediate_repeat	6	f024.bmp
-312.7861818182	n/a	78196.5455	show_circle	n/a	n/a	0	circle.bmp
-314.4861818182	n/a	78621.5455	show_cross	n/a	n/a	n/a	cross.bmp
-315.0180000000	n/a	78754.5	show_face	unfamiliar_face	delayed_repeat	15	u063.bmp
-315.8734545455	n/a	78968.3636	show_circle	n/a	n/a	0	circle.bmp
-317.5734545455	n/a	79393.3636	show_cross	n/a	n/a	n/a	cross.bmp
-318.1089090909	n/a	79527.2273	show_face	unfamiliar_face	first_show	13	u056.bmp
-318.6334545455	n/a	79658.3636	left_press	n/a	n/a	256	n/a
-318.9925454545	n/a	79748.1364	show_circle	n/a	n/a	0	circle.bmp
-320.6925454545	n/a	80173.1364	show_cross	n/a	n/a	n/a	cross.bmp
-321.3325454545	n/a	80333.1364	show_face	unfamiliar_face	immediate_repeat	14	u056.bmp
-321.9716363636	n/a	80492.9091	left_press	n/a	n/a	256	n/a
-322.1970909091	n/a	80549.2727	show_circle	n/a	n/a	0	circle.bmp
-323.8970909091	n/a	80974.2727	show_cross	n/a	n/a	n/a	cross.bmp
-324.5234545455	n/a	81130.8636	show_face	unfamiliar_face	delayed_repeat	15	u149.bmp
-325.1670909091	n/a	81291.7727	right_press	n/a	n/a	4096	n/a
-325.4398181818	n/a	81359.9545	show_circle	n/a	n/a	0	circle.bmp
-327.1398181818	n/a	81784.9545	show_cross	n/a	n/a	n/a	cross.bmp
-327.7643636364	n/a	81941.0909	show_face	scrambled_face	first_show	17	s066.bmp
-328.3352727273	n/a	82083.8182	right_press	n/a	n/a	4096	n/a
-328.7780000000	n/a	82194.5	show_circle	n/a	n/a	0	circle.bmp
-330.4780000000	n/a	82619.5	show_cross	n/a	n/a	n/a	cross.bmp
-330.9880000000	n/a	82747	show_face	scrambled_face	immediate_repeat	18	s066.bmp
-331.9534545455	n/a	82988.3636	show_circle	n/a	n/a	0	circle.bmp
-333.6534545455	n/a	83413.3636	show_cross	n/a	n/a	n/a	cross.bmp
-334.1289090909	n/a	83532.2273	show_face	famous_face	delayed_repeat	7	f015.bmp
-334.7725454545	n/a	83693.1364	right_press	n/a	n/a	4096	n/a
-334.9889090909	n/a	83747.2273	show_circle	n/a	n/a	0	circle.bmp
-336.6889090909	n/a	84172.2273	show_cross	n/a	n/a	n/a	cross.bmp
-337.1689090909	n/a	84292.2273	show_face	famous_face	first_show	5	f053.bmp
-338.0161818182	n/a	84504.0455	show_circle	n/a	n/a	0	circle.bmp
-339.7161818182	n/a	84929.0455	show_cross	n/a	n/a	n/a	cross.bmp
-340.2761818182	n/a	85069.0455	show_face	famous_face	immediate_repeat	6	f053.bmp
-341.2652727273	n/a	85316.3182	show_circle	n/a	n/a	0	circle.bmp
-342.9652727273	n/a	85741.3182	show_cross	n/a	n/a	n/a	cross.bmp
-343.6170909091	n/a	85904.2727	show_face	scrambled_face	first_show	17	s045.bmp
-344.3807272727	n/a	86095.1818	right_press	n/a	n/a	4096	n/a
-344.5607272727	n/a	86140.1818	show_circle	n/a	n/a	0	circle.bmp
-346.2607272727	n/a	86565.1818	show_cross	n/a	n/a	n/a	cross.bmp
-346.8580000000	n/a	86714.5	show_face	unfamiliar_face	first_show	13	u057.bmp
-347.7125454545	n/a	86928.1364	show_circle	n/a	n/a	0	circle.bmp
-349.4125454545	n/a	87353.1364	show_cross	n/a	n/a	n/a	cross.bmp
-349.8816363636	n/a	87470.4091	show_face	unfamiliar_face	immediate_repeat	14	u057.bmp
-350.7961818182	n/a	87699.0455	show_circle	n/a	n/a	0	circle.bmp
-352.4961818182	n/a	88124.0455	show_cross	n/a	n/a	n/a	cross.bmp
-353.0061818182	n/a	88251.5455	show_face	famous_face	first_show	5	f082.bmp
-353.6861818182	n/a	88421.5455	right_press	n/a	n/a	4096	n/a
-353.9816363636	n/a	88495.4091	show_circle	n/a	n/a	0	circle.bmp
-355.6816363636	n/a	88920.4091	show_cross	n/a	n/a	n/a	cross.bmp
-356.1461818182	n/a	89036.5455	show_face	scrambled_face	first_show	17	s124.bmp
-357.0198181818	n/a	89254.9545	show_circle	n/a	n/a	0	circle.bmp
-358.7198181818	n/a	89679.9545	show_cross	n/a	n/a	n/a	cross.bmp
-359.3207272727	n/a	89830.1818	show_face	unfamiliar_face	first_show	13	u069.bmp
-360.0952727273	n/a	90023.8182	right_press	n/a	n/a	4096	n/a
-360.2552727273	n/a	90063.8182	show_circle	n/a	n/a	0	circle.bmp
-361.9552727273	n/a	90488.8182	show_cross	n/a	n/a	n/a	cross.bmp
-362.4943636364	n/a	90623.5909	show_face	scrambled_face	first_show	17	s148.bmp
-363.5089090909	n/a	90877.2273	show_circle	n/a	n/a	0	circle.bmp
-365.2089090909	n/a	91302.2273	show_cross	n/a	n/a	n/a	cross.bmp
-365.8352727273	n/a	91458.8182	show_face	scrambled_face	immediate_repeat	18	s148.bmp
-366.6707272727	n/a	91667.6818	show_circle	n/a	n/a	0	circle.bmp
-368.3707272727	n/a	92092.6818	show_cross	n/a	n/a	n/a	cross.bmp
-368.9589090909	n/a	92239.7273	show_face	scrambled_face	delayed_repeat	19	s045.bmp
-369.8280000000	n/a	92457	show_circle	n/a	n/a	0	circle.bmp
-370.0289090909	n/a	92507.2273	right_press	n/a	n/a	4096	n/a
-371.5280000000	n/a	92882	show_cross	n/a	n/a	n/a	cross.bmp
-372.0161818182	n/a	93004.0455	show_face	scrambled_face	first_show	17	s108.bmp
-372.8434545455	n/a	93210.8636	show_circle	n/a	n/a	0	circle.bmp
-372.9116363636	n/a	93227.9091	right_press	n/a	n/a	4096	n/a
-374.5434545455	n/a	93635.8636	show_cross	n/a	n/a	n/a	cross.bmp
-375.0898181818	n/a	93772.4545	show_face	famous_face	first_show	5	f147.bmp
-375.8225454545	n/a	93955.6364	right_press	n/a	n/a	4096	n/a
-375.9161818182	n/a	93979.0455	show_circle	n/a	n/a	0	circle.bmp
-377.6161818182	n/a	94404.0455	show_cross	n/a	n/a	n/a	cross.bmp
-378.2470909091	n/a	94561.7727	show_face	famous_face	delayed_repeat	7	f082.bmp
-378.9843636364	n/a	94746.0909	right_press	n/a	n/a	4096	n/a
-379.1389090909	n/a	94784.7273	show_circle	n/a	n/a	0	circle.bmp
-380.8389090909	n/a	95209.7273	show_cross	n/a	n/a	n/a	cross.bmp
-381.4880000000	n/a	95372	show_face	unfamiliar_face	first_show	13	u031.bmp
-382.1125454545	n/a	95528.1364	right_press	n/a	n/a	4096	n/a
-382.4280000000	n/a	95607	show_circle	n/a	n/a	0	circle.bmp
-384.1280000000	n/a	96032	show_cross	n/a	n/a	n/a	cross.bmp
-384.6289090909	n/a	96157.2273	show_face	scrambled_face	delayed_repeat	19	s124.bmp
-385.4325454545	n/a	96358.1364	right_press	n/a	n/a	4096	n/a
-385.5880000000	n/a	96397	show_circle	n/a	n/a	0	circle.bmp
-387.2880000000	n/a	96822	show_cross	n/a	n/a	n/a	cross.bmp
-387.7861818182	n/a	96946.5455	show_face	scrambled_face	first_show	17	s024.bmp
-388.2798181818	n/a	97069.9545	right_press	n/a	n/a	4096	n/a
-388.6316363636	n/a	97157.9091	show_circle	n/a	n/a	0	circle.bmp
-390.3316363636	n/a	97582.9091	show_cross	n/a	n/a	n/a	cross.bmp
-390.8598181818	n/a	97714.9545	show_face	scrambled_face	immediate_repeat	18	s024.bmp
-391.4252727273	n/a	97856.3182	right_press	n/a	n/a	4096	n/a
-391.7107272727	n/a	97927.6818	show_circle	n/a	n/a	0	circle.bmp
-393.4107272727	n/a	98352.6818	show_cross	n/a	n/a	n/a	cross.bmp
-393.9498181818	n/a	98487.4545	show_face	unfamiliar_face	delayed_repeat	15	u069.bmp
-394.7789090909	n/a	98694.7273	show_circle	n/a	n/a	0	circle.bmp
-396.4789090909	n/a	99119.7273	show_cross	n/a	n/a	n/a	cross.bmp
-397.0070909091	n/a	99251.7727	show_face	scrambled_face	first_show	17	s018.bmp
-397.8552727273	n/a	99463.8182	show_circle	n/a	n/a	0	circle.bmp
-399.5552727273	n/a	99888.8182	show_cross	n/a	n/a	n/a	cross.bmp
-400.1480000000	n/a	100037	show_face	famous_face	first_show	5	f105.bmp
-400.8098181818	n/a	100202.4545	right_press	n/a	n/a	4096	n/a
-401.1552727273	n/a	100288.8182	show_circle	n/a	n/a	0	circle.bmp
-402.8552727273	n/a	100713.8182	show_cross	n/a	n/a	n/a	cross.bmp
-403.4716363636	n/a	100867.9091	show_face	famous_face	immediate_repeat	6	f105.bmp
-404.0398181818	n/a	101009.9545	right_press	n/a	n/a	4096	n/a
-404.3434545455	n/a	101085.8636	show_circle	n/a	n/a	0	circle.bmp
-406.0434545455	n/a	101510.8636	show_cross	n/a	n/a	n/a	cross.bmp
-406.6798181818	n/a	101669.9545	show_face	scrambled_face	delayed_repeat	19	s108.bmp
-407.1625454545	n/a	101790.6364	right_press	n/a	n/a	4096	n/a
-407.6270909091	n/a	101906.7727	show_circle	n/a	n/a	0	circle.bmp
-409.3270909091	n/a	102331.7727	show_cross	n/a	n/a	n/a	cross.bmp
-409.9034545455	n/a	102475.8636	show_face	scrambled_face	first_show	17	s099.bmp
-410.5834545455	n/a	102645.8636	right_press	n/a	n/a	4096	n/a
-410.8925454545	n/a	102723.1364	show_circle	n/a	n/a	0	circle.bmp
-412.5925454545	n/a	103148.1364	show_cross	n/a	n/a	n/a	cross.bmp
-413.1607272727	n/a	103290.1818	show_face	famous_face	delayed_repeat	7	f147.bmp
-414.0643636364	n/a	103516.0909	show_circle	n/a	n/a	0	circle.bmp
-415.7643636364	n/a	103941.0909	show_cross	n/a	n/a	n/a	cross.bmp
-416.3352727273	n/a	104083.8182	show_face	famous_face	first_show	5	f135.bmp
-417.1689090909	n/a	104292.2273	show_circle	n/a	n/a	0	circle.bmp
-418.8689090909	n/a	104717.2273	show_cross	n/a	n/a	n/a	cross.bmp
-419.4752727273	n/a	104868.8182	show_face	famous_face	immediate_repeat	6	f135.bmp
-420.4107272727	n/a	105102.6818	show_circle	n/a	n/a	0	circle.bmp
-422.1107272727	n/a	105527.6818	show_cross	n/a	n/a	n/a	cross.bmp
-422.7343636364	n/a	105683.5909	show_face	unfamiliar_face	delayed_repeat	15	u031.bmp
-423.6461818182	n/a	105911.5455	show_circle	n/a	n/a	0	circle.bmp
-425.3461818182	n/a	106336.5455	show_cross	n/a	n/a	n/a	cross.bmp
-425.8907272727	n/a	106472.6818	show_face	scrambled_face	first_show	17	s146.bmp
-426.4880000000	n/a	106622	right_press	n/a	n/a	4096	n/a
-426.8007272727	n/a	106700.1818	show_circle	n/a	n/a	0	circle.bmp
-428.5007272727	n/a	107125.1818	show_cross	n/a	n/a	n/a	cross.bmp
-428.9980000000	n/a	107249.5	show_face	scrambled_face	immediate_repeat	18	s146.bmp
-429.5898181818	n/a	107397.4545	right_press	n/a	n/a	4096	n/a
-429.9198181818	n/a	107479.9545	show_circle	n/a	n/a	0	circle.bmp
-431.6198181818	n/a	107904.9545	show_cross	n/a	n/a	n/a	cross.bmp
-432.1552727273	n/a	108038.8182	show_face	unfamiliar_face	first_show	13	u127.bmp
-433.0389090909	n/a	108259.7273	show_circle	n/a	n/a	0	circle.bmp
-434.7389090909	n/a	108684.7273	show_cross	n/a	n/a	n/a	cross.bmp
-435.3625454545	n/a	108840.6364	show_face	scrambled_face	delayed_repeat	19	s018.bmp
-435.9325454545	n/a	108983.1364	right_press	n/a	n/a	4096	n/a
-436.2952727273	n/a	109073.8182	show_circle	n/a	n/a	0	circle.bmp
-437.9952727273	n/a	109498.8182	show_cross	n/a	n/a	n/a	cross.bmp
-438.5025454545	n/a	109625.6364	show_face	scrambled_face	first_show	17	s113.bmp
-439.3552727273	n/a	109838.8182	right_press	n/a	n/a	4096	n/a
-439.4270909091	n/a	109856.7727	show_circle	n/a	n/a	0	circle.bmp
-441.1270909091	n/a	110281.7727	show_cross	n/a	n/a	n/a	cross.bmp
-441.7434545455	n/a	110435.8636	show_face	famous_face	first_show	5	f110.bmp
-442.6398181818	n/a	110659.9545	show_circle	n/a	n/a	0	circle.bmp
-444.3398181818	n/a	111084.9545	show_cross	n/a	n/a	n/a	cross.bmp
-444.9843636364	n/a	111246.0909	show_face	scrambled_face	delayed_repeat	19	s099.bmp
-445.7861818182	n/a	111446.5455	right_press	n/a	n/a	4096	n/a
-445.8261818182	n/a	111456.5455	show_circle	n/a	n/a	0	circle.bmp
-447.5261818182	n/a	111881.5455	show_cross	n/a	n/a	n/a	cross.bmp
-448.0580000000	n/a	112014.5	show_face	unfamiliar_face	first_show	13	u098.bmp
-448.7525454545	n/a	112188.1364	right_press	n/a	n/a	4096	n/a
-448.9834545455	n/a	112245.8636	show_circle	n/a	n/a	0	circle.bmp
-450.6834545455	n/a	112670.8636	show_cross	n/a	n/a	n/a	cross.bmp
-451.1489090909	n/a	112787.2273	show_face	unfamiliar_face	immediate_repeat	14	u098.bmp
-451.7270909091	n/a	112931.7727	right_press	n/a	n/a	4096	n/a
-452.1134545455	n/a	113028.3636	show_circle	n/a	n/a	0	circle.bmp
-453.8134545455	n/a	113453.3636	show_cross	n/a	n/a	n/a	cross.bmp
-454.4725454545	n/a	113618.1364	show_face	famous_face	first_show	5	f027.bmp
-455.3161818182	n/a	113829.0455	show_circle	n/a	n/a	0	circle.bmp
-457.0161818182	n/a	114254.0455	show_cross	n/a	n/a	n/a	cross.bmp
-457.5298181818	n/a	114382.4545	show_face	unfamiliar_face	first_show	13	u064.bmp
-458.1907272727	n/a	114547.6818	right_press	n/a	n/a	4096	n/a
-458.5161818182	n/a	114629.0455	show_circle	n/a	n/a	0	circle.bmp
-460.2161818182	n/a	115054.0455	show_cross	n/a	n/a	n/a	cross.bmp
-460.7370909091	n/a	115184.2727	show_face	unfamiliar_face	immediate_repeat	14	u064.bmp
-461.3543636364	n/a	115338.5909	right_press	n/a	n/a	4096	n/a
-461.7116363636	n/a	115427.9091	show_circle	n/a	n/a	0	circle.bmp
-463.4116363636	n/a	115852.9091	show_cross	n/a	n/a	n/a	cross.bmp
-463.9780000000	n/a	115994.5	show_face	unfamiliar_face	delayed_repeat	15	u127.bmp
-464.8325454545	n/a	116208.1364	show_circle	n/a	n/a	0	circle.bmp
-466.5325454545	n/a	116633.1364	show_cross	n/a	n/a	n/a	cross.bmp
-467.1189090909	n/a	116779.7273	show_face	unfamiliar_face	first_show	13	u089.bmp
-467.7916363636	n/a	116947.9091	right_press	n/a	n/a	4096	n/a
-467.9598181818	n/a	116989.9545	show_circle	n/a	n/a	0	circle.bmp
-469.6598181818	n/a	117414.9545	show_cross	n/a	n/a	n/a	cross.bmp
-470.2434545455	n/a	117560.8636	show_face	unfamiliar_face	immediate_repeat	14	u089.bmp
-470.7743636364	n/a	117693.5909	right_press	n/a	n/a	4096	n/a
-471.2361818182	n/a	117809.0455	show_circle	n/a	n/a	0	circle.bmp
-472.9361818182	n/a	118234.0455	show_cross	n/a	n/a	n/a	cross.bmp
-473.4334545455	n/a	118358.3636	show_face	scrambled_face	delayed_repeat	19	s113.bmp
-474.2361818182	n/a	118559.0455	right_press	n/a	n/a	4096	n/a
-474.4216363636	n/a	118605.4091	show_circle	n/a	n/a	0	circle.bmp
-476.1216363636	n/a	119030.4091	show_cross	n/a	n/a	n/a	cross.bmp
-476.7070909091	n/a	119176.7727	show_face	unfamiliar_face	first_show	13	u136.bmp
-477.6798181818	n/a	119419.9545	show_circle	n/a	n/a	0	circle.bmp
-479.3798181818	n/a	119844.9545	show_cross	n/a	n/a	n/a	cross.bmp
-479.9980000000	n/a	119999.5	show_face	unfamiliar_face	immediate_repeat	14	u136.bmp
-480.8925454545	n/a	120223.1364	show_circle	n/a	n/a	0	circle.bmp
-482.5925454545	n/a	120648.1364	show_cross	n/a	n/a	n/a	cross.bmp
-483.0552727273	n/a	120763.8182	show_face	famous_face	delayed_repeat	7	f110.bmp
-483.9461818182	n/a	120986.5455	show_circle	n/a	n/a	0	circle.bmp
-485.6461818182	n/a	121411.5455	show_cross	n/a	n/a	n/a	cross.bmp
-486.1461818182	n/a	121536.5455	show_face	scrambled_face	first_show	17	s011.bmp
-487.1007272727	n/a	121775.1818	show_circle	n/a	n/a	0	circle.bmp
-488.8007272727	n/a	122200.1818	show_cross	n/a	n/a	n/a	cross.bmp
-489.4370909091	n/a	122359.2727	show_face	scrambled_face	immediate_repeat	18	s011.bmp
-490.4498181818	n/a	122612.4545	show_circle	n/a	n/a	0	circle.bmp
-492.1498181818	n/a	123037.4545	show_cross	n/a	n/a	n/a	cross.bmp
-492.7943636364	n/a	123198.5909	show_face	unfamiliar_face	first_show	13	u145.bmp
-493.5007272727	n/a	123375.1818	right_press	n/a	n/a	4096	n/a
-493.6225454545	n/a	123405.6364	show_circle	n/a	n/a	0	circle.bmp
-495.3225454545	n/a	123830.6364	show_cross	n/a	n/a	n/a	cross.bmp
-495.8180000000	n/a	123954.5	show_face	unfamiliar_face	immediate_repeat	14	u145.bmp
-496.4516363636	n/a	124112.9091	right_press	n/a	n/a	4096	n/a
-496.6634545455	n/a	124165.8636	show_circle	n/a	n/a	0	circle.bmp
-498.3634545455	n/a	124590.8636	show_cross	n/a	n/a	n/a	cross.bmp
-498.8752727273	n/a	124718.8182	show_face	famous_face	delayed_repeat	7	f027.bmp
-499.7898181818	n/a	124947.4545	show_circle	n/a	n/a	0	circle.bmp
-501.4898181818	n/a	125372.4545	show_cross	n/a	n/a	n/a	cross.bmp
+onset	duration	sample	event_type	face_type	repetition_type	trial	trial_lag	trigger	stim_file
+0.004	n/a	1.0	setup	n/a	n/a	n/a	n/a	n/a	n/a
+0.004	n/a	1.0	right_sym	n/a	n/a	n/a	n/a	n/a	n/a
+24.5989090909	n/a	6149.7273	show_face	unfamiliar_face	first_show	1	n/a	13	u097.bmp
+25.3198181818	n/a	6329.9545	right_press	n/a	n/a	1	n/a	4096	n/a
+25.432545454499998	n/a	6358.1364	show_circle	n/a	n/a	1	n/a	0	circle.bmp
+27.132545454499997	n/a	6783.1364	show_cross	n/a	n/a	2	n/a	n/a	cross.bmp
+27.6225454545	n/a	6905.6364	show_face	unfamiliar_face	immediate_repeat	2	1	14	u097.bmp
+28.1198181818	n/a	7029.9545	right_press	n/a	n/a	2	n/a	4096	n/a
+28.5952727273	n/a	7148.8182	show_circle	n/a	n/a	2	n/a	0	circle.bmp
+30.2952727273	n/a	7573.8182	show_cross	n/a	n/a	3	n/a	n/a	cross.bmp
+30.879818181799997	n/a	7719.9545	show_face	famous_face	first_show	3	n/a	5	f103.bmp
+31.562545454499997	n/a	7890.6364	right_press	n/a	n/a	3	n/a	4096	n/a
+31.8161818182	n/a	7954.0455	show_circle	n/a	n/a	3	n/a	0	circle.bmp
+33.5161818182	n/a	8379.0455	show_cross	n/a	n/a	4	n/a	n/a	cross.bmp
+34.0543636364	n/a	8513.5909	show_face	famous_face	immediate_repeat	4	1	6	f103.bmp
+34.6689090909	n/a	8667.2273	right_press	n/a	n/a	4	n/a	4096	n/a
+34.9870909091	n/a	8746.7727	show_circle	n/a	n/a	4	n/a	0	circle.bmp
+36.6870909091	n/a	9171.7727	show_cross	n/a	n/a	5	n/a	n/a	cross.bmp
+37.3116363636	n/a	9327.9091	show_face	unfamiliar_face	first_show	5	n/a	13	u112.bmp
+38.2052727273	n/a	9551.3182	show_circle	n/a	n/a	5	n/a	0	circle.bmp
+39.9052727273	n/a	9976.3182	show_cross	n/a	n/a	6	n/a	n/a	cross.bmp
+40.368909090900004	n/a	10092.2273	show_face	famous_face	first_show	6	n/a	5	f130.bmp
+40.9825454545	n/a	10245.6364	right_press	n/a	n/a	6	n/a	4096	n/a
+41.3807272727	n/a	10345.1818	show_circle	n/a	n/a	6	n/a	0	circle.bmp
+43.0807272727	n/a	10770.1818	show_cross	n/a	n/a	7	n/a	n/a	cross.bmp
+43.5589090909	n/a	10889.7273	show_face	famous_face	first_show	7	n/a	5	f004.bmp
+44.558	n/a	11139.5	show_circle	n/a	n/a	7	n/a	0	circle.bmp
+46.258	n/a	11564.5	show_cross	n/a	n/a	8	n/a	n/a	cross.bmp
+46.8670909091	n/a	11716.7727	show_face	famous_face	immediate_repeat	8	1	6	f004.bmp
+47.780727272700005	n/a	11945.1818	show_circle	n/a	n/a	8	n/a	0	circle.bmp
+49.4807272727	n/a	12370.1818	show_cross	n/a	n/a	9	n/a	n/a	cross.bmp
+49.957090909099996	n/a	12489.2727	show_face	unfamiliar_face	first_show	9	n/a	13	u111.bmp
+50.5534545455	n/a	12638.3636	right_press	n/a	n/a	9	n/a	4096	n/a
+50.9643636364	n/a	12741.0909	show_circle	n/a	n/a	9	n/a	0	circle.bmp
+52.664363636400005	n/a	13166.0909	show_cross	n/a	n/a	10	n/a	n/a	cross.bmp
+53.265272727299994	n/a	13316.3182	show_face	unfamiliar_face	immediate_repeat	10	1	14	u111.bmp
+53.8561818182	n/a	13464.0455	right_press	n/a	n/a	10	n/a	4096	n/a
+54.2161818182	n/a	13554.0455	show_circle	n/a	n/a	10	n/a	0	circle.bmp
+55.916181818199995	n/a	13979.0455	show_cross	n/a	n/a	11	n/a	n/a	cross.bmp
+56.5225454545	n/a	14130.6364	show_face	famous_face	first_show	11	n/a	5	f025.bmp
+57.48527272729999	n/a	14371.3182	show_circle	n/a	n/a	11	n/a	0	circle.bmp
+59.185272727299996	n/a	14796.3182	show_cross	n/a	n/a	12	n/a	n/a	cross.bmp
+59.8298181818	n/a	14957.4545	show_face	scrambled_face	first_show	12	n/a	17	s111.bmp
+60.71163636359999	n/a	15177.9091	show_circle	n/a	n/a	12	n/a	0	circle.bmp
+62.411636363599996	n/a	15602.9091	show_cross	n/a	n/a	13	n/a	n/a	cross.bmp
+63.0043636364	n/a	15751.0909	show_face	scrambled_face	immediate_repeat	13	1	18	s111.bmp
+63.9534545455	n/a	15988.3636	show_circle	n/a	n/a	13	n/a	0	circle.bmp
+65.6534545455	n/a	16413.3636	show_cross	n/a	n/a	14	n/a	n/a	cross.bmp
+66.2116363636	n/a	16552.9091	show_face	unfamiliar_face	delayed_repeat	14	9	15	u112.bmp
+67.1134545455	n/a	16778.3636	show_circle	n/a	n/a	14	n/a	0	circle.bmp
+68.81345454550001	n/a	17203.3636	show_cross	n/a	n/a	15	n/a	n/a	cross.bmp
+69.2852727273	n/a	17321.3182	show_face	scrambled_face	first_show	15	n/a	17	s112.bmp
+70.2516363636	n/a	17562.9091	show_circle	n/a	n/a	15	n/a	0	circle.bmp
+71.9516363636	n/a	17987.9091	show_cross	n/a	n/a	16	n/a	n/a	cross.bmp
+72.5425454545	n/a	18135.6364	show_face	famous_face	delayed_repeat	16	10	7	f130.bmp
+73.0834545455	n/a	18270.8636	right_press	n/a	n/a	16	n/a	4096	n/a
+73.45345454550001	n/a	18363.3636	show_circle	n/a	n/a	16	n/a	0	circle.bmp
+75.1534545455	n/a	18788.3636	show_cross	n/a	n/a	17	n/a	n/a	cross.bmp
+75.74981818180001	n/a	18937.4545	show_face	scrambled_face	first_show	17	n/a	17	s115.bmp
+76.7543636364	n/a	19188.5909	show_circle	n/a	n/a	17	n/a	0	circle.bmp
+76.8561818182	n/a	19214.0455	right_press	n/a	n/a	17	n/a	4096	n/a
+78.4543636364	n/a	19613.5909	show_cross	n/a	n/a	18	n/a	n/a	cross.bmp
+78.9407272727	n/a	19735.1818	show_face	unfamiliar_face	first_show	18	n/a	13	u123.bmp
+79.82527272729999	n/a	19956.3182	show_circle	n/a	n/a	18	n/a	0	circle.bmp
+81.52527272729999	n/a	20381.3182	show_cross	n/a	n/a	19	n/a	n/a	cross.bmp
+82.0316363636	n/a	20507.9091	show_face	scrambled_face	first_show	19	n/a	17	s005.bmp
+82.708	n/a	20677.0	right_press	n/a	n/a	19	n/a	4096	n/a
+82.9961818182	n/a	20749.0455	show_circle	n/a	n/a	19	n/a	0	circle.bmp
+84.6961818182	n/a	21174.0455	show_cross	n/a	n/a	20	n/a	n/a	cross.bmp
+85.1716363636	n/a	21292.9091	show_face	scrambled_face	immediate_repeat	20	1	18	s005.bmp
+85.7807272727	n/a	21445.1818	right_press	n/a	n/a	20	n/a	4096	n/a
+86.09890909090001	n/a	21524.7273	show_circle	n/a	n/a	20	n/a	0	circle.bmp
+87.7989090909	n/a	21949.7273	show_cross	n/a	n/a	21	n/a	n/a	cross.bmp
+88.2952727273	n/a	22073.8182	show_face	famous_face	delayed_repeat	21	10	7	f025.bmp
+89.1589090909	n/a	22289.7273	show_circle	n/a	n/a	21	n/a	0	circle.bmp
+90.8589090909	n/a	22714.7273	show_cross	n/a	n/a	22	n/a	n/a	cross.bmp
+91.50345454549999	n/a	22875.8636	show_face	unfamiliar_face	first_show	22	n/a	13	u045.bmp
+92.38527272729999	n/a	23096.3182	show_circle	n/a	n/a	22	n/a	0	circle.bmp
+94.0852727273	n/a	23521.3182	show_cross	n/a	n/a	23	n/a	n/a	cross.bmp
+94.6270909091	n/a	23656.7727	show_face	unfamiliar_face	immediate_repeat	23	1	14	u045.bmp
+95.57072727270001	n/a	23892.6818	show_circle	n/a	n/a	23	n/a	0	circle.bmp
+97.2707272727	n/a	24317.6818	show_cross	n/a	n/a	24	n/a	n/a	cross.bmp
+97.818	n/a	24454.5	show_face	famous_face	first_show	24	n/a	5	f059.bmp
+98.5089090909	n/a	24627.2273	right_press	n/a	n/a	24	n/a	4096	n/a
+98.7143636364	n/a	24678.5909	show_circle	n/a	n/a	24	n/a	0	circle.bmp
+100.4143636364	n/a	25103.5909	show_cross	n/a	n/a	25	n/a	n/a	cross.bmp
+100.94163636360001	n/a	25235.4091	show_face	famous_face	immediate_repeat	25	1	6	f059.bmp
+101.5970909091	n/a	25399.2727	right_press	n/a	n/a	25	n/a	4096	n/a
+101.9198181818	n/a	25479.9545	show_circle	n/a	n/a	25	n/a	0	circle.bmp
+103.6198181818	n/a	25904.9545	show_cross	n/a	n/a	26	n/a	n/a	cross.bmp
+104.23254545450001	n/a	26058.1364	show_face	scrambled_face	delayed_repeat	26	11	19	s112.bmp
+104.8325454545	n/a	26208.1364	right_press	n/a	n/a	26	n/a	4096	n/a
+105.168	n/a	26292.0	show_circle	n/a	n/a	26	n/a	0	circle.bmp
+106.868	n/a	26717.0	show_cross	n/a	n/a	27	n/a	n/a	cross.bmp
+107.47345454549999	n/a	26868.3636	show_face	famous_face	first_show	27	n/a	5	f041.bmp
+108.1889090909	n/a	27047.2273	right_press	n/a	n/a	27	n/a	4096	n/a
+108.4498181818	n/a	27112.4545	show_circle	n/a	n/a	27	n/a	0	circle.bmp
+110.1498181818	n/a	27537.4545	show_cross	n/a	n/a	28	n/a	n/a	cross.bmp
+110.5970909091	n/a	27649.2727	show_face	scrambled_face	delayed_repeat	28	11	19	s115.bmp
+111.2870909091	n/a	27821.7727	right_press	n/a	n/a	28	n/a	4096	n/a
+111.43527272729999	n/a	27858.8182	show_circle	n/a	n/a	28	n/a	0	circle.bmp
+113.13527272729999	n/a	28283.8182	show_cross	n/a	n/a	29	n/a	n/a	cross.bmp
+113.738	n/a	28434.5	show_face	scrambled_face	first_show	29	n/a	17	s139.bmp
+114.4461818182	n/a	28611.5455	right_press	n/a	n/a	29	n/a	4096	n/a
+114.7461818182	n/a	28686.5455	show_circle	n/a	n/a	29	n/a	0	circle.bmp
+116.4461818182	n/a	29111.5455	show_cross	n/a	n/a	30	n/a	n/a	cross.bmp
+117.0952727273	n/a	29273.8182	show_face	scrambled_face	immediate_repeat	30	1	18	s139.bmp
+118.0598181818	n/a	29514.9545	show_circle	n/a	n/a	30	n/a	0	circle.bmp
+119.7598181818	n/a	29939.9545	show_cross	n/a	n/a	31	n/a	n/a	cross.bmp
+120.2698181818	n/a	30067.4545	show_face	unfamiliar_face	delayed_repeat	31	13	15	u123.bmp
+121.12436363639999	n/a	30281.0909	show_circle	n/a	n/a	31	n/a	0	circle.bmp
+122.8243636364	n/a	30706.0909	show_cross	n/a	n/a	32	n/a	n/a	cross.bmp
+123.3761818182	n/a	30844.0455	show_face	scrambled_face	first_show	32	n/a	17	s076.bmp
+124.1452727273	n/a	31036.3182	right_press	n/a	n/a	32	n/a	4096	n/a
+124.258	n/a	31064.5	show_circle	n/a	n/a	32	n/a	0	circle.bmp
+125.958	n/a	31489.5	show_cross	n/a	n/a	33	n/a	n/a	cross.bmp
+126.53345454549999	n/a	31633.3636	show_face	famous_face	first_show	33	n/a	5	f081.bmp
+127.4098181818	n/a	31852.4545	show_circle	n/a	n/a	33	n/a	0	circle.bmp
+127.4189090909	n/a	31854.7273	right_press	n/a	n/a	33	n/a	4096	n/a
+129.1098181818	n/a	32277.4545	show_cross	n/a	n/a	34	n/a	n/a	cross.bmp
+129.6907272727	n/a	32422.6818	show_face	famous_face	immediate_repeat	34	1	6	f081.bmp
+130.18345454549998	n/a	32545.8636	right_press	n/a	n/a	34	n/a	4096	n/a
+130.55436363639998	n/a	32638.5909	show_circle	n/a	n/a	34	n/a	0	circle.bmp
+132.2543636364	n/a	33063.5909	show_cross	n/a	n/a	35	n/a	n/a	cross.bmp
+132.73163636360002	n/a	33182.9091	show_face	famous_face	first_show	35	n/a	5	f141.bmp
+133.48163636360002	n/a	33370.4091	right_press	n/a	n/a	35	n/a	4096	n/a
+133.6643636364	n/a	33416.0909	show_circle	n/a	n/a	35	n/a	0	circle.bmp
+135.3643636364	n/a	33841.0909	show_cross	n/a	n/a	36	n/a	n/a	cross.bmp
+136.0052727273	n/a	34001.3182	show_face	scrambled_face	first_show	36	n/a	17	s137.bmp
+136.91254545450002	n/a	34228.1364	right_press	n/a	n/a	36	n/a	4096	n/a
+136.9370909091	n/a	34234.2727	show_circle	n/a	n/a	36	n/a	0	circle.bmp
+138.6370909091	n/a	34659.2727	show_cross	n/a	n/a	37	n/a	n/a	cross.bmp
+139.1125454545	n/a	34778.1364	show_face	famous_face	delayed_repeat	37	10	7	f041.bmp
+139.8934545455	n/a	34973.3636	right_press	n/a	n/a	37	n/a	4096	n/a
+140.0870909091	n/a	35021.7727	show_circle	n/a	n/a	37	n/a	0	circle.bmp
+141.7870909091	n/a	35446.7727	show_cross	n/a	n/a	38	n/a	n/a	cross.bmp
+142.4534545455	n/a	35613.3636	show_face	unfamiliar_face	first_show	38	n/a	13	u120.bmp
+143.4307272727	n/a	35857.6818	show_circle	n/a	n/a	38	n/a	0	circle.bmp
+145.1307272727	n/a	36282.6818	show_cross	n/a	n/a	39	n/a	n/a	cross.bmp
+145.74436363639998	n/a	36436.0909	show_face	unfamiliar_face	first_show	39	n/a	13	u002.bmp
+146.7252727273	n/a	36681.3182	show_circle	n/a	n/a	39	n/a	0	circle.bmp
+148.42527272729998	n/a	37106.3182	show_cross	n/a	n/a	40	n/a	n/a	cross.bmp
+149.0352727273	n/a	37258.8182	show_face	scrambled_face	delayed_repeat	40	8	19	s076.bmp
+149.8570909091	n/a	37464.2727	show_circle	n/a	n/a	40	n/a	0	circle.bmp
+151.5570909091	n/a	37889.2727	show_cross	n/a	n/a	41	n/a	n/a	cross.bmp
+152.1261818182	n/a	38031.5455	show_face	famous_face	first_show	41	n/a	5	f121.bmp
+153.0743636364	n/a	38268.5909	show_circle	n/a	n/a	41	n/a	0	circle.bmp
+154.77436363639998	n/a	38693.5909	show_cross	n/a	n/a	42	n/a	n/a	cross.bmp
+155.4007272727	n/a	38850.1818	show_face	famous_face	immediate_repeat	42	1	6	f121.bmp
+156.3989090909	n/a	39099.7273	show_circle	n/a	n/a	42	n/a	0	circle.bmp
+158.0989090909	n/a	39524.7273	show_cross	n/a	n/a	43	n/a	n/a	cross.bmp
+158.7416363636	n/a	39685.4091	show_face	unfamiliar_face	first_show	43	n/a	13	u018.bmp
+159.648	n/a	39912.0	show_circle	n/a	n/a	43	n/a	0	circle.bmp
+159.7498181818	n/a	39937.4545	right_press	n/a	n/a	43	n/a	4096	n/a
+161.348	n/a	40337.0	show_cross	n/a	n/a	44	n/a	n/a	cross.bmp
+161.9661818182	n/a	40491.5455	show_face	famous_face	delayed_repeat	44	9	7	f141.bmp
+162.8325454545	n/a	40708.1364	show_circle	n/a	n/a	44	n/a	0	circle.bmp
+162.8370909091	n/a	40709.2727	right_press	n/a	n/a	44	n/a	4096	n/a
+164.5325454545	n/a	41133.1364	show_cross	n/a	n/a	45	n/a	n/a	cross.bmp
+165.1725454545	n/a	41293.1364	show_face	unfamiliar_face	first_show	45	n/a	13	u014.bmp
+166.1261818182	n/a	41531.5455	show_circle	n/a	n/a	45	n/a	0	circle.bmp
+167.82618181819998	n/a	41956.5455	show_cross	n/a	n/a	46	n/a	n/a	cross.bmp
+168.448	n/a	42112.0	show_face	unfamiliar_face	immediate_repeat	46	1	14	u014.bmp
+169.3125454545	n/a	42328.1364	show_circle	n/a	n/a	46	n/a	0	circle.bmp
+171.0125454545	n/a	42753.1364	show_cross	n/a	n/a	47	n/a	n/a	cross.bmp
+171.5216363636	n/a	42880.4091	show_face	scrambled_face	delayed_repeat	47	11	19	s137.bmp
+172.218	n/a	43054.5	right_press	n/a	n/a	47	n/a	4096	n/a
+172.5052727273	n/a	43126.3182	show_circle	n/a	n/a	47	n/a	0	circle.bmp
+174.20527272729998	n/a	43551.3182	show_cross	n/a	n/a	48	n/a	n/a	cross.bmp
+174.728	n/a	43682.0	show_face	unfamiliar_face	first_show	48	n/a	13	u023.bmp
+175.5625454545	n/a	43890.6364	show_circle	n/a	n/a	48	n/a	0	circle.bmp
+177.2625454545	n/a	44315.6364	show_cross	n/a	n/a	49	n/a	n/a	cross.bmp
+177.8016363636	n/a	44450.4091	show_face	unfamiliar_face	delayed_repeat	49	11	15	u120.bmp
+178.7734545455	n/a	44693.3636	show_circle	n/a	n/a	49	n/a	0	circle.bmp
+180.4734545455	n/a	45118.3636	show_cross	n/a	n/a	50	n/a	n/a	cross.bmp
+181.07618181819998	n/a	45269.0455	show_face	unfamiliar_face	first_show	50	n/a	13	u041.bmp
+181.7389090909	n/a	45434.7273	right_press	n/a	n/a	50	n/a	4096	n/a
+182.0270909091	n/a	45506.7727	show_circle	n/a	n/a	50	n/a	0	circle.bmp
+183.72709090909999	n/a	45931.7727	show_cross	n/a	n/a	51	n/a	n/a	cross.bmp
+184.18345454549998	n/a	46045.8636	show_face	unfamiliar_face	delayed_repeat	51	12	15	u002.bmp
+185.1525454545	n/a	46288.1364	show_circle	n/a	n/a	51	n/a	0	circle.bmp
+186.85254545450002	n/a	46713.1364	show_cross	n/a	n/a	52	n/a	n/a	cross.bmp
+187.458	n/a	46864.5	show_face	scrambled_face	first_show	52	n/a	17	s125.bmp
+188.3852727273	n/a	47096.3182	show_circle	n/a	n/a	52	n/a	0	circle.bmp
+190.0852727273	n/a	47521.3182	show_cross	n/a	n/a	53	n/a	n/a	cross.bmp
+190.6652727273	n/a	47666.3182	show_face	scrambled_face	immediate_repeat	53	1	18	s125.bmp
+191.6407272727	n/a	47910.1818	show_circle	n/a	n/a	53	n/a	0	circle.bmp
+193.3407272727	n/a	48335.1818	show_cross	n/a	n/a	54	n/a	n/a	cross.bmp
+193.9225454545	n/a	48480.6364	show_face	famous_face	first_show	54	n/a	5	f146.bmp
+194.8325454545	n/a	48708.1364	show_circle	n/a	n/a	54	n/a	0	circle.bmp
+196.5325454545	n/a	49133.1364	show_cross	n/a	n/a	55	n/a	n/a	cross.bmp
+197.0125454545	n/a	49253.1364	show_face	unfamiliar_face	delayed_repeat	55	12	15	u018.bmp
+197.958	n/a	49489.5	show_circle	n/a	n/a	55	n/a	0	circle.bmp
+199.658	n/a	49914.5	show_cross	n/a	n/a	56	n/a	n/a	cross.bmp
+200.3034545455	n/a	50075.8636	show_face	famous_face	first_show	56	n/a	5	f058.bmp
+201.1316363636	n/a	50282.9091	right_press	n/a	n/a	56	n/a	4096	n/a
+201.1870909091	n/a	50296.7727	show_circle	n/a	n/a	56	n/a	0	circle.bmp
+202.8870909091	n/a	50721.7727	show_cross	n/a	n/a	57	n/a	n/a	cross.bmp
+203.4607272727	n/a	50865.1818	show_face	famous_face	immediate_repeat	57	1	6	f058.bmp
+204.1461818182	n/a	51036.5455	right_press	n/a	n/a	57	n/a	4096	n/a
+204.4789090909	n/a	51119.7273	show_circle	n/a	n/a	57	n/a	0	circle.bmp
+206.1789090909	n/a	51544.7273	show_cross	n/a	n/a	58	n/a	n/a	cross.bmp
+206.8189090909	n/a	51704.7273	show_face	unfamiliar_face	first_show	58	n/a	13	u146.bmp
+207.6316363636	n/a	51907.9091	right_press	n/a	n/a	58	n/a	4096	n/a
+207.7343636364	n/a	51933.5909	show_circle	n/a	n/a	58	n/a	0	circle.bmp
+209.4343636364	n/a	52358.5909	show_cross	n/a	n/a	59	n/a	n/a	cross.bmp
+209.95981818180002	n/a	52489.9545	show_face	unfamiliar_face	delayed_repeat	59	11	15	u023.bmp
+210.95163636360002	n/a	52737.9091	show_circle	n/a	n/a	59	n/a	0	circle.bmp
+212.6516363636	n/a	53162.9091	show_cross	n/a	n/a	60	n/a	n/a	cross.bmp
+213.1670909091	n/a	53291.7727	show_face	scrambled_face	first_show	60	n/a	17	s143.bmp
+213.8752727273	n/a	53468.8182	right_press	n/a	n/a	60	n/a	4096	n/a
+214.0361818182	n/a	53509.0455	show_circle	n/a	n/a	60	n/a	0	circle.bmp
+215.7361818182	n/a	53934.0455	show_cross	n/a	n/a	61	n/a	n/a	cross.bmp
+216.3743636364	n/a	54093.5909	show_face	scrambled_face	immediate_repeat	61	1	18	s143.bmp
+216.948	n/a	54237.0	right_press	n/a	n/a	61	n/a	4096	n/a
+217.2252727273	n/a	54306.3182	show_circle	n/a	n/a	61	n/a	0	circle.bmp
+218.92527272729998	n/a	54731.3182	show_cross	n/a	n/a	62	n/a	n/a	cross.bmp
+219.48163636360002	n/a	54870.4091	show_face	unfamiliar_face	delayed_repeat	62	12	15	u041.bmp
+220.3507272727	n/a	55087.6818	right_press	n/a	n/a	62	n/a	4096	n/a
+220.488	n/a	55122.0	show_circle	n/a	n/a	62	n/a	0	circle.bmp
+222.188	n/a	55547.0	show_cross	n/a	n/a	63	n/a	n/a	cross.bmp
+222.7889090909	n/a	55697.2273	show_face	famous_face	first_show	63	n/a	5	f067.bmp
+223.7816363636	n/a	55945.4091	show_circle	n/a	n/a	63	n/a	0	circle.bmp
+225.48163636360002	n/a	56370.4091	show_cross	n/a	n/a	64	n/a	n/a	cross.bmp
+226.0298181818	n/a	56507.4545	show_face	famous_face	first_show	64	n/a	5	f073.bmp
+227.02072727270001	n/a	56755.1818	right_press	n/a	n/a	64	n/a	4096	n/a
+227.02436363639998	n/a	56756.0909	show_circle	n/a	n/a	64	n/a	0	circle.bmp
+228.7243636364	n/a	57181.0909	show_cross	n/a	n/a	65	n/a	n/a	cross.bmp
+229.2370909091	n/a	57309.2727	show_face	famous_face	immediate_repeat	65	1	6	f073.bmp
+230.1698181818	n/a	57542.4545	show_circle	n/a	n/a	65	n/a	0	circle.bmp
+231.8698181818	n/a	57967.4545	show_cross	n/a	n/a	66	n/a	n/a	cross.bmp
+232.49436363639998	n/a	58123.5909	show_face	famous_face	delayed_repeat	66	12	7	f146.bmp
+233.4525454545	n/a	58363.1364	show_circle	n/a	n/a	66	n/a	0	circle.bmp
+235.1525454545	n/a	58788.1364	show_cross	n/a	n/a	67	n/a	n/a	cross.bmp
+235.6352727273	n/a	58908.8182	show_face	scrambled_face	first_show	67	n/a	17	s057.bmp
+236.42527272729998	n/a	59106.3182	right_press	n/a	n/a	67	n/a	4096	n/a
+236.45981818180002	n/a	59114.9545	show_circle	n/a	n/a	67	n/a	0	circle.bmp
+238.1598181818	n/a	59539.9545	show_cross	n/a	n/a	68	n/a	n/a	cross.bmp
+238.67527272729998	n/a	59668.8182	show_face	scrambled_face	first_show	68	n/a	17	s077.bmp
+239.5370909091	n/a	59884.2727	right_press	n/a	n/a	68	n/a	4096	n/a
+239.6689090909	n/a	59917.2273	show_circle	n/a	n/a	68	n/a	0	circle.bmp
+241.3689090909	n/a	60342.2273	show_cross	n/a	n/a	69	n/a	n/a	cross.bmp
+241.9161818182	n/a	60479.0455	show_face	unfamiliar_face	delayed_repeat	69	11	15	u146.bmp
+242.7816363636	n/a	60695.4091	right_press	n/a	n/a	69	n/a	4096	n/a
+242.928	n/a	60732.0	show_circle	n/a	n/a	69	n/a	0	circle.bmp
+244.628	n/a	61157.0	show_cross	n/a	n/a	70	n/a	n/a	cross.bmp
+245.27436363639998	n/a	61318.5909	show_face	famous_face	first_show	70	n/a	5	f055.bmp
+246.0552727273	n/a	61513.8182	right_press	n/a	n/a	70	n/a	4096	n/a
+246.1489090909	n/a	61537.2273	show_circle	n/a	n/a	70	n/a	0	circle.bmp
+247.8489090909	n/a	61962.2273	show_cross	n/a	n/a	71	n/a	n/a	cross.bmp
+248.4652727273	n/a	62116.3182	show_face	famous_face	immediate_repeat	71	1	6	f055.bmp
+249.0325454545	n/a	62258.1364	right_press	n/a	n/a	71	n/a	4096	n/a
+249.438	n/a	62359.5	show_circle	n/a	n/a	71	n/a	0	circle.bmp
+251.138	n/a	62784.5	show_cross	n/a	n/a	72	n/a	n/a	cross.bmp
+251.6225454545	n/a	62905.6364	show_face	famous_face	first_show	72	n/a	5	f068.bmp
+252.5261818182	n/a	63131.5455	show_circle	n/a	n/a	72	n/a	0	circle.bmp
+254.2261818182	n/a	63556.5455	show_cross	n/a	n/a	73	n/a	n/a	cross.bmp
+254.6961818182	n/a	63674.0455	show_face	famous_face	delayed_repeat	73	10	7	f067.bmp
+255.52436363639998	n/a	63881.0909	show_circle	n/a	n/a	73	n/a	0	circle.bmp
+257.22436363639997	n/a	64306.0909	show_cross	n/a	n/a	74	n/a	n/a	cross.bmp
+257.7361818182	n/a	64434.0455	show_face	scrambled_face	first_show	74	n/a	17	s009.bmp
+258.3698181818	n/a	64592.4545	right_press	n/a	n/a	74	n/a	4096	n/a
+258.7316363636	n/a	64682.9091	show_circle	n/a	n/a	74	n/a	0	circle.bmp
+260.4316363636	n/a	65107.9091	show_cross	n/a	n/a	75	n/a	n/a	cross.bmp
+261.0770909091	n/a	65269.2727	show_face	scrambled_face	immediate_repeat	75	1	18	s009.bmp
+261.9652727273	n/a	65491.3182	show_circle	n/a	n/a	75	n/a	0	circle.bmp
+263.6652727273	n/a	65916.3182	show_cross	n/a	n/a	76	n/a	n/a	cross.bmp
+264.318	n/a	66079.5	show_face	scrambled_face	first_show	76	n/a	17	s031.bmp
+265.1716363636	n/a	66292.9091	show_circle	n/a	n/a	76	n/a	0	circle.bmp
+266.87163636360003	n/a	66717.9091	show_cross	n/a	n/a	77	n/a	n/a	cross.bmp
+267.4416363636	n/a	66860.4091	show_face	scrambled_face	delayed_repeat	77	10	19	s057.bmp
+268.24254545450003	n/a	67060.6364	right_press	n/a	n/a	77	n/a	4096	n/a
+268.358	n/a	67089.5	show_circle	n/a	n/a	77	n/a	0	circle.bmp
+270.058	n/a	67514.5	show_cross	n/a	n/a	78	n/a	n/a	cross.bmp
+270.5152727273	n/a	67628.8182	show_face	scrambled_face	first_show	78	n/a	17	s021.bmp
+271.4134545455	n/a	67853.3636	right_press	n/a	n/a	78	n/a	4096	n/a
+271.48345454549997	n/a	67870.8636	show_circle	n/a	n/a	78	n/a	0	circle.bmp
+273.1834545455	n/a	68295.8636	show_cross	n/a	n/a	79	n/a	n/a	cross.bmp
+273.7561818182	n/a	68439.0455	show_face	scrambled_face	delayed_repeat	79	11	19	s077.bmp
+274.7398181818	n/a	68684.9545	show_circle	n/a	n/a	79	n/a	0	circle.bmp
+274.8552727273	n/a	68713.8182	right_press	n/a	n/a	79	n/a	4096	n/a
+276.4398181818	n/a	69109.9545	show_cross	n/a	n/a	80	n/a	n/a	cross.bmp
+276.9970909091	n/a	69249.2727	show_face	unfamiliar_face	first_show	80	n/a	13	u063.bmp
+277.8761818182	n/a	69469.0455	show_circle	n/a	n/a	80	n/a	0	circle.bmp
+279.5761818182	n/a	69894.0455	show_cross	n/a	n/a	81	n/a	n/a	cross.bmp
+280.2043636364	n/a	70051.0909	show_face	unfamiliar_face	first_show	81	n/a	13	u149.bmp
+281.1325454545	n/a	70283.1364	show_circle	n/a	n/a	81	n/a	0	circle.bmp
+282.8325454545	n/a	70708.1364	show_cross	n/a	n/a	82	n/a	n/a	cross.bmp
+283.3289090909	n/a	70832.2273	show_face	famous_face	delayed_repeat	82	10	7	f068.bmp
+284.2452727273	n/a	71061.3182	show_circle	n/a	n/a	82	n/a	0	circle.bmp
+285.9452727273	n/a	71486.3182	show_cross	n/a	n/a	83	n/a	n/a	cross.bmp
+286.5689090909	n/a	71642.2273	show_face	famous_face	first_show	83	n/a	5	f015.bmp
+287.2134545455	n/a	71803.3636	right_press	n/a	n/a	83	n/a	4096	n/a
+287.5125454545	n/a	71878.1364	show_circle	n/a	n/a	83	n/a	0	circle.bmp
+289.2125454545	n/a	72303.1364	show_cross	n/a	n/a	84	n/a	n/a	cross.bmp
+289.8434545455	n/a	72460.8636	show_face	famous_face	first_show	84	n/a	5	f031.bmp
+290.4725454545	n/a	72618.1364	right_press	n/a	n/a	84	n/a	4096	n/a
+290.7770909091	n/a	72694.2727	show_circle	n/a	n/a	84	n/a	0	circle.bmp
+292.4770909091	n/a	73119.2727	show_cross	n/a	n/a	85	n/a	n/a	cross.bmp
+292.9507272727	n/a	73237.6818	show_face	famous_face	immediate_repeat	85	1	6	f031.bmp
+293.548	n/a	73387.0	right_press	n/a	n/a	85	n/a	4096	n/a
+293.9425454545	n/a	73485.6364	show_circle	n/a	n/a	85	n/a	0	circle.bmp
+295.6425454545	n/a	73910.6364	show_cross	n/a	n/a	86	n/a	n/a	cross.bmp
+296.108	n/a	74027.0	show_face	scrambled_face	delayed_repeat	86	10	19	s031.bmp
+297.0907272727	n/a	74272.6818	show_circle	n/a	n/a	86	n/a	0	circle.bmp
+298.7907272727	n/a	74697.6818	show_cross	n/a	n/a	87	n/a	n/a	cross.bmp
+299.3489090909	n/a	74837.2273	show_face	unfamiliar_face	first_show	87	n/a	13	u099.bmp
+300.31163636360003	n/a	75077.9091	right_press	n/a	n/a	87	n/a	4096	n/a
+300.3561818182	n/a	75089.0455	show_circle	n/a	n/a	87	n/a	0	circle.bmp
+302.0561818182	n/a	75514.0455	show_cross	n/a	n/a	88	n/a	n/a	cross.bmp
+302.5561818182	n/a	75639.0455	show_face	unfamiliar_face	immediate_repeat	88	1	14	u099.bmp
+303.4189090909	n/a	75854.7273	show_circle	n/a	n/a	88	n/a	0	circle.bmp
+303.4652727273	n/a	75866.3182	right_press	n/a	n/a	88	n/a	4096	n/a
+305.1189090909	n/a	76279.7273	show_cross	n/a	n/a	89	n/a	n/a	cross.bmp
+305.6798181818	n/a	76419.9545	show_face	scrambled_face	delayed_repeat	89	11	19	s021.bmp
+306.5734545455	n/a	76643.3636	show_circle	n/a	n/a	89	n/a	0	circle.bmp
+308.2734545455	n/a	77068.3636	show_cross	n/a	n/a	90	n/a	n/a	cross.bmp
+308.8034545455	n/a	77200.8636	show_face	famous_face	first_show	90	n/a	5	f024.bmp
+309.6943636364	n/a	77423.5909	show_circle	n/a	n/a	90	n/a	0	circle.bmp
+311.3943636364	n/a	77848.5909	show_cross	n/a	n/a	91	n/a	n/a	cross.bmp
+311.9107272727	n/a	77977.6818	show_face	famous_face	immediate_repeat	91	1	6	f024.bmp
+312.7861818182	n/a	78196.5455	show_circle	n/a	n/a	91	n/a	0	circle.bmp
+314.4861818182	n/a	78621.5455	show_cross	n/a	n/a	92	n/a	n/a	cross.bmp
+315.018	n/a	78754.5	show_face	unfamiliar_face	delayed_repeat	92	12	15	u063.bmp
+315.8734545455	n/a	78968.3636	show_circle	n/a	n/a	92	n/a	0	circle.bmp
+317.5734545455	n/a	79393.3636	show_cross	n/a	n/a	93	n/a	n/a	cross.bmp
+318.1089090909	n/a	79527.2273	show_face	unfamiliar_face	first_show	93	n/a	13	u056.bmp
+318.6334545455	n/a	79658.3636	left_press	n/a	n/a	93	n/a	256	n/a
+318.99254545450003	n/a	79748.1364	show_circle	n/a	n/a	93	n/a	0	circle.bmp
+320.6925454545	n/a	80173.1364	show_cross	n/a	n/a	94	n/a	n/a	cross.bmp
+321.3325454545	n/a	80333.1364	show_face	unfamiliar_face	immediate_repeat	94	1	14	u056.bmp
+321.9716363636	n/a	80492.9091	left_press	n/a	n/a	94	n/a	256	n/a
+322.1970909091	n/a	80549.2727	show_circle	n/a	n/a	94	n/a	0	circle.bmp
+323.8970909091	n/a	80974.2727	show_cross	n/a	n/a	95	n/a	n/a	cross.bmp
+324.5234545455	n/a	81130.8636	show_face	unfamiliar_face	delayed_repeat	95	14	15	u149.bmp
+325.1670909091	n/a	81291.7727	right_press	n/a	n/a	95	n/a	4096	n/a
+325.4398181818	n/a	81359.9545	show_circle	n/a	n/a	95	n/a	0	circle.bmp
+327.1398181818	n/a	81784.9545	show_cross	n/a	n/a	96	n/a	n/a	cross.bmp
+327.7643636364	n/a	81941.0909	show_face	scrambled_face	first_show	96	n/a	17	s066.bmp
+328.3352727273	n/a	82083.8182	right_press	n/a	n/a	96	n/a	4096	n/a
+328.778	n/a	82194.5	show_circle	n/a	n/a	96	n/a	0	circle.bmp
+330.478	n/a	82619.5	show_cross	n/a	n/a	97	n/a	n/a	cross.bmp
+330.988	n/a	82747.0	show_face	scrambled_face	immediate_repeat	97	1	18	s066.bmp
+331.9534545455	n/a	82988.3636	show_circle	n/a	n/a	97	n/a	0	circle.bmp
+333.6534545455	n/a	83413.3636	show_cross	n/a	n/a	98	n/a	n/a	cross.bmp
+334.1289090909	n/a	83532.2273	show_face	famous_face	delayed_repeat	98	15	7	f015.bmp
+334.7725454545	n/a	83693.1364	right_press	n/a	n/a	98	n/a	4096	n/a
+334.9889090909	n/a	83747.2273	show_circle	n/a	n/a	98	n/a	0	circle.bmp
+336.6889090909	n/a	84172.2273	show_cross	n/a	n/a	99	n/a	n/a	cross.bmp
+337.1689090909	n/a	84292.2273	show_face	famous_face	first_show	99	n/a	5	f053.bmp
+338.0161818182	n/a	84504.0455	show_circle	n/a	n/a	99	n/a	0	circle.bmp
+339.71618181819997	n/a	84929.0455	show_cross	n/a	n/a	100	n/a	n/a	cross.bmp
+340.2761818182	n/a	85069.0455	show_face	famous_face	immediate_repeat	100	1	6	f053.bmp
+341.2652727273	n/a	85316.3182	show_circle	n/a	n/a	100	n/a	0	circle.bmp
+342.9652727273	n/a	85741.3182	show_cross	n/a	n/a	101	n/a	n/a	cross.bmp
+343.61709090910006	n/a	85904.2727	show_face	scrambled_face	first_show	101	n/a	17	s045.bmp
+344.38072727269997	n/a	86095.1818	right_press	n/a	n/a	101	n/a	4096	n/a
+344.5607272727	n/a	86140.1818	show_circle	n/a	n/a	101	n/a	0	circle.bmp
+346.26072727269997	n/a	86565.1818	show_cross	n/a	n/a	102	n/a	n/a	cross.bmp
+346.858	n/a	86714.5	show_face	unfamiliar_face	first_show	102	n/a	13	u057.bmp
+347.71254545449995	n/a	86928.1364	show_circle	n/a	n/a	102	n/a	0	circle.bmp
+349.4125454545	n/a	87353.1364	show_cross	n/a	n/a	103	n/a	n/a	cross.bmp
+349.8816363636	n/a	87470.4091	show_face	unfamiliar_face	immediate_repeat	103	1	14	u057.bmp
+350.7961818182	n/a	87699.0455	show_circle	n/a	n/a	103	n/a	0	circle.bmp
+352.4961818182	n/a	88124.0455	show_cross	n/a	n/a	104	n/a	n/a	cross.bmp
+353.0061818182	n/a	88251.5455	show_face	famous_face	first_show	104	n/a	5	f082.bmp
+353.6861818182	n/a	88421.5455	right_press	n/a	n/a	104	n/a	4096	n/a
+353.9816363636	n/a	88495.4091	show_circle	n/a	n/a	104	n/a	0	circle.bmp
+355.6816363636	n/a	88920.4091	show_cross	n/a	n/a	105	n/a	n/a	cross.bmp
+356.1461818182	n/a	89036.5455	show_face	scrambled_face	first_show	105	n/a	17	s124.bmp
+357.0198181818	n/a	89254.9545	show_circle	n/a	n/a	105	n/a	0	circle.bmp
+358.7198181818	n/a	89679.9545	show_cross	n/a	n/a	106	n/a	n/a	cross.bmp
+359.32072727269997	n/a	89830.1818	show_face	unfamiliar_face	first_show	106	n/a	13	u069.bmp
+360.0952727273	n/a	90023.8182	right_press	n/a	n/a	106	n/a	4096	n/a
+360.25527272730005	n/a	90063.8182	show_circle	n/a	n/a	106	n/a	0	circle.bmp
+361.95527272730004	n/a	90488.8182	show_cross	n/a	n/a	107	n/a	n/a	cross.bmp
+362.4943636364	n/a	90623.5909	show_face	scrambled_face	first_show	107	n/a	17	s148.bmp
+363.5089090909	n/a	90877.2273	show_circle	n/a	n/a	107	n/a	0	circle.bmp
+365.20890909089997	n/a	91302.2273	show_cross	n/a	n/a	108	n/a	n/a	cross.bmp
+365.83527272730004	n/a	91458.8182	show_face	scrambled_face	immediate_repeat	108	1	18	s148.bmp
+366.6707272727	n/a	91667.6818	show_circle	n/a	n/a	108	n/a	0	circle.bmp
+368.3707272727	n/a	92092.6818	show_cross	n/a	n/a	109	n/a	n/a	cross.bmp
+368.95890909089997	n/a	92239.7273	show_face	scrambled_face	delayed_repeat	109	8	19	s045.bmp
+369.828	n/a	92457.0	show_circle	n/a	n/a	109	n/a	0	circle.bmp
+370.02890909089996	n/a	92507.2273	right_press	n/a	n/a	109	n/a	4096	n/a
+371.528	n/a	92882.0	show_cross	n/a	n/a	110	n/a	n/a	cross.bmp
+372.0161818182	n/a	93004.0455	show_face	scrambled_face	first_show	110	n/a	17	s108.bmp
+372.84345454550004	n/a	93210.8636	show_circle	n/a	n/a	110	n/a	0	circle.bmp
+372.9116363636	n/a	93227.9091	right_press	n/a	n/a	110	n/a	4096	n/a
+374.5434545455	n/a	93635.8636	show_cross	n/a	n/a	111	n/a	n/a	cross.bmp
+375.0898181818	n/a	93772.4545	show_face	famous_face	first_show	111	n/a	5	f147.bmp
+375.82254545449996	n/a	93955.6364	right_press	n/a	n/a	111	n/a	4096	n/a
+375.9161818182	n/a	93979.0455	show_circle	n/a	n/a	111	n/a	0	circle.bmp
+377.6161818182	n/a	94404.0455	show_cross	n/a	n/a	112	n/a	n/a	cross.bmp
+378.24709090910005	n/a	94561.7727	show_face	famous_face	delayed_repeat	112	8	7	f082.bmp
+378.9843636364	n/a	94746.0909	right_press	n/a	n/a	112	n/a	4096	n/a
+379.1389090909	n/a	94784.7273	show_circle	n/a	n/a	112	n/a	0	circle.bmp
+380.83890909089996	n/a	95209.7273	show_cross	n/a	n/a	113	n/a	n/a	cross.bmp
+381.488	n/a	95372.0	show_face	unfamiliar_face	first_show	113	n/a	13	u031.bmp
+382.1125454545	n/a	95528.1364	right_press	n/a	n/a	113	n/a	4096	n/a
+382.428	n/a	95607.0	show_circle	n/a	n/a	113	n/a	0	circle.bmp
+384.128	n/a	96032.0	show_cross	n/a	n/a	114	n/a	n/a	cross.bmp
+384.6289090909	n/a	96157.2273	show_face	scrambled_face	delayed_repeat	114	9	19	s124.bmp
+385.4325454545	n/a	96358.1364	right_press	n/a	n/a	114	n/a	4096	n/a
+385.588	n/a	96397.0	show_circle	n/a	n/a	114	n/a	0	circle.bmp
+387.288	n/a	96822.0	show_cross	n/a	n/a	115	n/a	n/a	cross.bmp
+387.7861818182	n/a	96946.5455	show_face	scrambled_face	first_show	115	n/a	17	s024.bmp
+388.2798181818	n/a	97069.9545	right_press	n/a	n/a	115	n/a	4096	n/a
+388.6316363636	n/a	97157.9091	show_circle	n/a	n/a	115	n/a	0	circle.bmp
+390.3316363636	n/a	97582.9091	show_cross	n/a	n/a	116	n/a	n/a	cross.bmp
+390.8598181818	n/a	97714.9545	show_face	scrambled_face	immediate_repeat	116	1	18	s024.bmp
+391.4252727273	n/a	97856.3182	right_press	n/a	n/a	116	n/a	4096	n/a
+391.71072727269996	n/a	97927.6818	show_circle	n/a	n/a	116	n/a	0	circle.bmp
+393.41072727269994	n/a	98352.6818	show_cross	n/a	n/a	117	n/a	n/a	cross.bmp
+393.9498181818	n/a	98487.4545	show_face	unfamiliar_face	delayed_repeat	117	11	15	u069.bmp
+394.77890909089996	n/a	98694.7273	show_circle	n/a	n/a	117	n/a	0	circle.bmp
+396.47890909089995	n/a	99119.7273	show_cross	n/a	n/a	118	n/a	n/a	cross.bmp
+397.00709090910004	n/a	99251.7727	show_face	scrambled_face	first_show	118	n/a	17	s018.bmp
+397.8552727273	n/a	99463.8182	show_circle	n/a	n/a	118	n/a	0	circle.bmp
+399.5552727273	n/a	99888.8182	show_cross	n/a	n/a	119	n/a	n/a	cross.bmp
+400.148	n/a	100037.0	show_face	famous_face	first_show	119	n/a	5	f105.bmp
+400.8098181818	n/a	100202.4545	right_press	n/a	n/a	119	n/a	4096	n/a
+401.15527272730003	n/a	100288.8182	show_circle	n/a	n/a	119	n/a	0	circle.bmp
+402.8552727273	n/a	100713.8182	show_cross	n/a	n/a	120	n/a	n/a	cross.bmp
+403.4716363636	n/a	100867.9091	show_face	famous_face	immediate_repeat	120	1	6	f105.bmp
+404.0398181818	n/a	101009.9545	right_press	n/a	n/a	120	n/a	4096	n/a
+404.34345454550004	n/a	101085.8636	show_circle	n/a	n/a	120	n/a	0	circle.bmp
+406.0434545455	n/a	101510.8636	show_cross	n/a	n/a	121	n/a	n/a	cross.bmp
+406.6798181818	n/a	101669.9545	show_face	scrambled_face	delayed_repeat	121	11	19	s108.bmp
+407.1625454545	n/a	101790.6364	right_press	n/a	n/a	121	n/a	4096	n/a
+407.62709090910005	n/a	101906.7727	show_circle	n/a	n/a	121	n/a	0	circle.bmp
+409.32709090910004	n/a	102331.7727	show_cross	n/a	n/a	122	n/a	n/a	cross.bmp
+409.90345454550004	n/a	102475.8636	show_face	scrambled_face	first_show	122	n/a	17	s099.bmp
+410.58345454550005	n/a	102645.8636	right_press	n/a	n/a	122	n/a	4096	n/a
+410.89254545449995	n/a	102723.1364	show_circle	n/a	n/a	122	n/a	0	circle.bmp
+412.59254545449994	n/a	103148.1364	show_cross	n/a	n/a	123	n/a	n/a	cross.bmp
+413.16072727269994	n/a	103290.1818	show_face	famous_face	delayed_repeat	123	12	7	f147.bmp
+414.0643636364	n/a	103516.0909	show_circle	n/a	n/a	123	n/a	0	circle.bmp
+415.7643636364	n/a	103941.0909	show_cross	n/a	n/a	124	n/a	n/a	cross.bmp
+416.33527272730004	n/a	104083.8182	show_face	famous_face	first_show	124	n/a	5	f135.bmp
+417.16890909089994	n/a	104292.2273	show_circle	n/a	n/a	124	n/a	0	circle.bmp
+418.8689090909	n/a	104717.2273	show_cross	n/a	n/a	125	n/a	n/a	cross.bmp
+419.4752727273	n/a	104868.8182	show_face	famous_face	immediate_repeat	125	1	6	f135.bmp
+420.41072727269994	n/a	105102.6818	show_circle	n/a	n/a	125	n/a	0	circle.bmp
+422.1107272727	n/a	105527.6818	show_cross	n/a	n/a	126	n/a	n/a	cross.bmp
+422.7343636364	n/a	105683.5909	show_face	unfamiliar_face	delayed_repeat	126	13	15	u031.bmp
+423.6461818182	n/a	105911.5455	show_circle	n/a	n/a	126	n/a	0	circle.bmp
+425.3461818182	n/a	106336.5455	show_cross	n/a	n/a	127	n/a	n/a	cross.bmp
+425.89072727269996	n/a	106472.6818	show_face	scrambled_face	first_show	127	n/a	17	s146.bmp
+426.488	n/a	106622.0	right_press	n/a	n/a	127	n/a	4096	n/a
+426.8007272727	n/a	106700.1818	show_circle	n/a	n/a	127	n/a	0	circle.bmp
+428.5007272727	n/a	107125.1818	show_cross	n/a	n/a	128	n/a	n/a	cross.bmp
+428.998	n/a	107249.5	show_face	scrambled_face	immediate_repeat	128	1	18	s146.bmp
+429.5898181818	n/a	107397.4545	right_press	n/a	n/a	128	n/a	4096	n/a
+429.9198181818	n/a	107479.9545	show_circle	n/a	n/a	128	n/a	0	circle.bmp
+431.6198181818	n/a	107904.9545	show_cross	n/a	n/a	129	n/a	n/a	cross.bmp
+432.15527272730003	n/a	108038.8182	show_face	unfamiliar_face	first_show	129	n/a	13	u127.bmp
+433.03890909089995	n/a	108259.7273	show_circle	n/a	n/a	129	n/a	0	circle.bmp
+434.73890909089994	n/a	108684.7273	show_cross	n/a	n/a	130	n/a	n/a	cross.bmp
+435.3625454545	n/a	108840.6364	show_face	scrambled_face	delayed_repeat	130	12	19	s018.bmp
+435.9325454545	n/a	108983.1364	right_press	n/a	n/a	130	n/a	4096	n/a
+436.2952727273	n/a	109073.8182	show_circle	n/a	n/a	130	n/a	0	circle.bmp
+437.99527272730006	n/a	109498.8182	show_cross	n/a	n/a	131	n/a	n/a	cross.bmp
+438.50254545449997	n/a	109625.6364	show_face	scrambled_face	first_show	131	n/a	17	s113.bmp
+439.3552727273	n/a	109838.8182	right_press	n/a	n/a	131	n/a	4096	n/a
+439.42709090910006	n/a	109856.7727	show_circle	n/a	n/a	131	n/a	0	circle.bmp
+441.12709090910005	n/a	110281.7727	show_cross	n/a	n/a	132	n/a	n/a	cross.bmp
+441.7434545455	n/a	110435.8636	show_face	famous_face	first_show	132	n/a	5	f110.bmp
+442.6398181818	n/a	110659.9545	show_circle	n/a	n/a	132	n/a	0	circle.bmp
+444.3398181818	n/a	111084.9545	show_cross	n/a	n/a	133	n/a	n/a	cross.bmp
+444.9843636364	n/a	111246.0909	show_face	scrambled_face	delayed_repeat	133	11	19	s099.bmp
+445.7861818182	n/a	111446.5455	right_press	n/a	n/a	133	n/a	4096	n/a
+445.8261818182	n/a	111456.5455	show_circle	n/a	n/a	133	n/a	0	circle.bmp
+447.5261818182	n/a	111881.5455	show_cross	n/a	n/a	134	n/a	n/a	cross.bmp
+448.058	n/a	112014.5	show_face	unfamiliar_face	first_show	134	n/a	13	u098.bmp
+448.75254545449997	n/a	112188.1364	right_press	n/a	n/a	134	n/a	4096	n/a
+448.9834545455	n/a	112245.8636	show_circle	n/a	n/a	134	n/a	0	circle.bmp
+450.6834545455	n/a	112670.8636	show_cross	n/a	n/a	135	n/a	n/a	cross.bmp
+451.14890909089996	n/a	112787.2273	show_face	unfamiliar_face	immediate_repeat	135	1	14	u098.bmp
+451.7270909091	n/a	112931.7727	right_press	n/a	n/a	135	n/a	4096	n/a
+452.1134545455	n/a	113028.3636	show_circle	n/a	n/a	135	n/a	0	circle.bmp
+453.8134545455	n/a	113453.3636	show_cross	n/a	n/a	136	n/a	n/a	cross.bmp
+454.4725454545	n/a	113618.1364	show_face	famous_face	first_show	136	n/a	5	f027.bmp
+455.3161818182	n/a	113829.0455	show_circle	n/a	n/a	136	n/a	0	circle.bmp
+457.0161818182	n/a	114254.0455	show_cross	n/a	n/a	137	n/a	n/a	cross.bmp
+457.5298181818	n/a	114382.4545	show_face	unfamiliar_face	first_show	137	n/a	13	u064.bmp
+458.1907272727	n/a	114547.6818	right_press	n/a	n/a	137	n/a	4096	n/a
+458.5161818182	n/a	114629.0455	show_circle	n/a	n/a	137	n/a	0	circle.bmp
+460.21618181819997	n/a	115054.0455	show_cross	n/a	n/a	138	n/a	n/a	cross.bmp
+460.73709090910006	n/a	115184.2727	show_face	unfamiliar_face	immediate_repeat	138	1	14	u064.bmp
+461.35436363639997	n/a	115338.5909	right_press	n/a	n/a	138	n/a	4096	n/a
+461.7116363636	n/a	115427.9091	show_circle	n/a	n/a	138	n/a	0	circle.bmp
+463.4116363636	n/a	115852.9091	show_cross	n/a	n/a	139	n/a	n/a	cross.bmp
+463.978	n/a	115994.5	show_face	unfamiliar_face	delayed_repeat	139	10	15	u127.bmp
+464.83254545449995	n/a	116208.1364	show_circle	n/a	n/a	139	n/a	0	circle.bmp
+466.5325454545	n/a	116633.1364	show_cross	n/a	n/a	140	n/a	n/a	cross.bmp
+467.1189090909	n/a	116779.7273	show_face	unfamiliar_face	first_show	140	n/a	13	u089.bmp
+467.7916363636	n/a	116947.9091	right_press	n/a	n/a	140	n/a	4096	n/a
+467.9598181818	n/a	116989.9545	show_circle	n/a	n/a	140	n/a	0	circle.bmp
+469.6598181818	n/a	117414.9545	show_cross	n/a	n/a	141	n/a	n/a	cross.bmp
+470.2434545455	n/a	117560.8636	show_face	unfamiliar_face	immediate_repeat	141	1	14	u089.bmp
+470.7743636364	n/a	117693.5909	right_press	n/a	n/a	141	n/a	4096	n/a
+471.2361818182	n/a	117809.0455	show_circle	n/a	n/a	141	n/a	0	circle.bmp
+472.9361818182	n/a	118234.0455	show_cross	n/a	n/a	142	n/a	n/a	cross.bmp
+473.4334545455	n/a	118358.3636	show_face	scrambled_face	delayed_repeat	142	11	19	s113.bmp
+474.2361818182	n/a	118559.0455	right_press	n/a	n/a	142	n/a	4096	n/a
+474.4216363636	n/a	118605.4091	show_circle	n/a	n/a	142	n/a	0	circle.bmp
+476.12163636360003	n/a	119030.4091	show_cross	n/a	n/a	143	n/a	n/a	cross.bmp
+476.70709090910003	n/a	119176.7727	show_face	unfamiliar_face	first_show	143	n/a	13	u136.bmp
+477.6798181818	n/a	119419.9545	show_circle	n/a	n/a	143	n/a	0	circle.bmp
+479.3798181818	n/a	119844.9545	show_cross	n/a	n/a	144	n/a	n/a	cross.bmp
+479.998	n/a	119999.5	show_face	unfamiliar_face	immediate_repeat	144	1	14	u136.bmp
+480.89254545449995	n/a	120223.1364	show_circle	n/a	n/a	144	n/a	0	circle.bmp
+482.59254545449994	n/a	120648.1364	show_cross	n/a	n/a	145	n/a	n/a	cross.bmp
+483.0552727273	n/a	120763.8182	show_face	famous_face	delayed_repeat	145	13	7	f110.bmp
+483.9461818182	n/a	120986.5455	show_circle	n/a	n/a	145	n/a	0	circle.bmp
+485.6461818182	n/a	121411.5455	show_cross	n/a	n/a	146	n/a	n/a	cross.bmp
+486.1461818182	n/a	121536.5455	show_face	scrambled_face	first_show	146	n/a	17	s011.bmp
+487.10072727269994	n/a	121775.1818	show_circle	n/a	n/a	146	n/a	0	circle.bmp
+488.8007272727	n/a	122200.1818	show_cross	n/a	n/a	147	n/a	n/a	cross.bmp
+489.43709090910005	n/a	122359.2727	show_face	scrambled_face	immediate_repeat	147	1	18	s011.bmp
+490.4498181818	n/a	122612.4545	show_circle	n/a	n/a	147	n/a	0	circle.bmp
+492.1498181818	n/a	123037.4545	show_cross	n/a	n/a	148	n/a	n/a	cross.bmp
+492.7943636364	n/a	123198.5909	show_face	unfamiliar_face	first_show	148	n/a	13	u145.bmp
+493.5007272727	n/a	123375.1818	right_press	n/a	n/a	148	n/a	4096	n/a
+493.62254545449997	n/a	123405.6364	show_circle	n/a	n/a	148	n/a	0	circle.bmp
+495.32254545449996	n/a	123830.6364	show_cross	n/a	n/a	149	n/a	n/a	cross.bmp
+495.818	n/a	123954.5	show_face	unfamiliar_face	immediate_repeat	149	1	14	u145.bmp
+496.4516363636	n/a	124112.9091	right_press	n/a	n/a	149	n/a	4096	n/a
+496.66345454550003	n/a	124165.8636	show_circle	n/a	n/a	149	n/a	0	circle.bmp
+498.3634545455	n/a	124590.8636	show_cross	n/a	n/a	150	n/a	n/a	cross.bmp
+498.87527272730006	n/a	124718.8182	show_face	famous_face	delayed_repeat	150	14	7	f027.bmp
+499.7898181818	n/a	124947.4545	show_circle	n/a	n/a	150	n/a	0	circle.bmp
+501.4898181818	n/a	125372.4545	show_cross	n/a	n/a	151	n/a	n/a	cross.bmp

--- a/eeg_hed_small/sub-002/eeg/sub-002_task-FacePerception_run-4_events.tsv
+++ b/eeg_hed_small/sub-002/eeg/sub-002_task-FacePerception_run-4_events.tsv
@@ -1,534 +1,534 @@
-onset	duration	sample	event_type	face_type	repetition_type	trigger	stim_file
-0.0040000000	n/a	1	setup	n/a	n/a	n/a	n/a
-0.0040000000	n/a	1	right_sym	n/a	n/a	n/a	n/a
-24.3352727273	n/a	6083.8182	show_face	unfamiliar_face	first_show	13	u124.bmp
-25.1889090909	n/a	6297.2273	show_circle	n/a	n/a	0	circle.bmp
-26.8889090909	n/a	6722.2273	show_cross	n/a	n/a	n/a	cross.bmp
-27.3752727273	n/a	6843.8182	show_face	famous_face	first_show	5	f125.bmp
-28.0570909091	n/a	7014.2727	right_press	n/a	n/a	4096	n/a
-28.3561818182	n/a	7089.0455	show_circle	n/a	n/a	0	circle.bmp
-30.0561818182	n/a	7514.0455	show_cross	n/a	n/a	n/a	cross.bmp
-30.5489090909	n/a	7637.2273	show_face	famous_face	immediate_repeat	6	f125.bmp
-31.1016363636	n/a	7775.4091	right_press	n/a	n/a	4096	n/a
-31.4298181818	n/a	7857.4545	show_circle	n/a	n/a	0	circle.bmp
-33.1298181818	n/a	8282.4545	show_cross	n/a	n/a	n/a	cross.bmp
-33.7234545455	n/a	8430.8636	show_face	famous_face	first_show	5	f012.bmp
-34.6561818182	n/a	8664.0455	show_circle	n/a	n/a	0	circle.bmp
-36.3561818182	n/a	9089.0455	show_cross	n/a	n/a	n/a	cross.bmp
-36.8134545455	n/a	9203.3636	show_face	famous_face	immediate_repeat	6	f012.bmp
-37.3752727273	n/a	9343.8182	right_press	n/a	n/a	4096	n/a
-37.6589090909	n/a	9414.7273	show_circle	n/a	n/a	0	circle.bmp
-39.3589090909	n/a	9839.7273	show_cross	n/a	n/a	n/a	cross.bmp
-40.0216363636	n/a	10005.4091	show_face	unfamiliar_face	first_show	13	u044.bmp
-40.9243636364	n/a	10231.0909	show_circle	n/a	n/a	0	circle.bmp
-42.6243636364	n/a	10656.0909	show_cross	n/a	n/a	n/a	cross.bmp
-43.2452727273	n/a	10811.3182	show_face	unfamiliar_face	immediate_repeat	14	u044.bmp
-44.2152727273	n/a	11053.8182	show_circle	n/a	n/a	0	circle.bmp
-45.9152727273	n/a	11478.8182	show_cross	n/a	n/a	n/a	cross.bmp
-46.3689090909	n/a	11592.2273	show_face	scrambled_face	first_show	17	s006.bmp
-47.0134545455	n/a	11753.3636	right_press	n/a	n/a	4096	n/a
-47.3725454545	n/a	11843.1364	show_circle	n/a	n/a	0	circle.bmp
-49.0725454545	n/a	12268.1364	show_cross	n/a	n/a	n/a	cross.bmp
-49.6270909091	n/a	12406.7727	show_face	scrambled_face	first_show	17	s029.bmp
-50.5834545455	n/a	12645.8636	show_circle	n/a	n/a	0	circle.bmp
-52.2834545455	n/a	13070.8636	show_cross	n/a	n/a	n/a	cross.bmp
-52.8170909091	n/a	13204.2727	show_face	unfamiliar_face	delayed_repeat	15	u124.bmp
-53.7134545455	n/a	13428.3636	show_circle	n/a	n/a	0	circle.bmp
-55.4134545455	n/a	13853.3636	show_cross	n/a	n/a	n/a	cross.bmp
-55.9080000000	n/a	13977	show_face	unfamiliar_face	first_show	13	u106.bmp
-56.7316363636	n/a	14182.9091	show_circle	n/a	n/a	0	circle.bmp
-58.4316363636	n/a	14607.9091	show_cross	n/a	n/a	n/a	cross.bmp
-58.9143636364	n/a	14728.5909	show_face	unfamiliar_face	immediate_repeat	14	u106.bmp
-59.8225454545	n/a	14955.6364	show_circle	n/a	n/a	0	circle.bmp
-61.5225454545	n/a	15380.6364	show_cross	n/a	n/a	n/a	cross.bmp
-62.1725454545	n/a	15543.1364	show_face	unfamiliar_face	first_show	13	u061.bmp
-63.0061818182	n/a	15751.5455	show_circle	n/a	n/a	0	circle.bmp
-64.7061818182	n/a	16176.5455	show_cross	n/a	n/a	n/a	cross.bmp
-65.2798181818	n/a	16319.9545	show_face	famous_face	first_show	5	f071.bmp
-65.8634545455	n/a	16465.8636	right_press	n/a	n/a	4096	n/a
-66.2870909091	n/a	16571.7727	show_circle	n/a	n/a	0	circle.bmp
-67.9870909091	n/a	16996.7727	show_cross	n/a	n/a	n/a	cross.bmp
-68.5034545455	n/a	17125.8636	show_face	famous_face	first_show	5	f037.bmp
-69.3734545455	n/a	17343.3636	show_circle	n/a	n/a	0	circle.bmp
-71.0734545455	n/a	17768.3636	show_cross	n/a	n/a	n/a	cross.bmp
-71.6770909091	n/a	17919.2727	show_face	famous_face	immediate_repeat	6	f037.bmp
-72.5389090909	n/a	18134.7273	show_circle	n/a	n/a	0	circle.bmp
-74.2389090909	n/a	18559.7273	show_cross	n/a	n/a	n/a	cross.bmp
-74.8516363636	n/a	18712.9091	show_face	scrambled_face	delayed_repeat	19	s006.bmp
-75.7270909091	n/a	18931.7727	show_circle	n/a	n/a	0	circle.bmp
-75.7489090909	n/a	18937.2273	right_press	n/a	n/a	4096	n/a
-77.4270909091	n/a	19356.7727	show_cross	n/a	n/a	n/a	cross.bmp
-78.0589090909	n/a	19514.7273	show_face	famous_face	first_show	5	f018.bmp
-78.8289090909	n/a	19707.2273	right_press	n/a	n/a	4096	n/a
-78.9243636364	n/a	19731.0909	show_circle	n/a	n/a	0	circle.bmp
-80.6243636364	n/a	20156.0909	show_cross	n/a	n/a	n/a	cross.bmp
-81.1661818182	n/a	20291.5455	show_face	scrambled_face	delayed_repeat	19	s029.bmp
-82.1507272727	n/a	20537.6818	show_circle	n/a	n/a	0	circle.bmp
-83.8507272727	n/a	20962.6818	show_cross	n/a	n/a	n/a	cross.bmp
-84.3734545455	n/a	21093.3636	show_face	famous_face	first_show	5	f122.bmp
-85.0889090909	n/a	21272.2273	right_press	n/a	n/a	4096	n/a
-85.3452727273	n/a	21336.3182	show_circle	n/a	n/a	0	circle.bmp
-87.0452727273	n/a	21761.3182	show_cross	n/a	n/a	n/a	cross.bmp
-87.6143636364	n/a	21903.5909	show_face	scrambled_face	first_show	17	s080.bmp
-88.4316363636	n/a	22107.9091	right_press	n/a	n/a	4096	n/a
-88.5870909091	n/a	22146.7727	show_circle	n/a	n/a	0	circle.bmp
-90.2870909091	n/a	22571.7727	show_cross	n/a	n/a	n/a	cross.bmp
-90.9052727273	n/a	22726.3182	show_face	unfamiliar_face	delayed_repeat	15	u061.bmp
-91.5980000000	n/a	22899.5	right_press	n/a	n/a	4096	n/a
-91.8252727273	n/a	22956.3182	show_circle	n/a	n/a	0	circle.bmp
-93.5252727273	n/a	23381.3182	show_cross	n/a	n/a	n/a	cross.bmp
-94.0452727273	n/a	23511.3182	show_face	famous_face	first_show	5	f047.bmp
-94.9825454545	n/a	23745.6364	show_circle	n/a	n/a	0	circle.bmp
-96.6825454545	n/a	24170.6364	show_cross	n/a	n/a	n/a	cross.bmp
-97.3198181818	n/a	24329.9545	show_face	famous_face	immediate_repeat	6	f047.bmp
-98.2652727273	n/a	24566.3182	show_circle	n/a	n/a	0	circle.bmp
-99.9652727273	n/a	24991.3182	show_cross	n/a	n/a	n/a	cross.bmp
-100.6107272727	n/a	25152.6818	show_face	famous_face	delayed_repeat	7	f071.bmp
-101.2434545455	n/a	25310.8636	right_press	n/a	n/a	4096	n/a
-101.5698181818	n/a	25392.4545	show_circle	n/a	n/a	0	circle.bmp
-103.2698181818	n/a	25817.4545	show_cross	n/a	n/a	n/a	cross.bmp
-103.8852727273	n/a	25971.3182	show_face	unfamiliar_face	first_show	13	u133.bmp
-104.7716363636	n/a	26192.9091	show_circle	n/a	n/a	0	circle.bmp
-106.4716363636	n/a	26617.9091	show_cross	n/a	n/a	n/a	cross.bmp
-107.0252727273	n/a	26756.3182	show_face	scrambled_face	first_show	17	s004.bmp
-107.9407272727	n/a	26985.1818	show_circle	n/a	n/a	0	circle.bmp
-109.6407272727	n/a	27410.1818	show_cross	n/a	n/a	n/a	cross.bmp
-110.2161818182	n/a	27554.0455	show_face	famous_face	delayed_repeat	7	f018.bmp
-111.0889090909	n/a	27772.2273	show_circle	n/a	n/a	0	circle.bmp
-112.7889090909	n/a	28197.2273	show_cross	n/a	n/a	n/a	cross.bmp
-113.3907272727	n/a	28347.6818	show_face	famous_face	first_show	5	f007.bmp
-114.0007272727	n/a	28500.1818	right_press	n/a	n/a	4096	n/a
-114.3534545455	n/a	28588.3636	show_circle	n/a	n/a	0	circle.bmp
-116.0534545455	n/a	29013.3636	show_cross	n/a	n/a	n/a	cross.bmp
-116.6307272727	n/a	29157.6818	show_face	famous_face	immediate_repeat	6	f007.bmp
-117.2934545455	n/a	29323.3636	right_press	n/a	n/a	4096	n/a
-117.5452727273	n/a	29386.3182	show_circle	n/a	n/a	0	circle.bmp
-119.2452727273	n/a	29811.3182	show_cross	n/a	n/a	n/a	cross.bmp
-119.8052727273	n/a	29951.3182	show_face	famous_face	delayed_repeat	7	f122.bmp
-120.4316363636	n/a	30107.9091	right_press	n/a	n/a	4096	n/a
-120.6870909091	n/a	30171.7727	show_circle	n/a	n/a	0	circle.bmp
-122.3870909091	n/a	30596.7727	show_cross	n/a	n/a	n/a	cross.bmp
-122.9625454545	n/a	30740.6364	show_face	famous_face	first_show	5	f101.bmp
-123.8189090909	n/a	30954.7273	right_press	n/a	n/a	4096	n/a
-123.8243636364	n/a	30956.0909	show_circle	n/a	n/a	0	circle.bmp
-125.5243636364	n/a	31381.0909	show_cross	n/a	n/a	n/a	cross.bmp
-126.1534545455	n/a	31538.3636	show_face	scrambled_face	delayed_repeat	19	s080.bmp
-127.0898181818	n/a	31772.4545	show_circle	n/a	n/a	0	circle.bmp
-128.7898181818	n/a	32197.4545	show_cross	n/a	n/a	n/a	cross.bmp
-129.4107272727	n/a	32352.6818	show_face	unfamiliar_face	first_show	13	u038.bmp
-130.3998181818	n/a	32599.9545	show_circle	n/a	n/a	0	circle.bmp
-132.0998181818	n/a	33024.9545	show_cross	n/a	n/a	n/a	cross.bmp
-132.7180000000	n/a	33179.5	show_face	famous_face	first_show	5	f108.bmp
-133.2580000000	n/a	33314.5	right_press	n/a	n/a	4096	n/a
-133.7152727273	n/a	33428.8182	show_circle	n/a	n/a	0	circle.bmp
-135.4152727273	n/a	33853.8182	show_cross	n/a	n/a	n/a	cross.bmp
-135.9425454545	n/a	33985.6364	show_face	famous_face	immediate_repeat	6	f108.bmp
-136.4916363636	n/a	34122.9091	right_press	n/a	n/a	4096	n/a
-136.9216363636	n/a	34230.4091	show_circle	n/a	n/a	0	circle.bmp
-138.6216363636	n/a	34655.4091	show_cross	n/a	n/a	n/a	cross.bmp
-139.1161818182	n/a	34779.0455	show_face	unfamiliar_face	delayed_repeat	15	u133.bmp
-140.0889090909	n/a	35022.2273	show_circle	n/a	n/a	0	circle.bmp
-141.7889090909	n/a	35447.2273	show_cross	n/a	n/a	n/a	cross.bmp
-142.3234545455	n/a	35580.8636	show_face	scrambled_face	first_show	17	s094.bmp
-143.0525454545	n/a	35763.1364	right_press	n/a	n/a	4096	n/a
-143.2980000000	n/a	35824.5	show_circle	n/a	n/a	0	circle.bmp
-144.9980000000	n/a	36249.5	show_cross	n/a	n/a	n/a	cross.bmp
-145.5143636364	n/a	36378.5909	show_face	scrambled_face	immediate_repeat	18	s094.bmp
-146.1352727273	n/a	36533.8182	right_press	n/a	n/a	4096	n/a
-146.3943636364	n/a	36598.5909	show_circle	n/a	n/a	0	circle.bmp
-148.0943636364	n/a	37023.5909	show_cross	n/a	n/a	n/a	cross.bmp
-148.6380000000	n/a	37159.5	show_face	scrambled_face	delayed_repeat	19	s004.bmp
-149.2289090909	n/a	37307.2273	right_press	n/a	n/a	4096	n/a
-149.6207272727	n/a	37405.1818	show_circle	n/a	n/a	0	circle.bmp
-151.3207272727	n/a	37830.1818	show_cross	n/a	n/a	n/a	cross.bmp
-151.7952727273	n/a	37948.8182	show_face	unfamiliar_face	first_show	13	u121.bmp
-152.7552727273	n/a	38188.8182	right_press	n/a	n/a	4096	n/a
-152.7907272727	n/a	38197.6818	show_circle	n/a	n/a	0	circle.bmp
-154.4907272727	n/a	38622.6818	show_cross	n/a	n/a	n/a	cross.bmp
-155.0698181818	n/a	38767.4545	show_face	unfamiliar_face	immediate_repeat	14	u121.bmp
-155.7398181818	n/a	38934.9545	right_press	n/a	n/a	4096	n/a
-156.0752727273	n/a	39018.8182	show_circle	n/a	n/a	0	circle.bmp
-157.7752727273	n/a	39443.8182	show_cross	n/a	n/a	n/a	cross.bmp
-158.3107272727	n/a	39577.6818	show_face	scrambled_face	first_show	17	s095.bmp
-159.1607272727	n/a	39790.1818	show_circle	n/a	n/a	0	circle.bmp
-160.8607272727	n/a	40215.1818	show_cross	n/a	n/a	n/a	cross.bmp
-161.4343636364	n/a	40358.5909	show_face	famous_face	delayed_repeat	7	f101.bmp
-162.1052727273	n/a	40526.3182	right_press	n/a	n/a	4096	n/a
-162.3216363636	n/a	40580.4091	show_circle	n/a	n/a	0	circle.bmp
-164.0216363636	n/a	41005.4091	show_cross	n/a	n/a	n/a	cross.bmp
-164.6580000000	n/a	41164.5	show_face	scrambled_face	first_show	17	s061.bmp
-165.3743636364	n/a	41343.5909	right_press	n/a	n/a	4096	n/a
-165.5989090909	n/a	41399.7273	show_circle	n/a	n/a	0	circle.bmp
-167.2989090909	n/a	41824.7273	show_cross	n/a	n/a	n/a	cross.bmp
-167.8152727273	n/a	41953.8182	show_face	scrambled_face	immediate_repeat	18	s061.bmp
-168.5570909091	n/a	42139.2727	right_press	n/a	n/a	4096	n/a
-168.7689090909	n/a	42192.2273	show_circle	n/a	n/a	0	circle.bmp
-170.4689090909	n/a	42617.2273	show_cross	n/a	n/a	n/a	cross.bmp
-170.9734545455	n/a	42743.3636	show_face	unfamiliar_face	delayed_repeat	15	u038.bmp
-171.8043636364	n/a	42951.0909	show_circle	n/a	n/a	0	circle.bmp
-173.5043636364	n/a	43376.0909	show_cross	n/a	n/a	n/a	cross.bmp
-174.0470909091	n/a	43511.7727	show_face	unfamiliar_face	first_show	13	u067.bmp
-175.0134545455	n/a	43753.3636	show_circle	n/a	n/a	0	circle.bmp
-176.7134545455	n/a	44178.3636	show_cross	n/a	n/a	n/a	cross.bmp
-177.2370909091	n/a	44309.2727	show_face	unfamiliar_face	immediate_repeat	14	u067.bmp
-178.1434545455	n/a	44535.8636	show_circle	n/a	n/a	0	circle.bmp
-179.8434545455	n/a	44960.8636	show_cross	n/a	n/a	n/a	cross.bmp
-180.4616363636	n/a	45115.4091	show_face	scrambled_face	first_show	17	s130.bmp
-181.4152727273	n/a	45353.8182	show_circle	n/a	n/a	0	circle.bmp
-183.1152727273	n/a	45778.8182	show_cross	n/a	n/a	n/a	cross.bmp
-183.6525454545	n/a	45913.1364	show_face	unfamiliar_face	first_show	13	u035.bmp
-184.4798181818	n/a	46119.9545	right_press	n/a	n/a	4096	n/a
-184.5861818182	n/a	46146.5455	show_circle	n/a	n/a	0	circle.bmp
-186.2861818182	n/a	46571.5455	show_cross	n/a	n/a	n/a	cross.bmp
-186.8425454545	n/a	46710.6364	show_face	famous_face	first_show	5	f070.bmp
-187.5007272727	n/a	46875.1818	right_press	n/a	n/a	4096	n/a
-187.6970909091	n/a	46924.2727	show_circle	n/a	n/a	0	circle.bmp
-189.3970909091	n/a	47349.2727	show_cross	n/a	n/a	n/a	cross.bmp
-190.0170909091	n/a	47504.2727	show_face	scrambled_face	delayed_repeat	19	s095.bmp
-190.8870909091	n/a	47721.7727	show_circle	n/a	n/a	0	circle.bmp
-192.5870909091	n/a	48146.7727	show_cross	n/a	n/a	n/a	cross.bmp
-193.0907272727	n/a	48272.6818	show_face	scrambled_face	first_show	17	s064.bmp
-193.7398181818	n/a	48434.9545	right_press	n/a	n/a	4096	n/a
-194.0352727273	n/a	48508.8182	show_circle	n/a	n/a	0	circle.bmp
-195.7352727273	n/a	48933.8182	show_cross	n/a	n/a	n/a	cross.bmp
-196.3816363636	n/a	49095.4091	show_face	scrambled_face	first_show	17	s016.bmp
-196.9252727273	n/a	49231.3182	right_press	n/a	n/a	4096	n/a
-197.2298181818	n/a	49307.4545	show_circle	n/a	n/a	0	circle.bmp
-198.9298181818	n/a	49732.4545	show_cross	n/a	n/a	n/a	cross.bmp
-199.5052727273	n/a	49876.3182	show_face	scrambled_face	immediate_repeat	18	s016.bmp
-200.5207272727	n/a	50130.1818	show_circle	n/a	n/a	0	circle.bmp
-202.2207272727	n/a	50555.1818	show_cross	n/a	n/a	n/a	cross.bmp
-202.8634545455	n/a	50715.8636	show_face	scrambled_face	first_show	17	s147.bmp
-203.4170909091	n/a	50854.2727	right_press	n/a	n/a	4096	n/a
-203.7325454545	n/a	50933.1364	show_circle	n/a	n/a	0	circle.bmp
-205.4325454545	n/a	51358.1364	show_cross	n/a	n/a	n/a	cross.bmp
-206.0207272727	n/a	51505.1818	show_face	scrambled_face	immediate_repeat	18	s147.bmp
-206.6780000000	n/a	51669.5	right_press	n/a	n/a	4096	n/a
-206.9970909091	n/a	51749.2727	show_circle	n/a	n/a	0	circle.bmp
-208.6970909091	n/a	52174.2727	show_cross	n/a	n/a	n/a	cross.bmp
-209.2107272727	n/a	52302.6818	show_face	scrambled_face	delayed_repeat	19	s130.bmp
-209.7652727273	n/a	52441.3182	right_press	n/a	n/a	4096	n/a
-210.1898181818	n/a	52547.4545	show_circle	n/a	n/a	0	circle.bmp
-211.8898181818	n/a	52972.4545	show_cross	n/a	n/a	n/a	cross.bmp
-212.4516363636	n/a	53112.9091	show_face	scrambled_face	first_show	17	s047.bmp
-213.3989090909	n/a	53349.7273	show_circle	n/a	n/a	0	circle.bmp
-213.4389090909	n/a	53359.7273	right_press	n/a	n/a	4096	n/a
-215.0989090909	n/a	53774.7273	show_cross	n/a	n/a	n/a	cross.bmp
-215.7098181818	n/a	53927.4545	show_face	scrambled_face	immediate_repeat	18	s047.bmp
-216.4725454545	n/a	54118.1364	right_press	n/a	n/a	4096	n/a
-216.6780000000	n/a	54169.5	show_circle	n/a	n/a	0	circle.bmp
-218.3780000000	n/a	54594.5	show_cross	n/a	n/a	n/a	cross.bmp
-218.9498181818	n/a	54737.4545	show_face	unfamiliar_face	delayed_repeat	15	u035.bmp
-219.8389090909	n/a	54959.7273	show_circle	n/a	n/a	0	circle.bmp
-221.5389090909	n/a	55384.7273	show_cross	n/a	n/a	n/a	cross.bmp
-222.1743636364	n/a	55543.5909	show_face	unfamiliar_face	first_show	13	u115.bmp
-222.8061818182	n/a	55701.5455	right_press	n/a	n/a	4096	n/a
-223.0934545455	n/a	55773.3636	show_circle	n/a	n/a	0	circle.bmp
-224.7934545455	n/a	56198.3636	show_cross	n/a	n/a	n/a	cross.bmp
-225.3152727273	n/a	56328.8182	show_face	unfamiliar_face	immediate_repeat	14	u115.bmp
-225.8643636364	n/a	56466.0909	right_press	n/a	n/a	4096	n/a
-226.2661818182	n/a	56566.5455	show_circle	n/a	n/a	0	circle.bmp
-227.9661818182	n/a	56991.5455	show_cross	n/a	n/a	n/a	cross.bmp
-228.4725454545	n/a	57118.1364	show_face	famous_face	delayed_repeat	7	f070.bmp
-229.0889090909	n/a	57272.2273	right_press	n/a	n/a	4096	n/a
-229.3125454545	n/a	57328.1364	show_circle	n/a	n/a	0	circle.bmp
-231.0125454545	n/a	57753.1364	show_cross	n/a	n/a	n/a	cross.bmp
-231.5289090909	n/a	57882.2273	show_face	unfamiliar_face	first_show	13	u049.bmp
-232.1243636364	n/a	58031.0909	right_press	n/a	n/a	4096	n/a
-232.5398181818	n/a	58134.9545	show_circle	n/a	n/a	0	circle.bmp
-234.2398181818	n/a	58559.9545	show_cross	n/a	n/a	n/a	cross.bmp
-234.7361818182	n/a	58684.0455	show_face	scrambled_face	delayed_repeat	19	s064.bmp
-235.4052727273	n/a	58851.3182	right_press	n/a	n/a	4096	n/a
-235.5680000000	n/a	58892	show_circle	n/a	n/a	0	circle.bmp
-237.2680000000	n/a	59317	show_cross	n/a	n/a	n/a	cross.bmp
-237.7934545455	n/a	59448.3636	show_face	scrambled_face	first_show	17	s067.bmp
-238.2789090909	n/a	59569.7273	right_press	n/a	n/a	4096	n/a
-238.6552727273	n/a	59663.8182	show_circle	n/a	n/a	0	circle.bmp
-240.3552727273	n/a	60088.8182	show_cross	n/a	n/a	n/a	cross.bmp
-241.0007272727	n/a	60250.1818	show_face	famous_face	first_show	5	f056.bmp
-241.6634545455	n/a	60415.8636	right_press	n/a	n/a	4096	n/a
-241.9680000000	n/a	60492	show_circle	n/a	n/a	0	circle.bmp
-243.6680000000	n/a	60917	show_cross	n/a	n/a	n/a	cross.bmp
-244.2252727273	n/a	61056.3182	show_face	famous_face	immediate_repeat	6	f056.bmp
-244.9370909091	n/a	61234.2727	right_press	n/a	n/a	4096	n/a
-245.0780000000	n/a	61269.5	show_circle	n/a	n/a	0	circle.bmp
-246.7780000000	n/a	61694.5	show_cross	n/a	n/a	n/a	cross.bmp
-247.2325454545	n/a	61808.1364	show_face	scrambled_face	first_show	17	s002.bmp
-248.2098181818	n/a	62052.4545	show_circle	n/a	n/a	0	circle.bmp
-249.9098181818	n/a	62477.4545	show_cross	n/a	n/a	n/a	cross.bmp
-250.4898181818	n/a	62622.4545	show_face	unfamiliar_face	first_show	13	u092.bmp
-251.3452727273	n/a	62836.3182	show_circle	n/a	n/a	0	circle.bmp
-253.0452727273	n/a	63261.3182	show_cross	n/a	n/a	n/a	cross.bmp
-253.6634545455	n/a	63415.8636	show_face	unfamiliar_face	first_show	13	u091.bmp
-254.2607272727	n/a	63565.1818	right_press	n/a	n/a	4096	n/a
-254.6270909091	n/a	63656.7727	show_circle	n/a	n/a	0	circle.bmp
-256.3270909091	n/a	64081.7727	show_cross	n/a	n/a	n/a	cross.bmp
-256.9207272727	n/a	64230.1818	show_face	unfamiliar_face	delayed_repeat	15	u049.bmp
-257.7925454545	n/a	64448.1364	show_circle	n/a	n/a	0	circle.bmp
-257.8707272727	n/a	64467.6818	right_press	n/a	n/a	4096	n/a
-259.4925454545	n/a	64873.1364	show_cross	n/a	n/a	n/a	cross.bmp
-260.0452727273	n/a	65011.3182	show_face	famous_face	first_show	5	f052.bmp
-260.6480000000	n/a	65162	right_press	n/a	n/a	4096	n/a
-261.0161818182	n/a	65254.0455	show_circle	n/a	n/a	0	circle.bmp
-262.7161818182	n/a	65679.0455	show_cross	n/a	n/a	n/a	cross.bmp
-263.3189090909	n/a	65829.7273	show_face	famous_face	immediate_repeat	6	f052.bmp
-263.8307272727	n/a	65957.6818	right_press	n/a	n/a	4096	n/a
-264.1916363636	n/a	66047.9091	show_circle	n/a	n/a	0	circle.bmp
-265.8916363636	n/a	66472.9091	show_cross	n/a	n/a	n/a	cross.bmp
-266.3761818182	n/a	66594.0455	show_face	scrambled_face	delayed_repeat	19	s067.bmp
-267.0798181818	n/a	66769.9545	right_press	n/a	n/a	4096	n/a
-267.3343636364	n/a	66833.5909	show_circle	n/a	n/a	0	circle.bmp
-269.0343636364	n/a	67258.5909	show_cross	n/a	n/a	n/a	cross.bmp
-269.6007272727	n/a	67400.1818	show_face	unfamiliar_face	first_show	13	u029.bmp
-270.2743636364	n/a	67568.5909	right_press	n/a	n/a	4096	n/a
-270.5107272727	n/a	67627.6818	show_circle	n/a	n/a	0	circle.bmp
-272.2107272727	n/a	68052.6818	show_cross	n/a	n/a	n/a	cross.bmp
-272.8080000000	n/a	68202	show_face	famous_face	first_show	5	f114.bmp
-273.6298181818	n/a	68407.4545	show_circle	n/a	n/a	0	circle.bmp
-275.3298181818	n/a	68832.4545	show_cross	n/a	n/a	n/a	cross.bmp
-275.8316363636	n/a	68957.9091	show_face	famous_face	immediate_repeat	6	f114.bmp
-276.7561818182	n/a	69189.0455	show_circle	n/a	n/a	0	circle.bmp
-278.4561818182	n/a	69614.0455	show_cross	n/a	n/a	n/a	cross.bmp
-279.0052727273	n/a	69751.3182	show_face	scrambled_face	delayed_repeat	19	s002.bmp
-279.6189090909	n/a	69904.7273	right_press	n/a	n/a	4096	n/a
-279.9880000000	n/a	69997	show_circle	n/a	n/a	0	circle.bmp
-281.6880000000	n/a	70422	show_cross	n/a	n/a	n/a	cross.bmp
-282.1789090909	n/a	70544.7273	show_face	scrambled_face	first_show	17	s120.bmp
-282.8361818182	n/a	70709.0455	right_press	n/a	n/a	4096	n/a
-283.1798181818	n/a	70794.9545	show_circle	n/a	n/a	0	circle.bmp
-284.8798181818	n/a	71219.9545	show_cross	n/a	n/a	n/a	cross.bmp
-285.3534545455	n/a	71338.3636	show_face	unfamiliar_face	delayed_repeat	15	u092.bmp
-286.0107272727	n/a	71502.6818	right_press	n/a	n/a	4096	n/a
-286.3543636364	n/a	71588.5909	show_circle	n/a	n/a	0	circle.bmp
-288.0543636364	n/a	72013.5909	show_cross	n/a	n/a	n/a	cross.bmp
-288.5943636364	n/a	72148.5909	show_face	scrambled_face	first_show	17	s049.bmp
-289.5916363636	n/a	72397.9091	show_circle	n/a	n/a	0	circle.bmp
-291.2916363636	n/a	72822.9091	show_cross	n/a	n/a	n/a	cross.bmp
-291.7516363636	n/a	72937.9091	show_face	scrambled_face	immediate_repeat	18	s049.bmp
-292.6507272727	n/a	73162.6818	show_circle	n/a	n/a	0	circle.bmp
-294.3507272727	n/a	73587.6818	show_cross	n/a	n/a	n/a	cross.bmp
-294.8416363636	n/a	73710.4091	show_face	unfamiliar_face	delayed_repeat	15	u091.bmp
-295.6380000000	n/a	73909.5	right_press	n/a	n/a	4096	n/a
-295.6998181818	n/a	73924.9545	show_circle	n/a	n/a	0	circle.bmp
-297.3998181818	n/a	74349.9545	show_cross	n/a	n/a	n/a	cross.bmp
-298.0489090909	n/a	74512.2273	show_face	scrambled_face	first_show	17	s128.bmp
-298.9680000000	n/a	74742	show_circle	n/a	n/a	0	circle.bmp
-299.0498181818	n/a	74762.4545	right_press	n/a	n/a	4096	n/a
-300.6680000000	n/a	75167	show_cross	n/a	n/a	n/a	cross.bmp
-301.2561818182	n/a	75314.0455	show_face	scrambled_face	immediate_repeat	18	s128.bmp
-301.8116363636	n/a	75452.9091	right_press	n/a	n/a	4096	n/a
-302.1143636364	n/a	75528.5909	show_circle	n/a	n/a	0	circle.bmp
-303.8143636364	n/a	75953.5909	show_cross	n/a	n/a	n/a	cross.bmp
-304.4470909091	n/a	76111.7727	show_face	scrambled_face	first_show	17	s106.bmp
-304.9670909091	n/a	76241.7727	right_press	n/a	n/a	4096	n/a
-305.3807272727	n/a	76345.1818	show_circle	n/a	n/a	0	circle.bmp
-307.0807272727	n/a	76770.1818	show_cross	n/a	n/a	n/a	cross.bmp
-307.5543636364	n/a	76888.5909	show_face	scrambled_face	immediate_repeat	18	s106.bmp
-308.1234545455	n/a	77030.8636	right_press	n/a	n/a	4096	n/a
-308.4389090909	n/a	77109.7273	show_circle	n/a	n/a	0	circle.bmp
-310.1389090909	n/a	77534.7273	show_cross	n/a	n/a	n/a	cross.bmp
-310.6452727273	n/a	77661.3182	show_face	unfamiliar_face	delayed_repeat	15	u029.bmp
-311.3098181818	n/a	77827.4545	right_press	n/a	n/a	4096	n/a
-311.4861818182	n/a	77871.5455	show_circle	n/a	n/a	0	circle.bmp
-313.1861818182	n/a	78296.5455	show_cross	n/a	n/a	n/a	cross.bmp
-313.7352727273	n/a	78433.8182	show_face	scrambled_face	first_show	17	s003.bmp
-314.6925454545	n/a	78673.1364	show_circle	n/a	n/a	0	circle.bmp
-316.3925454545	n/a	79098.1364	show_cross	n/a	n/a	n/a	cross.bmp
-316.9598181818	n/a	79239.9545	show_face	scrambled_face	immediate_repeat	18	s003.bmp
-317.8698181818	n/a	79467.4545	show_circle	n/a	n/a	0	circle.bmp
-319.5698181818	n/a	79892.4545	show_cross	n/a	n/a	n/a	cross.bmp
-320.1998181818	n/a	80049.9545	show_face	famous_face	first_show	5	f075.bmp
-321.0343636364	n/a	80258.5909	right_press	n/a	n/a	4096	n/a
-321.1825454545	n/a	80295.6364	show_circle	n/a	n/a	0	circle.bmp
-322.8825454545	n/a	80720.6364	show_cross	n/a	n/a	n/a	cross.bmp
-323.4580000000	n/a	80864.5	show_face	scrambled_face	delayed_repeat	19	s120.bmp
-323.9189090909	n/a	80979.7273	right_press	n/a	n/a	4096	n/a
-324.3752727273	n/a	81093.8182	show_circle	n/a	n/a	0	circle.bmp
-326.0752727273	n/a	81518.8182	show_cross	n/a	n/a	n/a	cross.bmp
-326.6652727273	n/a	81666.3182	show_face	unfamiliar_face	first_show	13	u113.bmp
-327.2725454545	n/a	81818.1364	right_press	n/a	n/a	4096	n/a
-327.6089090909	n/a	81902.2273	show_circle	n/a	n/a	0	circle.bmp
-329.3089090909	n/a	82327.2273	show_cross	n/a	n/a	n/a	cross.bmp
-329.9225454545	n/a	82480.6364	show_face	famous_face	first_show	5	f091.bmp
-330.4216363636	n/a	82605.4091	right_press	n/a	n/a	4096	n/a
-330.8561818182	n/a	82714.0455	show_circle	n/a	n/a	0	circle.bmp
-332.5561818182	n/a	83139.0455	show_cross	n/a	n/a	n/a	cross.bmp
-333.1134545455	n/a	83278.3636	show_face	famous_face	immediate_repeat	6	f091.bmp
-333.5680000000	n/a	83392	right_press	n/a	n/a	4096	n/a
-333.9961818182	n/a	83499.0455	show_circle	n/a	n/a	0	circle.bmp
-335.6961818182	n/a	83924.0455	show_cross	n/a	n/a	n/a	cross.bmp
-336.2543636364	n/a	84063.5909	show_face	unfamiliar_face	first_show	13	u024.bmp
-337.1970909091	n/a	84299.2727	show_circle	n/a	n/a	0	circle.bmp
-338.8970909091	n/a	84724.2727	show_cross	n/a	n/a	n/a	cross.bmp
-339.5280000000	n/a	84882	show_face	famous_face	first_show	5	f076.bmp
-340.1989090909	n/a	85049.7273	right_press	n/a	n/a	4096	n/a
-340.4780000000	n/a	85119.5	show_circle	n/a	n/a	0	circle.bmp
-342.1780000000	n/a	85544.5	show_cross	n/a	n/a	n/a	cross.bmp
-342.6689090909	n/a	85667.2273	show_face	unfamiliar_face	first_show	13	u016.bmp
-343.5316363636	n/a	85882.9091	show_circle	n/a	n/a	0	circle.bmp
-345.2316363636	n/a	86307.9091	show_cross	n/a	n/a	n/a	cross.bmp
-345.8425454545	n/a	86460.6364	show_face	unfamiliar_face	immediate_repeat	14	u016.bmp
-346.6643636364	n/a	86666.0909	show_circle	n/a	n/a	0	circle.bmp
-348.3643636364	n/a	87091.0909	show_cross	n/a	n/a	n/a	cross.bmp
-348.8661818182	n/a	87216.5455	show_face	famous_face	delayed_repeat	7	f075.bmp
-349.4370909091	n/a	87359.2727	right_press	n/a	n/a	4096	n/a
-349.8734545455	n/a	87468.3636	show_circle	n/a	n/a	0	circle.bmp
-351.5734545455	n/a	87893.3636	show_cross	n/a	n/a	n/a	cross.bmp
-352.1407272727	n/a	88035.1818	show_face	scrambled_face	first_show	17	s121.bmp
-352.7689090909	n/a	88192.2273	right_press	n/a	n/a	4096	n/a
-353.0980000000	n/a	88274.5	show_circle	n/a	n/a	0	circle.bmp
-354.7980000000	n/a	88699.5	show_cross	n/a	n/a	n/a	cross.bmp
-355.4316363636	n/a	88857.9091	show_face	unfamiliar_face	delayed_repeat	15	u113.bmp
-355.9934545455	n/a	88998.3636	right_press	n/a	n/a	4096	n/a
-356.3470909091	n/a	89086.7727	show_circle	n/a	n/a	0	circle.bmp
-358.0470909091	n/a	89511.7727	show_cross	n/a	n/a	n/a	cross.bmp
-358.5052727273	n/a	89626.3182	show_face	famous_face	first_show	5	f115.bmp
-359.1743636364	n/a	89793.5909	right_press	n/a	n/a	4096	n/a
-359.5180000000	n/a	89879.5	show_circle	n/a	n/a	0	circle.bmp
-361.2180000000	n/a	90304.5	show_cross	n/a	n/a	n/a	cross.bmp
-361.7961818182	n/a	90449.0455	show_face	scrambled_face	first_show	17	s070.bmp
-362.4398181818	n/a	90609.9545	right_press	n/a	n/a	4096	n/a
-362.8016363636	n/a	90700.4091	show_circle	n/a	n/a	0	circle.bmp
-364.5016363636	n/a	91125.4091	show_cross	n/a	n/a	n/a	cross.bmp
-364.9534545455	n/a	91238.3636	show_face	scrambled_face	immediate_repeat	18	s070.bmp
-365.5561818182	n/a	91389.0455	right_press	n/a	n/a	4096	n/a
-365.9343636364	n/a	91483.5909	show_circle	n/a	n/a	0	circle.bmp
-367.6343636364	n/a	91908.5909	show_cross	n/a	n/a	n/a	cross.bmp
-368.1107272727	n/a	92027.6818	show_face	unfamiliar_face	delayed_repeat	15	u024.bmp
-368.9443636364	n/a	92236.0909	show_circle	n/a	n/a	0	circle.bmp
-370.6443636364	n/a	92661.0909	show_cross	n/a	n/a	n/a	cross.bmp
-371.1343636364	n/a	92783.5909	show_face	unfamiliar_face	first_show	13	u028.bmp
-372.0525454545	n/a	93013.1364	show_circle	n/a	n/a	0	circle.bmp
-373.7525454545	n/a	93438.1364	show_cross	n/a	n/a	n/a	cross.bmp
-374.3580000000	n/a	93589.5	show_face	famous_face	delayed_repeat	7	f076.bmp
-375.3761818182	n/a	93844.0455	show_circle	n/a	n/a	0	circle.bmp
-377.0761818182	n/a	94269.0455	show_cross	n/a	n/a	n/a	cross.bmp
-377.7161818182	n/a	94429.0455	show_face	famous_face	first_show	5	f011.bmp
-378.5307272727	n/a	94632.6818	right_press	n/a	n/a	4096	n/a
-378.6870909091	n/a	94671.7727	show_circle	n/a	n/a	0	circle.bmp
-380.3870909091	n/a	95096.7727	show_cross	n/a	n/a	n/a	cross.bmp
-380.8570909091	n/a	95214.2727	show_face	scrambled_face	first_show	17	s017.bmp
-381.4125454545	n/a	95353.1364	right_press	n/a	n/a	4096	n/a
-381.8643636364	n/a	95466.0909	show_circle	n/a	n/a	0	circle.bmp
-383.5643636364	n/a	95891.0909	show_cross	n/a	n/a	n/a	cross.bmp
-384.1480000000	n/a	96037	show_face	scrambled_face	immediate_repeat	18	s017.bmp
-384.6470909091	n/a	96161.7727	right_press	n/a	n/a	4096	n/a
-385.1516363636	n/a	96287.9091	show_circle	n/a	n/a	0	circle.bmp
-386.8516363636	n/a	96712.9091	show_cross	n/a	n/a	n/a	cross.bmp
-387.3216363636	n/a	96830.4091	show_face	scrambled_face	delayed_repeat	19	s121.bmp
-387.8852727273	n/a	96971.3182	right_press	n/a	n/a	4096	n/a
-388.1398181818	n/a	97034.9545	show_circle	n/a	n/a	0	circle.bmp
-389.8398181818	n/a	97459.9545	show_cross	n/a	n/a	n/a	cross.bmp
-390.4789090909	n/a	97619.7273	show_face	unfamiliar_face	first_show	13	u094.bmp
-391.0580000000	n/a	97764.5	right_press	n/a	n/a	4096	n/a
-391.2980000000	n/a	97824.5	show_circle	n/a	n/a	0	circle.bmp
-392.9980000000	n/a	98249.5	show_cross	n/a	n/a	n/a	cross.bmp
-393.5534545455	n/a	98388.3636	show_face	unfamiliar_face	immediate_repeat	14	u094.bmp
-394.0180000000	n/a	98504.5	right_press	n/a	n/a	4096	n/a
-394.5507272727	n/a	98637.6818	show_circle	n/a	n/a	0	circle.bmp
-396.2507272727	n/a	99062.6818	show_cross	n/a	n/a	n/a	cross.bmp
-396.8098181818	n/a	99202.4545	show_face	famous_face	delayed_repeat	7	f115.bmp
-397.4561818182	n/a	99364.0455	right_press	n/a	n/a	4096	n/a
-397.8234545455	n/a	99455.8636	show_circle	n/a	n/a	0	circle.bmp
-399.5234545455	n/a	99880.8636	show_cross	n/a	n/a	n/a	cross.bmp
-400.1007272727	n/a	100025.1818	show_face	scrambled_face	first_show	17	s059.bmp
-400.9843636364	n/a	100246.0909	show_circle	n/a	n/a	0	circle.bmp
-400.9907272727	n/a	100247.6818	right_press	n/a	n/a	4096	n/a
-402.6843636364	n/a	100671.0909	show_cross	n/a	n/a	n/a	cross.bmp
-403.2080000000	n/a	100802	show_face	scrambled_face	first_show	17	s050.bmp
-403.9334545455	n/a	100983.3636	right_press	n/a	n/a	4096	n/a
-404.2161818182	n/a	101054.0455	show_circle	n/a	n/a	0	circle.bmp
-405.9161818182	n/a	101479.0455	show_cross	n/a	n/a	n/a	cross.bmp
-406.5507272727	n/a	101637.6818	show_face	scrambled_face	immediate_repeat	18	s050.bmp
-407.3670909091	n/a	101841.7727	show_circle	n/a	n/a	0	circle.bmp
-407.4270909091	n/a	101856.7727	right_press	n/a	n/a	4096	n/a
-409.0670909091	n/a	102266.7727	show_cross	n/a	n/a	n/a	cross.bmp
-409.5398181818	n/a	102384.9545	show_face	unfamiliar_face	delayed_repeat	15	u028.bmp
-410.4770909091	n/a	102619.2727	show_circle	n/a	n/a	0	circle.bmp
-412.1770909091	n/a	103044.2727	show_cross	n/a	n/a	n/a	cross.bmp
-412.6470909091	n/a	103161.7727	show_face	unfamiliar_face	first_show	13	u007.bmp
-413.5952727273	n/a	103398.8182	show_circle	n/a	n/a	0	circle.bmp
-415.2952727273	n/a	103823.8182	show_cross	n/a	n/a	n/a	cross.bmp
-415.9043636364	n/a	103976.0909	show_face	famous_face	delayed_repeat	7	f011.bmp
-416.5243636364	n/a	104131.0909	right_press	n/a	n/a	4096	n/a
-416.8870909091	n/a	104221.7727	show_circle	n/a	n/a	0	circle.bmp
-418.5870909091	n/a	104646.7727	show_cross	n/a	n/a	n/a	cross.bmp
-419.0952727273	n/a	104773.8182	show_face	unfamiliar_face	first_show	13	u071.bmp
-419.6570909091	n/a	104914.2727	right_press	n/a	n/a	4096	n/a
-420.0189090909	n/a	105004.7273	show_circle	n/a	n/a	0	circle.bmp
-421.7189090909	n/a	105429.7273	show_cross	n/a	n/a	n/a	cross.bmp
-422.2698181818	n/a	105567.4545	show_face	unfamiliar_face	first_show	13	u090.bmp
-423.2198181818	n/a	105804.9545	show_circle	n/a	n/a	0	circle.bmp
-424.9198181818	n/a	106229.9545	show_cross	n/a	n/a	n/a	cross.bmp
-425.5434545455	n/a	106385.8636	show_face	unfamiliar_face	immediate_repeat	14	u090.bmp
-426.5007272727	n/a	106625.1818	show_circle	n/a	n/a	0	circle.bmp
-428.2007272727	n/a	107050.1818	show_cross	n/a	n/a	n/a	cross.bmp
-428.6834545455	n/a	107170.8636	show_face	famous_face	first_show	5	f069.bmp
-429.5643636364	n/a	107391.0909	show_circle	n/a	n/a	0	circle.bmp
-431.2643636364	n/a	107816.0909	show_cross	n/a	n/a	n/a	cross.bmp
-431.9080000000	n/a	107977	show_face	famous_face	immediate_repeat	6	f069.bmp
-432.8298181818	n/a	108207.4545	show_circle	n/a	n/a	0	circle.bmp
-434.5298181818	n/a	108632.4545	show_cross	n/a	n/a	n/a	cross.bmp
-435.0980000000	n/a	108774.5	show_face	scrambled_face	delayed_repeat	19	s059.bmp
-435.9480000000	n/a	108987	show_circle	n/a	n/a	0	circle.bmp
-436.1061818182	n/a	109026.5455	right_press	n/a	n/a	4096	n/a
-437.6480000000	n/a	109412	show_cross	n/a	n/a	n/a	cross.bmp
-438.2389090909	n/a	109559.7273	show_face	famous_face	first_show	5	f078.bmp
-439.2398181818	n/a	109809.9545	show_circle	n/a	n/a	0	circle.bmp
-440.9398181818	n/a	110234.9545	show_cross	n/a	n/a	n/a	cross.bmp
-441.4298181818	n/a	110357.4545	show_face	famous_face	immediate_repeat	6	f078.bmp
-442.3843636364	n/a	110596.0909	show_circle	n/a	n/a	0	circle.bmp
-444.0843636364	n/a	111021.0909	show_cross	n/a	n/a	n/a	cross.bmp
-444.6370909091	n/a	111159.2727	show_face	famous_face	first_show	5	f090.bmp
-445.5825454545	n/a	111395.6364	show_circle	n/a	n/a	0	circle.bmp
-447.2825454545	n/a	111820.6364	show_cross	n/a	n/a	n/a	cross.bmp
-447.8943636364	n/a	111973.5909	show_face	famous_face	immediate_repeat	6	f090.bmp
-448.8134545455	n/a	112203.3636	show_circle	n/a	n/a	0	circle.bmp
-450.5134545455	n/a	112628.3636	show_cross	n/a	n/a	n/a	cross.bmp
-450.9852727273	n/a	112746.3182	show_face	unfamiliar_face	delayed_repeat	15	u007.bmp
-451.9270909091	n/a	112981.7727	show_circle	n/a	n/a	0	circle.bmp
-453.6270909091	n/a	113406.7727	show_cross	n/a	n/a	n/a	cross.bmp
-454.1089090909	n/a	113527.2273	show_face	unfamiliar_face	first_show	13	u110.bmp
-454.7789090909	n/a	113694.7273	right_press	n/a	n/a	4096	n/a
-455.1207272727	n/a	113780.1818	show_circle	n/a	n/a	0	circle.bmp
-456.8207272727	n/a	114205.1818	show_cross	n/a	n/a	n/a	cross.bmp
-457.4661818182	n/a	114366.5455	show_face	unfamiliar_face	immediate_repeat	14	u110.bmp
-458.0280000000	n/a	114507	right_press	n/a	n/a	4096	n/a
-458.4798181818	n/a	114619.9545	show_circle	n/a	n/a	0	circle.bmp
-460.1798181818	n/a	115044.9545	show_cross	n/a	n/a	n/a	cross.bmp
-460.6907272727	n/a	115172.6818	show_face	unfamiliar_face	delayed_repeat	15	u071.bmp
-461.4089090909	n/a	115352.2273	right_press	n/a	n/a	4096	n/a
-461.6770909091	n/a	115419.2727	show_circle	n/a	n/a	0	circle.bmp
-463.3770909091	n/a	115844.2727	show_cross	n/a	n/a	n/a	cross.bmp
-463.9152727273	n/a	115978.8182	show_face	unfamiliar_face	first_show	13	u104.bmp
-464.9107272727	n/a	116227.6818	show_circle	n/a	n/a	0	circle.bmp
-466.6107272727	n/a	116652.6818	show_cross	n/a	n/a	n/a	cross.bmp
-467.1225454545	n/a	116780.6364	show_face	unfamiliar_face	first_show	13	u043.bmp
-467.9880000000	n/a	116997	show_circle	n/a	n/a	0	circle.bmp
-469.6880000000	n/a	117422	show_cross	n/a	n/a	n/a	cross.bmp
-470.3125454545	n/a	117578.1364	show_face	unfamiliar_face	immediate_repeat	14	u043.bmp
-471.2261818182	n/a	117806.5455	show_circle	n/a	n/a	0	circle.bmp
-472.9261818182	n/a	118231.5455	show_cross	n/a	n/a	n/a	cross.bmp
-473.4034545455	n/a	118350.8636	show_face	famous_face	first_show	5	f116.bmp
-474.0116363636	n/a	118502.9091	right_press	n/a	n/a	4096	n/a
-474.3098181818	n/a	118577.4545	show_circle	n/a	n/a	0	circle.bmp
-476.0098181818	n/a	119002.4545	show_cross	n/a	n/a	n/a	cross.bmp
-476.5780000000	n/a	119144.5	show_face	famous_face	first_show	5	f142.bmp
-477.2125454545	n/a	119303.1364	right_press	n/a	n/a	4096	n/a
-477.4825454545	n/a	119370.6364	show_circle	n/a	n/a	0	circle.bmp
-479.1825454545	n/a	119795.6364	show_cross	n/a	n/a	n/a	cross.bmp
-479.8180000000	n/a	119954.5	show_face	famous_face	immediate_repeat	6	f142.bmp
-480.3234545455	n/a	120080.8636	right_press	n/a	n/a	4096	n/a
-480.7416363636	n/a	120185.4091	show_circle	n/a	n/a	0	circle.bmp
-482.4416363636	n/a	120610.4091	show_cross	n/a	n/a	n/a	cross.bmp
-482.9261818182	n/a	120731.5455	show_face	scrambled_face	first_show	17	s117.bmp
-483.8961818182	n/a	120974.0455	show_circle	n/a	n/a	0	circle.bmp
-485.5961818182	n/a	121399.0455	show_cross	n/a	n/a	n/a	cross.bmp
-486.1998181818	n/a	121549.9545	show_face	famous_face	first_show	5	f084.bmp
-486.7789090909	n/a	121694.7273	right_press	n/a	n/a	4096	n/a
-487.1834545455	n/a	121795.8636	show_circle	n/a	n/a	0	circle.bmp
-488.8834545455	n/a	122220.8636	show_cross	n/a	n/a	n/a	cross.bmp
-489.4743636364	n/a	122368.5909	show_face	unfamiliar_face	delayed_repeat	15	u104.bmp
-490.1134545455	n/a	122528.3636	right_press	n/a	n/a	4096	n/a
-490.3343636364	n/a	122583.5909	show_circle	n/a	n/a	0	circle.bmp
-492.0343636364	n/a	123008.5909	show_cross	n/a	n/a	n/a	cross.bmp
+onset	duration	sample	event_type	face_type	repetition_type	trial	trial_lag	trigger	stim_file
+0.004	n/a	1.0	setup	n/a	n/a	n/a	n/a	n/a	n/a
+0.004	n/a	1.0	right_sym	n/a	n/a	n/a	n/a	n/a	n/a
+24.3352727273	n/a	6083.8182	show_face	unfamiliar_face	first_show	1	n/a	13	u124.bmp
+25.1889090909	n/a	6297.2273	show_circle	n/a	n/a	1	n/a	0	circle.bmp
+26.8889090909	n/a	6722.2273	show_cross	n/a	n/a	2	n/a	n/a	cross.bmp
+27.3752727273	n/a	6843.8182	show_face	famous_face	first_show	2	n/a	5	f125.bmp
+28.057090909099998	n/a	7014.2727	right_press	n/a	n/a	2	n/a	4096	n/a
+28.356181818200003	n/a	7089.0455	show_circle	n/a	n/a	2	n/a	0	circle.bmp
+30.056181818200002	n/a	7514.0455	show_cross	n/a	n/a	3	n/a	n/a	cross.bmp
+30.5489090909	n/a	7637.2273	show_face	famous_face	immediate_repeat	3	1	6	f125.bmp
+31.1016363636	n/a	7775.4091	right_press	n/a	n/a	3	n/a	4096	n/a
+31.429818181799998	n/a	7857.4545	show_circle	n/a	n/a	3	n/a	0	circle.bmp
+33.1298181818	n/a	8282.4545	show_cross	n/a	n/a	4	n/a	n/a	cross.bmp
+33.723454545500005	n/a	8430.8636	show_face	famous_face	first_show	4	n/a	5	f012.bmp
+34.656181818200004	n/a	8664.0455	show_circle	n/a	n/a	4	n/a	0	circle.bmp
+36.3561818182	n/a	9089.0455	show_cross	n/a	n/a	5	n/a	n/a	cross.bmp
+36.8134545455	n/a	9203.3636	show_face	famous_face	immediate_repeat	5	1	6	f012.bmp
+37.3752727273	n/a	9343.8182	right_press	n/a	n/a	5	n/a	4096	n/a
+37.6589090909	n/a	9414.7273	show_circle	n/a	n/a	5	n/a	0	circle.bmp
+39.3589090909	n/a	9839.7273	show_cross	n/a	n/a	6	n/a	n/a	cross.bmp
+40.0216363636	n/a	10005.4091	show_face	unfamiliar_face	first_show	6	n/a	13	u044.bmp
+40.924363636399995	n/a	10231.0909	show_circle	n/a	n/a	6	n/a	0	circle.bmp
+42.6243636364	n/a	10656.0909	show_cross	n/a	n/a	7	n/a	n/a	cross.bmp
+43.2452727273	n/a	10811.3182	show_face	unfamiliar_face	immediate_repeat	7	1	14	u044.bmp
+44.2152727273	n/a	11053.8182	show_circle	n/a	n/a	7	n/a	0	circle.bmp
+45.91527272729999	n/a	11478.8182	show_cross	n/a	n/a	8	n/a	n/a	cross.bmp
+46.368909090900004	n/a	11592.2273	show_face	scrambled_face	first_show	8	n/a	17	s006.bmp
+47.013454545500004	n/a	11753.3636	right_press	n/a	n/a	8	n/a	4096	n/a
+47.3725454545	n/a	11843.1364	show_circle	n/a	n/a	8	n/a	0	circle.bmp
+49.072545454499995	n/a	12268.1364	show_cross	n/a	n/a	9	n/a	n/a	cross.bmp
+49.6270909091	n/a	12406.7727	show_face	scrambled_face	first_show	9	n/a	17	s029.bmp
+50.583454545500004	n/a	12645.8636	show_circle	n/a	n/a	9	n/a	0	circle.bmp
+52.2834545455	n/a	13070.8636	show_cross	n/a	n/a	10	n/a	n/a	cross.bmp
+52.817090909099996	n/a	13204.2727	show_face	unfamiliar_face	delayed_repeat	10	9	15	u124.bmp
+53.7134545455	n/a	13428.3636	show_circle	n/a	n/a	10	n/a	0	circle.bmp
+55.4134545455	n/a	13853.3636	show_cross	n/a	n/a	11	n/a	n/a	cross.bmp
+55.908	n/a	13977.0	show_face	unfamiliar_face	first_show	11	n/a	13	u106.bmp
+56.731636363599996	n/a	14182.9091	show_circle	n/a	n/a	11	n/a	0	circle.bmp
+58.4316363636	n/a	14607.9091	show_cross	n/a	n/a	12	n/a	n/a	cross.bmp
+58.914363636400005	n/a	14728.5909	show_face	unfamiliar_face	immediate_repeat	12	1	14	u106.bmp
+59.822545454499995	n/a	14955.6364	show_circle	n/a	n/a	12	n/a	0	circle.bmp
+61.5225454545	n/a	15380.6364	show_cross	n/a	n/a	13	n/a	n/a	cross.bmp
+62.172545454499996	n/a	15543.1364	show_face	unfamiliar_face	first_show	13	n/a	13	u061.bmp
+63.0061818182	n/a	15751.5455	show_circle	n/a	n/a	13	n/a	0	circle.bmp
+64.7061818182	n/a	16176.5455	show_cross	n/a	n/a	14	n/a	n/a	cross.bmp
+65.2798181818	n/a	16319.9545	show_face	famous_face	first_show	14	n/a	5	f071.bmp
+65.8634545455	n/a	16465.8636	right_press	n/a	n/a	14	n/a	4096	n/a
+66.2870909091	n/a	16571.7727	show_circle	n/a	n/a	14	n/a	0	circle.bmp
+67.9870909091	n/a	16996.7727	show_cross	n/a	n/a	15	n/a	n/a	cross.bmp
+68.5034545455	n/a	17125.8636	show_face	famous_face	first_show	15	n/a	5	f037.bmp
+69.3734545455	n/a	17343.3636	show_circle	n/a	n/a	15	n/a	0	circle.bmp
+71.0734545455	n/a	17768.3636	show_cross	n/a	n/a	16	n/a	n/a	cross.bmp
+71.6770909091	n/a	17919.2727	show_face	famous_face	immediate_repeat	16	1	6	f037.bmp
+72.5389090909	n/a	18134.7273	show_circle	n/a	n/a	16	n/a	0	circle.bmp
+74.2389090909	n/a	18559.7273	show_cross	n/a	n/a	17	n/a	n/a	cross.bmp
+74.8516363636	n/a	18712.9091	show_face	scrambled_face	delayed_repeat	17	9	19	s006.bmp
+75.7270909091	n/a	18931.7727	show_circle	n/a	n/a	17	n/a	0	circle.bmp
+75.7489090909	n/a	18937.2273	right_press	n/a	n/a	17	n/a	4096	n/a
+77.4270909091	n/a	19356.7727	show_cross	n/a	n/a	18	n/a	n/a	cross.bmp
+78.0589090909	n/a	19514.7273	show_face	famous_face	first_show	18	n/a	5	f018.bmp
+78.8289090909	n/a	19707.2273	right_press	n/a	n/a	18	n/a	4096	n/a
+78.9243636364	n/a	19731.0909	show_circle	n/a	n/a	18	n/a	0	circle.bmp
+80.6243636364	n/a	20156.0909	show_cross	n/a	n/a	19	n/a	n/a	cross.bmp
+81.1661818182	n/a	20291.5455	show_face	scrambled_face	delayed_repeat	19	10	19	s029.bmp
+82.15072727270001	n/a	20537.6818	show_circle	n/a	n/a	19	n/a	0	circle.bmp
+83.8507272727	n/a	20962.6818	show_cross	n/a	n/a	20	n/a	n/a	cross.bmp
+84.3734545455	n/a	21093.3636	show_face	famous_face	first_show	20	n/a	5	f122.bmp
+85.0889090909	n/a	21272.2273	right_press	n/a	n/a	20	n/a	4096	n/a
+85.3452727273	n/a	21336.3182	show_circle	n/a	n/a	20	n/a	0	circle.bmp
+87.0452727273	n/a	21761.3182	show_cross	n/a	n/a	21	n/a	n/a	cross.bmp
+87.6143636364	n/a	21903.5909	show_face	scrambled_face	first_show	21	n/a	17	s080.bmp
+88.4316363636	n/a	22107.9091	right_press	n/a	n/a	21	n/a	4096	n/a
+88.5870909091	n/a	22146.7727	show_circle	n/a	n/a	21	n/a	0	circle.bmp
+90.2870909091	n/a	22571.7727	show_cross	n/a	n/a	22	n/a	n/a	cross.bmp
+90.9052727273	n/a	22726.3182	show_face	unfamiliar_face	delayed_repeat	22	9	15	u061.bmp
+91.598	n/a	22899.5	right_press	n/a	n/a	22	n/a	4096	n/a
+91.82527272729999	n/a	22956.3182	show_circle	n/a	n/a	22	n/a	0	circle.bmp
+93.52527272729999	n/a	23381.3182	show_cross	n/a	n/a	23	n/a	n/a	cross.bmp
+94.0452727273	n/a	23511.3182	show_face	famous_face	first_show	23	n/a	5	f047.bmp
+94.98254545450001	n/a	23745.6364	show_circle	n/a	n/a	23	n/a	0	circle.bmp
+96.6825454545	n/a	24170.6364	show_cross	n/a	n/a	24	n/a	n/a	cross.bmp
+97.3198181818	n/a	24329.9545	show_face	famous_face	immediate_repeat	24	1	6	f047.bmp
+98.2652727273	n/a	24566.3182	show_circle	n/a	n/a	24	n/a	0	circle.bmp
+99.96527272729999	n/a	24991.3182	show_cross	n/a	n/a	25	n/a	n/a	cross.bmp
+100.6107272727	n/a	25152.6818	show_face	famous_face	delayed_repeat	25	11	7	f071.bmp
+101.24345454549999	n/a	25310.8636	right_press	n/a	n/a	25	n/a	4096	n/a
+101.5698181818	n/a	25392.4545	show_circle	n/a	n/a	25	n/a	0	circle.bmp
+103.2698181818	n/a	25817.4545	show_cross	n/a	n/a	26	n/a	n/a	cross.bmp
+103.88527272729999	n/a	25971.3182	show_face	unfamiliar_face	first_show	26	n/a	13	u133.bmp
+104.77163636360001	n/a	26192.9091	show_circle	n/a	n/a	26	n/a	0	circle.bmp
+106.47163636360001	n/a	26617.9091	show_cross	n/a	n/a	27	n/a	n/a	cross.bmp
+107.02527272729999	n/a	26756.3182	show_face	scrambled_face	first_show	27	n/a	17	s004.bmp
+107.9407272727	n/a	26985.1818	show_circle	n/a	n/a	27	n/a	0	circle.bmp
+109.6407272727	n/a	27410.1818	show_cross	n/a	n/a	28	n/a	n/a	cross.bmp
+110.2161818182	n/a	27554.0455	show_face	famous_face	delayed_repeat	28	10	7	f018.bmp
+111.0889090909	n/a	27772.2273	show_circle	n/a	n/a	28	n/a	0	circle.bmp
+112.7889090909	n/a	28197.2273	show_cross	n/a	n/a	29	n/a	n/a	cross.bmp
+113.3907272727	n/a	28347.6818	show_face	famous_face	first_show	29	n/a	5	f007.bmp
+114.0007272727	n/a	28500.1818	right_press	n/a	n/a	29	n/a	4096	n/a
+114.35345454549999	n/a	28588.3636	show_circle	n/a	n/a	29	n/a	0	circle.bmp
+116.05345454549999	n/a	29013.3636	show_cross	n/a	n/a	30	n/a	n/a	cross.bmp
+116.6307272727	n/a	29157.6818	show_face	famous_face	immediate_repeat	30	1	6	f007.bmp
+117.2934545455	n/a	29323.3636	right_press	n/a	n/a	30	n/a	4096	n/a
+117.5452727273	n/a	29386.3182	show_circle	n/a	n/a	30	n/a	0	circle.bmp
+119.24527272729999	n/a	29811.3182	show_cross	n/a	n/a	31	n/a	n/a	cross.bmp
+119.8052727273	n/a	29951.3182	show_face	famous_face	delayed_repeat	31	11	7	f122.bmp
+120.4316363636	n/a	30107.9091	right_press	n/a	n/a	31	n/a	4096	n/a
+120.6870909091	n/a	30171.7727	show_circle	n/a	n/a	31	n/a	0	circle.bmp
+122.3870909091	n/a	30596.7727	show_cross	n/a	n/a	32	n/a	n/a	cross.bmp
+122.9625454545	n/a	30740.6364	show_face	famous_face	first_show	32	n/a	5	f101.bmp
+123.81890909090001	n/a	30954.7273	right_press	n/a	n/a	32	n/a	4096	n/a
+123.8243636364	n/a	30956.0909	show_circle	n/a	n/a	32	n/a	0	circle.bmp
+125.5243636364	n/a	31381.0909	show_cross	n/a	n/a	33	n/a	n/a	cross.bmp
+126.1534545455	n/a	31538.3636	show_face	scrambled_face	delayed_repeat	33	12	19	s080.bmp
+127.0898181818	n/a	31772.4545	show_circle	n/a	n/a	33	n/a	0	circle.bmp
+128.7898181818	n/a	32197.4545	show_cross	n/a	n/a	34	n/a	n/a	cross.bmp
+129.4107272727	n/a	32352.6818	show_face	unfamiliar_face	first_show	34	n/a	13	u038.bmp
+130.39981818180001	n/a	32599.9545	show_circle	n/a	n/a	34	n/a	0	circle.bmp
+132.0998181818	n/a	33024.9545	show_cross	n/a	n/a	35	n/a	n/a	cross.bmp
+132.718	n/a	33179.5	show_face	famous_face	first_show	35	n/a	5	f108.bmp
+133.258	n/a	33314.5	right_press	n/a	n/a	35	n/a	4096	n/a
+133.7152727273	n/a	33428.8182	show_circle	n/a	n/a	35	n/a	0	circle.bmp
+135.4152727273	n/a	33853.8182	show_cross	n/a	n/a	36	n/a	n/a	cross.bmp
+135.94254545450002	n/a	33985.6364	show_face	famous_face	immediate_repeat	36	1	6	f108.bmp
+136.4916363636	n/a	34122.9091	right_press	n/a	n/a	36	n/a	4096	n/a
+136.92163636360002	n/a	34230.4091	show_circle	n/a	n/a	36	n/a	0	circle.bmp
+138.6216363636	n/a	34655.4091	show_cross	n/a	n/a	37	n/a	n/a	cross.bmp
+139.1161818182	n/a	34779.0455	show_face	unfamiliar_face	delayed_repeat	37	11	15	u133.bmp
+140.0889090909	n/a	35022.2273	show_circle	n/a	n/a	37	n/a	0	circle.bmp
+141.7889090909	n/a	35447.2273	show_cross	n/a	n/a	38	n/a	n/a	cross.bmp
+142.3234545455	n/a	35580.8636	show_face	scrambled_face	first_show	38	n/a	17	s094.bmp
+143.0525454545	n/a	35763.1364	right_press	n/a	n/a	38	n/a	4096	n/a
+143.298	n/a	35824.5	show_circle	n/a	n/a	38	n/a	0	circle.bmp
+144.998	n/a	36249.5	show_cross	n/a	n/a	39	n/a	n/a	cross.bmp
+145.5143636364	n/a	36378.5909	show_face	scrambled_face	immediate_repeat	39	1	18	s094.bmp
+146.1352727273	n/a	36533.8182	right_press	n/a	n/a	39	n/a	4096	n/a
+146.3943636364	n/a	36598.5909	show_circle	n/a	n/a	39	n/a	0	circle.bmp
+148.0943636364	n/a	37023.5909	show_cross	n/a	n/a	40	n/a	n/a	cross.bmp
+148.638	n/a	37159.5	show_face	scrambled_face	delayed_repeat	40	13	19	s004.bmp
+149.2289090909	n/a	37307.2273	right_press	n/a	n/a	40	n/a	4096	n/a
+149.6207272727	n/a	37405.1818	show_circle	n/a	n/a	40	n/a	0	circle.bmp
+151.3207272727	n/a	37830.1818	show_cross	n/a	n/a	41	n/a	n/a	cross.bmp
+151.7952727273	n/a	37948.8182	show_face	unfamiliar_face	first_show	41	n/a	13	u121.bmp
+152.7552727273	n/a	38188.8182	right_press	n/a	n/a	41	n/a	4096	n/a
+152.7907272727	n/a	38197.6818	show_circle	n/a	n/a	41	n/a	0	circle.bmp
+154.4907272727	n/a	38622.6818	show_cross	n/a	n/a	42	n/a	n/a	cross.bmp
+155.0698181818	n/a	38767.4545	show_face	unfamiliar_face	immediate_repeat	42	1	14	u121.bmp
+155.7398181818	n/a	38934.9545	right_press	n/a	n/a	42	n/a	4096	n/a
+156.0752727273	n/a	39018.8182	show_circle	n/a	n/a	42	n/a	0	circle.bmp
+157.7752727273	n/a	39443.8182	show_cross	n/a	n/a	43	n/a	n/a	cross.bmp
+158.3107272727	n/a	39577.6818	show_face	scrambled_face	first_show	43	n/a	17	s095.bmp
+159.1607272727	n/a	39790.1818	show_circle	n/a	n/a	43	n/a	0	circle.bmp
+160.86072727270002	n/a	40215.1818	show_cross	n/a	n/a	44	n/a	n/a	cross.bmp
+161.4343636364	n/a	40358.5909	show_face	famous_face	delayed_repeat	44	12	7	f101.bmp
+162.1052727273	n/a	40526.3182	right_press	n/a	n/a	44	n/a	4096	n/a
+162.3216363636	n/a	40580.4091	show_circle	n/a	n/a	44	n/a	0	circle.bmp
+164.0216363636	n/a	41005.4091	show_cross	n/a	n/a	45	n/a	n/a	cross.bmp
+164.658	n/a	41164.5	show_face	scrambled_face	first_show	45	n/a	17	s061.bmp
+165.3743636364	n/a	41343.5909	right_press	n/a	n/a	45	n/a	4096	n/a
+165.5989090909	n/a	41399.7273	show_circle	n/a	n/a	45	n/a	0	circle.bmp
+167.2989090909	n/a	41824.7273	show_cross	n/a	n/a	46	n/a	n/a	cross.bmp
+167.8152727273	n/a	41953.8182	show_face	scrambled_face	immediate_repeat	46	1	18	s061.bmp
+168.5570909091	n/a	42139.2727	right_press	n/a	n/a	46	n/a	4096	n/a
+168.7689090909	n/a	42192.2273	show_circle	n/a	n/a	46	n/a	0	circle.bmp
+170.4689090909	n/a	42617.2273	show_cross	n/a	n/a	47	n/a	n/a	cross.bmp
+170.9734545455	n/a	42743.3636	show_face	unfamiliar_face	delayed_repeat	47	13	15	u038.bmp
+171.80436363639998	n/a	42951.0909	show_circle	n/a	n/a	47	n/a	0	circle.bmp
+173.5043636364	n/a	43376.0909	show_cross	n/a	n/a	48	n/a	n/a	cross.bmp
+174.0470909091	n/a	43511.7727	show_face	unfamiliar_face	first_show	48	n/a	13	u067.bmp
+175.0134545455	n/a	43753.3636	show_circle	n/a	n/a	48	n/a	0	circle.bmp
+176.71345454549999	n/a	44178.3636	show_cross	n/a	n/a	49	n/a	n/a	cross.bmp
+177.2370909091	n/a	44309.2727	show_face	unfamiliar_face	immediate_repeat	49	1	14	u067.bmp
+178.1434545455	n/a	44535.8636	show_circle	n/a	n/a	49	n/a	0	circle.bmp
+179.84345454549998	n/a	44960.8636	show_cross	n/a	n/a	50	n/a	n/a	cross.bmp
+180.4616363636	n/a	45115.4091	show_face	scrambled_face	first_show	50	n/a	17	s130.bmp
+181.4152727273	n/a	45353.8182	show_circle	n/a	n/a	50	n/a	0	circle.bmp
+183.1152727273	n/a	45778.8182	show_cross	n/a	n/a	51	n/a	n/a	cross.bmp
+183.6525454545	n/a	45913.1364	show_face	unfamiliar_face	first_show	51	n/a	13	u035.bmp
+184.4798181818	n/a	46119.9545	right_press	n/a	n/a	51	n/a	4096	n/a
+184.5861818182	n/a	46146.5455	show_circle	n/a	n/a	51	n/a	0	circle.bmp
+186.2861818182	n/a	46571.5455	show_cross	n/a	n/a	52	n/a	n/a	cross.bmp
+186.8425454545	n/a	46710.6364	show_face	famous_face	first_show	52	n/a	5	f070.bmp
+187.5007272727	n/a	46875.1818	right_press	n/a	n/a	52	n/a	4096	n/a
+187.6970909091	n/a	46924.2727	show_circle	n/a	n/a	52	n/a	0	circle.bmp
+189.3970909091	n/a	47349.2727	show_cross	n/a	n/a	53	n/a	n/a	cross.bmp
+190.0170909091	n/a	47504.2727	show_face	scrambled_face	delayed_repeat	53	10	19	s095.bmp
+190.8870909091	n/a	47721.7727	show_circle	n/a	n/a	53	n/a	0	circle.bmp
+192.5870909091	n/a	48146.7727	show_cross	n/a	n/a	54	n/a	n/a	cross.bmp
+193.0907272727	n/a	48272.6818	show_face	scrambled_face	first_show	54	n/a	17	s064.bmp
+193.7398181818	n/a	48434.9545	right_press	n/a	n/a	54	n/a	4096	n/a
+194.0352727273	n/a	48508.8182	show_circle	n/a	n/a	54	n/a	0	circle.bmp
+195.73527272729999	n/a	48933.8182	show_cross	n/a	n/a	55	n/a	n/a	cross.bmp
+196.3816363636	n/a	49095.4091	show_face	scrambled_face	first_show	55	n/a	17	s016.bmp
+196.92527272729998	n/a	49231.3182	right_press	n/a	n/a	55	n/a	4096	n/a
+197.2298181818	n/a	49307.4545	show_circle	n/a	n/a	55	n/a	0	circle.bmp
+198.92981818180002	n/a	49732.4545	show_cross	n/a	n/a	56	n/a	n/a	cross.bmp
+199.5052727273	n/a	49876.3182	show_face	scrambled_face	immediate_repeat	56	1	18	s016.bmp
+200.52072727270001	n/a	50130.1818	show_circle	n/a	n/a	56	n/a	0	circle.bmp
+202.2207272727	n/a	50555.1818	show_cross	n/a	n/a	57	n/a	n/a	cross.bmp
+202.8634545455	n/a	50715.8636	show_face	scrambled_face	first_show	57	n/a	17	s147.bmp
+203.4170909091	n/a	50854.2727	right_press	n/a	n/a	57	n/a	4096	n/a
+203.7325454545	n/a	50933.1364	show_circle	n/a	n/a	57	n/a	0	circle.bmp
+205.4325454545	n/a	51358.1364	show_cross	n/a	n/a	58	n/a	n/a	cross.bmp
+206.02072727270001	n/a	51505.1818	show_face	scrambled_face	immediate_repeat	58	1	18	s147.bmp
+206.678	n/a	51669.5	right_press	n/a	n/a	58	n/a	4096	n/a
+206.9970909091	n/a	51749.2727	show_circle	n/a	n/a	58	n/a	0	circle.bmp
+208.6970909091	n/a	52174.2727	show_cross	n/a	n/a	59	n/a	n/a	cross.bmp
+209.2107272727	n/a	52302.6818	show_face	scrambled_face	delayed_repeat	59	9	19	s130.bmp
+209.7652727273	n/a	52441.3182	right_press	n/a	n/a	59	n/a	4096	n/a
+210.1898181818	n/a	52547.4545	show_circle	n/a	n/a	59	n/a	0	circle.bmp
+211.8898181818	n/a	52972.4545	show_cross	n/a	n/a	60	n/a	n/a	cross.bmp
+212.45163636360002	n/a	53112.9091	show_face	scrambled_face	first_show	60	n/a	17	s047.bmp
+213.3989090909	n/a	53349.7273	show_circle	n/a	n/a	60	n/a	0	circle.bmp
+213.4389090909	n/a	53359.7273	right_press	n/a	n/a	60	n/a	4096	n/a
+215.0989090909	n/a	53774.7273	show_cross	n/a	n/a	61	n/a	n/a	cross.bmp
+215.70981818180002	n/a	53927.4545	show_face	scrambled_face	immediate_repeat	61	1	18	s047.bmp
+216.47254545450002	n/a	54118.1364	right_press	n/a	n/a	61	n/a	4096	n/a
+216.678	n/a	54169.5	show_circle	n/a	n/a	61	n/a	0	circle.bmp
+218.378	n/a	54594.5	show_cross	n/a	n/a	62	n/a	n/a	cross.bmp
+218.9498181818	n/a	54737.4545	show_face	unfamiliar_face	delayed_repeat	62	11	15	u035.bmp
+219.8389090909	n/a	54959.7273	show_circle	n/a	n/a	62	n/a	0	circle.bmp
+221.5389090909	n/a	55384.7273	show_cross	n/a	n/a	63	n/a	n/a	cross.bmp
+222.1743636364	n/a	55543.5909	show_face	unfamiliar_face	first_show	63	n/a	13	u115.bmp
+222.8061818182	n/a	55701.5455	right_press	n/a	n/a	63	n/a	4096	n/a
+223.09345454549998	n/a	55773.3636	show_circle	n/a	n/a	63	n/a	0	circle.bmp
+224.7934545455	n/a	56198.3636	show_cross	n/a	n/a	64	n/a	n/a	cross.bmp
+225.3152727273	n/a	56328.8182	show_face	unfamiliar_face	immediate_repeat	64	1	14	u115.bmp
+225.8643636364	n/a	56466.0909	right_press	n/a	n/a	64	n/a	4096	n/a
+226.2661818182	n/a	56566.5455	show_circle	n/a	n/a	64	n/a	0	circle.bmp
+227.9661818182	n/a	56991.5455	show_cross	n/a	n/a	65	n/a	n/a	cross.bmp
+228.47254545450002	n/a	57118.1364	show_face	famous_face	delayed_repeat	65	13	7	f070.bmp
+229.0889090909	n/a	57272.2273	right_press	n/a	n/a	65	n/a	4096	n/a
+229.3125454545	n/a	57328.1364	show_circle	n/a	n/a	65	n/a	0	circle.bmp
+231.0125454545	n/a	57753.1364	show_cross	n/a	n/a	66	n/a	n/a	cross.bmp
+231.52890909090002	n/a	57882.2273	show_face	unfamiliar_face	first_show	66	n/a	13	u049.bmp
+232.1243636364	n/a	58031.0909	right_press	n/a	n/a	66	n/a	4096	n/a
+232.5398181818	n/a	58134.9545	show_circle	n/a	n/a	66	n/a	0	circle.bmp
+234.2398181818	n/a	58559.9545	show_cross	n/a	n/a	67	n/a	n/a	cross.bmp
+234.7361818182	n/a	58684.0455	show_face	scrambled_face	delayed_repeat	67	13	19	s064.bmp
+235.4052727273	n/a	58851.3182	right_press	n/a	n/a	67	n/a	4096	n/a
+235.568	n/a	58892.0	show_circle	n/a	n/a	67	n/a	0	circle.bmp
+237.268	n/a	59317.0	show_cross	n/a	n/a	68	n/a	n/a	cross.bmp
+237.7934545455	n/a	59448.3636	show_face	scrambled_face	first_show	68	n/a	17	s067.bmp
+238.27890909090002	n/a	59569.7273	right_press	n/a	n/a	68	n/a	4096	n/a
+238.6552727273	n/a	59663.8182	show_circle	n/a	n/a	68	n/a	0	circle.bmp
+240.3552727273	n/a	60088.8182	show_cross	n/a	n/a	69	n/a	n/a	cross.bmp
+241.0007272727	n/a	60250.1818	show_face	famous_face	first_show	69	n/a	5	f056.bmp
+241.6634545455	n/a	60415.8636	right_press	n/a	n/a	69	n/a	4096	n/a
+241.968	n/a	60492.0	show_circle	n/a	n/a	69	n/a	0	circle.bmp
+243.668	n/a	60917.0	show_cross	n/a	n/a	70	n/a	n/a	cross.bmp
+244.2252727273	n/a	61056.3182	show_face	famous_face	immediate_repeat	70	1	6	f056.bmp
+244.9370909091	n/a	61234.2727	right_press	n/a	n/a	70	n/a	4096	n/a
+245.078	n/a	61269.5	show_circle	n/a	n/a	70	n/a	0	circle.bmp
+246.778	n/a	61694.5	show_cross	n/a	n/a	71	n/a	n/a	cross.bmp
+247.2325454545	n/a	61808.1364	show_face	scrambled_face	first_show	71	n/a	17	s002.bmp
+248.20981818180002	n/a	62052.4545	show_circle	n/a	n/a	71	n/a	0	circle.bmp
+249.9098181818	n/a	62477.4545	show_cross	n/a	n/a	72	n/a	n/a	cross.bmp
+250.4898181818	n/a	62622.4545	show_face	unfamiliar_face	first_show	72	n/a	13	u092.bmp
+251.3452727273	n/a	62836.3182	show_circle	n/a	n/a	72	n/a	0	circle.bmp
+253.0452727273	n/a	63261.3182	show_cross	n/a	n/a	73	n/a	n/a	cross.bmp
+253.6634545455	n/a	63415.8636	show_face	unfamiliar_face	first_show	73	n/a	13	u091.bmp
+254.2607272727	n/a	63565.1818	right_press	n/a	n/a	73	n/a	4096	n/a
+254.6270909091	n/a	63656.7727	show_circle	n/a	n/a	73	n/a	0	circle.bmp
+256.3270909091	n/a	64081.7727	show_cross	n/a	n/a	74	n/a	n/a	cross.bmp
+256.9207272727	n/a	64230.1818	show_face	unfamiliar_face	delayed_repeat	74	8	15	u049.bmp
+257.7925454545	n/a	64448.1364	show_circle	n/a	n/a	74	n/a	0	circle.bmp
+257.8707272727	n/a	64467.6818	right_press	n/a	n/a	74	n/a	4096	n/a
+259.49254545450003	n/a	64873.1364	show_cross	n/a	n/a	75	n/a	n/a	cross.bmp
+260.0452727273	n/a	65011.3182	show_face	famous_face	first_show	75	n/a	5	f052.bmp
+260.648	n/a	65162.0	right_press	n/a	n/a	75	n/a	4096	n/a
+261.0161818182	n/a	65254.0455	show_circle	n/a	n/a	75	n/a	0	circle.bmp
+262.71618181819997	n/a	65679.0455	show_cross	n/a	n/a	76	n/a	n/a	cross.bmp
+263.3189090909	n/a	65829.7273	show_face	famous_face	immediate_repeat	76	1	6	f052.bmp
+263.8307272727	n/a	65957.6818	right_press	n/a	n/a	76	n/a	4096	n/a
+264.1916363636	n/a	66047.9091	show_circle	n/a	n/a	76	n/a	0	circle.bmp
+265.8916363636	n/a	66472.9091	show_cross	n/a	n/a	77	n/a	n/a	cross.bmp
+266.3761818182	n/a	66594.0455	show_face	scrambled_face	delayed_repeat	77	9	19	s067.bmp
+267.0798181818	n/a	66769.9545	right_press	n/a	n/a	77	n/a	4096	n/a
+267.3343636364	n/a	66833.5909	show_circle	n/a	n/a	77	n/a	0	circle.bmp
+269.0343636364	n/a	67258.5909	show_cross	n/a	n/a	78	n/a	n/a	cross.bmp
+269.6007272727	n/a	67400.1818	show_face	unfamiliar_face	first_show	78	n/a	13	u029.bmp
+270.2743636364	n/a	67568.5909	right_press	n/a	n/a	78	n/a	4096	n/a
+270.5107272727	n/a	67627.6818	show_circle	n/a	n/a	78	n/a	0	circle.bmp
+272.2107272727	n/a	68052.6818	show_cross	n/a	n/a	79	n/a	n/a	cross.bmp
+272.808	n/a	68202.0	show_face	famous_face	first_show	79	n/a	5	f114.bmp
+273.6298181818	n/a	68407.4545	show_circle	n/a	n/a	79	n/a	0	circle.bmp
+275.3298181818	n/a	68832.4545	show_cross	n/a	n/a	80	n/a	n/a	cross.bmp
+275.8316363636	n/a	68957.9091	show_face	famous_face	immediate_repeat	80	1	6	f114.bmp
+276.7561818182	n/a	69189.0455	show_circle	n/a	n/a	80	n/a	0	circle.bmp
+278.4561818182	n/a	69614.0455	show_cross	n/a	n/a	81	n/a	n/a	cross.bmp
+279.0052727273	n/a	69751.3182	show_face	scrambled_face	delayed_repeat	81	10	19	s002.bmp
+279.6189090909	n/a	69904.7273	right_press	n/a	n/a	81	n/a	4096	n/a
+279.988	n/a	69997.0	show_circle	n/a	n/a	81	n/a	0	circle.bmp
+281.688	n/a	70422.0	show_cross	n/a	n/a	82	n/a	n/a	cross.bmp
+282.1789090909	n/a	70544.7273	show_face	scrambled_face	first_show	82	n/a	17	s120.bmp
+282.8361818182	n/a	70709.0455	right_press	n/a	n/a	82	n/a	4096	n/a
+283.1798181818	n/a	70794.9545	show_circle	n/a	n/a	82	n/a	0	circle.bmp
+284.8798181818	n/a	71219.9545	show_cross	n/a	n/a	83	n/a	n/a	cross.bmp
+285.35345454549997	n/a	71338.3636	show_face	unfamiliar_face	delayed_repeat	83	11	15	u092.bmp
+286.0107272727	n/a	71502.6818	right_press	n/a	n/a	83	n/a	4096	n/a
+286.35436363639997	n/a	71588.5909	show_circle	n/a	n/a	83	n/a	0	circle.bmp
+288.0543636364	n/a	72013.5909	show_cross	n/a	n/a	84	n/a	n/a	cross.bmp
+288.5943636364	n/a	72148.5909	show_face	scrambled_face	first_show	84	n/a	17	s049.bmp
+289.5916363636	n/a	72397.9091	show_circle	n/a	n/a	84	n/a	0	circle.bmp
+291.2916363636	n/a	72822.9091	show_cross	n/a	n/a	85	n/a	n/a	cross.bmp
+291.7516363636	n/a	72937.9091	show_face	scrambled_face	immediate_repeat	85	1	18	s049.bmp
+292.6507272727	n/a	73162.6818	show_circle	n/a	n/a	85	n/a	0	circle.bmp
+294.3507272727	n/a	73587.6818	show_cross	n/a	n/a	86	n/a	n/a	cross.bmp
+294.8416363636	n/a	73710.4091	show_face	unfamiliar_face	delayed_repeat	86	13	15	u091.bmp
+295.638	n/a	73909.5	right_press	n/a	n/a	86	n/a	4096	n/a
+295.6998181818	n/a	73924.9545	show_circle	n/a	n/a	86	n/a	0	circle.bmp
+297.3998181818	n/a	74349.9545	show_cross	n/a	n/a	87	n/a	n/a	cross.bmp
+298.0489090909	n/a	74512.2273	show_face	scrambled_face	first_show	87	n/a	17	s128.bmp
+298.968	n/a	74742.0	show_circle	n/a	n/a	87	n/a	0	circle.bmp
+299.0498181818	n/a	74762.4545	right_press	n/a	n/a	87	n/a	4096	n/a
+300.668	n/a	75167.0	show_cross	n/a	n/a	88	n/a	n/a	cross.bmp
+301.2561818182	n/a	75314.0455	show_face	scrambled_face	immediate_repeat	88	1	18	s128.bmp
+301.81163636360003	n/a	75452.9091	right_press	n/a	n/a	88	n/a	4096	n/a
+302.1143636364	n/a	75528.5909	show_circle	n/a	n/a	88	n/a	0	circle.bmp
+303.8143636364	n/a	75953.5909	show_cross	n/a	n/a	89	n/a	n/a	cross.bmp
+304.4470909091	n/a	76111.7727	show_face	scrambled_face	first_show	89	n/a	17	s106.bmp
+304.9670909091	n/a	76241.7727	right_press	n/a	n/a	89	n/a	4096	n/a
+305.3807272727	n/a	76345.1818	show_circle	n/a	n/a	89	n/a	0	circle.bmp
+307.0807272727	n/a	76770.1818	show_cross	n/a	n/a	90	n/a	n/a	cross.bmp
+307.5543636364	n/a	76888.5909	show_face	scrambled_face	immediate_repeat	90	1	18	s106.bmp
+308.1234545455	n/a	77030.8636	right_press	n/a	n/a	90	n/a	4096	n/a
+308.4389090909	n/a	77109.7273	show_circle	n/a	n/a	90	n/a	0	circle.bmp
+310.13890909090003	n/a	77534.7273	show_cross	n/a	n/a	91	n/a	n/a	cross.bmp
+310.6452727273	n/a	77661.3182	show_face	unfamiliar_face	delayed_repeat	91	13	15	u029.bmp
+311.3098181818	n/a	77827.4545	right_press	n/a	n/a	91	n/a	4096	n/a
+311.4861818182	n/a	77871.5455	show_circle	n/a	n/a	91	n/a	0	circle.bmp
+313.1861818182	n/a	78296.5455	show_cross	n/a	n/a	92	n/a	n/a	cross.bmp
+313.7352727273	n/a	78433.8182	show_face	scrambled_face	first_show	92	n/a	17	s003.bmp
+314.6925454545	n/a	78673.1364	show_circle	n/a	n/a	92	n/a	0	circle.bmp
+316.3925454545	n/a	79098.1364	show_cross	n/a	n/a	93	n/a	n/a	cross.bmp
+316.9598181818	n/a	79239.9545	show_face	scrambled_face	immediate_repeat	93	1	18	s003.bmp
+317.8698181818	n/a	79467.4545	show_circle	n/a	n/a	93	n/a	0	circle.bmp
+319.56981818180003	n/a	79892.4545	show_cross	n/a	n/a	94	n/a	n/a	cross.bmp
+320.1998181818	n/a	80049.9545	show_face	famous_face	first_show	94	n/a	5	f075.bmp
+321.0343636364	n/a	80258.5909	right_press	n/a	n/a	94	n/a	4096	n/a
+321.18254545450003	n/a	80295.6364	show_circle	n/a	n/a	94	n/a	0	circle.bmp
+322.8825454545	n/a	80720.6364	show_cross	n/a	n/a	95	n/a	n/a	cross.bmp
+323.458	n/a	80864.5	show_face	scrambled_face	delayed_repeat	95	13	19	s120.bmp
+323.9189090909	n/a	80979.7273	right_press	n/a	n/a	95	n/a	4096	n/a
+324.3752727273	n/a	81093.8182	show_circle	n/a	n/a	95	n/a	0	circle.bmp
+326.0752727273	n/a	81518.8182	show_cross	n/a	n/a	96	n/a	n/a	cross.bmp
+326.6652727273	n/a	81666.3182	show_face	unfamiliar_face	first_show	96	n/a	13	u113.bmp
+327.2725454545	n/a	81818.1364	right_press	n/a	n/a	96	n/a	4096	n/a
+327.6089090909	n/a	81902.2273	show_circle	n/a	n/a	96	n/a	0	circle.bmp
+329.3089090909	n/a	82327.2273	show_cross	n/a	n/a	97	n/a	n/a	cross.bmp
+329.9225454545	n/a	82480.6364	show_face	famous_face	first_show	97	n/a	5	f091.bmp
+330.4216363636	n/a	82605.4091	right_press	n/a	n/a	97	n/a	4096	n/a
+330.8561818182	n/a	82714.0455	show_circle	n/a	n/a	97	n/a	0	circle.bmp
+332.5561818182	n/a	83139.0455	show_cross	n/a	n/a	98	n/a	n/a	cross.bmp
+333.1134545455	n/a	83278.3636	show_face	famous_face	immediate_repeat	98	1	6	f091.bmp
+333.568	n/a	83392.0	right_press	n/a	n/a	98	n/a	4096	n/a
+333.9961818182	n/a	83499.0455	show_circle	n/a	n/a	98	n/a	0	circle.bmp
+335.6961818182	n/a	83924.0455	show_cross	n/a	n/a	99	n/a	n/a	cross.bmp
+336.2543636364	n/a	84063.5909	show_face	unfamiliar_face	first_show	99	n/a	13	u024.bmp
+337.1970909091	n/a	84299.2727	show_circle	n/a	n/a	99	n/a	0	circle.bmp
+338.8970909091	n/a	84724.2727	show_cross	n/a	n/a	100	n/a	n/a	cross.bmp
+339.528	n/a	84882.0	show_face	famous_face	first_show	100	n/a	5	f076.bmp
+340.1989090909	n/a	85049.7273	right_press	n/a	n/a	100	n/a	4096	n/a
+340.478	n/a	85119.5	show_circle	n/a	n/a	100	n/a	0	circle.bmp
+342.178	n/a	85544.5	show_cross	n/a	n/a	101	n/a	n/a	cross.bmp
+342.6689090909	n/a	85667.2273	show_face	unfamiliar_face	first_show	101	n/a	13	u016.bmp
+343.5316363636	n/a	85882.9091	show_circle	n/a	n/a	101	n/a	0	circle.bmp
+345.2316363636	n/a	86307.9091	show_cross	n/a	n/a	102	n/a	n/a	cross.bmp
+345.84254545449994	n/a	86460.6364	show_face	unfamiliar_face	immediate_repeat	102	1	14	u016.bmp
+346.66436363639997	n/a	86666.0909	show_circle	n/a	n/a	102	n/a	0	circle.bmp
+348.3643636364	n/a	87091.0909	show_cross	n/a	n/a	103	n/a	n/a	cross.bmp
+348.8661818182	n/a	87216.5455	show_face	famous_face	delayed_repeat	103	9	7	f075.bmp
+349.43709090910005	n/a	87359.2727	right_press	n/a	n/a	103	n/a	4096	n/a
+349.8734545455	n/a	87468.3636	show_circle	n/a	n/a	103	n/a	0	circle.bmp
+351.57345454550006	n/a	87893.3636	show_cross	n/a	n/a	104	n/a	n/a	cross.bmp
+352.14072727269996	n/a	88035.1818	show_face	scrambled_face	first_show	104	n/a	17	s121.bmp
+352.76890909089997	n/a	88192.2273	right_press	n/a	n/a	104	n/a	4096	n/a
+353.098	n/a	88274.5	show_circle	n/a	n/a	104	n/a	0	circle.bmp
+354.798	n/a	88699.5	show_cross	n/a	n/a	105	n/a	n/a	cross.bmp
+355.4316363636	n/a	88857.9091	show_face	unfamiliar_face	delayed_repeat	105	9	15	u113.bmp
+355.9934545455	n/a	88998.3636	right_press	n/a	n/a	105	n/a	4096	n/a
+356.3470909091	n/a	89086.7727	show_circle	n/a	n/a	105	n/a	0	circle.bmp
+358.04709090910006	n/a	89511.7727	show_cross	n/a	n/a	106	n/a	n/a	cross.bmp
+358.50527272730005	n/a	89626.3182	show_face	famous_face	first_show	106	n/a	5	f115.bmp
+359.1743636364	n/a	89793.5909	right_press	n/a	n/a	106	n/a	4096	n/a
+359.518	n/a	89879.5	show_circle	n/a	n/a	106	n/a	0	circle.bmp
+361.218	n/a	90304.5	show_cross	n/a	n/a	107	n/a	n/a	cross.bmp
+361.7961818182	n/a	90449.0455	show_face	scrambled_face	first_show	107	n/a	17	s070.bmp
+362.4398181818	n/a	90609.9545	right_press	n/a	n/a	107	n/a	4096	n/a
+362.8016363636	n/a	90700.4091	show_circle	n/a	n/a	107	n/a	0	circle.bmp
+364.5016363636	n/a	91125.4091	show_cross	n/a	n/a	108	n/a	n/a	cross.bmp
+364.95345454550005	n/a	91238.3636	show_face	scrambled_face	immediate_repeat	108	1	18	s070.bmp
+365.5561818182	n/a	91389.0455	right_press	n/a	n/a	108	n/a	4096	n/a
+365.9343636364	n/a	91483.5909	show_circle	n/a	n/a	108	n/a	0	circle.bmp
+367.6343636364	n/a	91908.5909	show_cross	n/a	n/a	109	n/a	n/a	cross.bmp
+368.1107272727	n/a	92027.6818	show_face	unfamiliar_face	delayed_repeat	109	10	15	u024.bmp
+368.9443636364	n/a	92236.0909	show_circle	n/a	n/a	109	n/a	0	circle.bmp
+370.6443636364	n/a	92661.0909	show_cross	n/a	n/a	110	n/a	n/a	cross.bmp
+371.1343636364	n/a	92783.5909	show_face	unfamiliar_face	first_show	110	n/a	13	u028.bmp
+372.0525454545	n/a	93013.1364	show_circle	n/a	n/a	110	n/a	0	circle.bmp
+373.75254545449997	n/a	93438.1364	show_cross	n/a	n/a	111	n/a	n/a	cross.bmp
+374.358	n/a	93589.5	show_face	famous_face	delayed_repeat	111	11	7	f076.bmp
+375.3761818182	n/a	93844.0455	show_circle	n/a	n/a	111	n/a	0	circle.bmp
+377.0761818182	n/a	94269.0455	show_cross	n/a	n/a	112	n/a	n/a	cross.bmp
+377.71618181819997	n/a	94429.0455	show_face	famous_face	first_show	112	n/a	5	f011.bmp
+378.53072727269995	n/a	94632.6818	right_press	n/a	n/a	112	n/a	4096	n/a
+378.68709090910005	n/a	94671.7727	show_circle	n/a	n/a	112	n/a	0	circle.bmp
+380.38709090910004	n/a	95096.7727	show_cross	n/a	n/a	113	n/a	n/a	cross.bmp
+380.8570909091	n/a	95214.2727	show_face	scrambled_face	first_show	113	n/a	17	s017.bmp
+381.4125454545	n/a	95353.1364	right_press	n/a	n/a	113	n/a	4096	n/a
+381.8643636364	n/a	95466.0909	show_circle	n/a	n/a	113	n/a	0	circle.bmp
+383.5643636364	n/a	95891.0909	show_cross	n/a	n/a	114	n/a	n/a	cross.bmp
+384.148	n/a	96037.0	show_face	scrambled_face	immediate_repeat	114	1	18	s017.bmp
+384.64709090910003	n/a	96161.7727	right_press	n/a	n/a	114	n/a	4096	n/a
+385.1516363636	n/a	96287.9091	show_circle	n/a	n/a	114	n/a	0	circle.bmp
+386.8516363636	n/a	96712.9091	show_cross	n/a	n/a	115	n/a	n/a	cross.bmp
+387.3216363636	n/a	96830.4091	show_face	scrambled_face	delayed_repeat	115	11	19	s121.bmp
+387.88527272730005	n/a	96971.3182	right_press	n/a	n/a	115	n/a	4096	n/a
+388.1398181818	n/a	97034.9545	show_circle	n/a	n/a	115	n/a	0	circle.bmp
+389.8398181818	n/a	97459.9545	show_cross	n/a	n/a	116	n/a	n/a	cross.bmp
+390.47890909089995	n/a	97619.7273	show_face	unfamiliar_face	first_show	116	n/a	13	u094.bmp
+391.058	n/a	97764.5	right_press	n/a	n/a	116	n/a	4096	n/a
+391.298	n/a	97824.5	show_circle	n/a	n/a	116	n/a	0	circle.bmp
+392.998	n/a	98249.5	show_cross	n/a	n/a	117	n/a	n/a	cross.bmp
+393.5534545455	n/a	98388.3636	show_face	unfamiliar_face	immediate_repeat	117	1	14	u094.bmp
+394.018	n/a	98504.5	right_press	n/a	n/a	117	n/a	4096	n/a
+394.5507272727	n/a	98637.6818	show_circle	n/a	n/a	117	n/a	0	circle.bmp
+396.2507272727	n/a	99062.6818	show_cross	n/a	n/a	118	n/a	n/a	cross.bmp
+396.8098181818	n/a	99202.4545	show_face	famous_face	delayed_repeat	118	12	7	f115.bmp
+397.4561818182	n/a	99364.0455	right_press	n/a	n/a	118	n/a	4096	n/a
+397.82345454550006	n/a	99455.8636	show_circle	n/a	n/a	118	n/a	0	circle.bmp
+399.52345454550004	n/a	99880.8636	show_cross	n/a	n/a	119	n/a	n/a	cross.bmp
+400.10072727269994	n/a	100025.1818	show_face	scrambled_face	first_show	119	n/a	17	s059.bmp
+400.9843636364	n/a	100246.0909	show_circle	n/a	n/a	119	n/a	0	circle.bmp
+400.9907272727	n/a	100247.6818	right_press	n/a	n/a	119	n/a	4096	n/a
+402.6843636364	n/a	100671.0909	show_cross	n/a	n/a	120	n/a	n/a	cross.bmp
+403.208	n/a	100802.0	show_face	scrambled_face	first_show	120	n/a	17	s050.bmp
+403.9334545455	n/a	100983.3636	right_press	n/a	n/a	120	n/a	4096	n/a
+404.21618181819997	n/a	101054.0455	show_circle	n/a	n/a	120	n/a	0	circle.bmp
+405.9161818182	n/a	101479.0455	show_cross	n/a	n/a	121	n/a	n/a	cross.bmp
+406.5507272727	n/a	101637.6818	show_face	scrambled_face	immediate_repeat	121	1	18	s050.bmp
+407.36709090910006	n/a	101841.7727	show_circle	n/a	n/a	121	n/a	0	circle.bmp
+407.42709090910006	n/a	101856.7727	right_press	n/a	n/a	121	n/a	4096	n/a
+409.06709090910005	n/a	102266.7727	show_cross	n/a	n/a	122	n/a	n/a	cross.bmp
+409.5398181818	n/a	102384.9545	show_face	unfamiliar_face	delayed_repeat	122	12	15	u028.bmp
+410.4770909091	n/a	102619.2727	show_circle	n/a	n/a	122	n/a	0	circle.bmp
+412.17709090910006	n/a	103044.2727	show_cross	n/a	n/a	123	n/a	n/a	cross.bmp
+412.64709090910003	n/a	103161.7727	show_face	unfamiliar_face	first_show	123	n/a	13	u007.bmp
+413.5952727273	n/a	103398.8182	show_circle	n/a	n/a	123	n/a	0	circle.bmp
+415.2952727273	n/a	103823.8182	show_cross	n/a	n/a	124	n/a	n/a	cross.bmp
+415.9043636364	n/a	103976.0909	show_face	famous_face	delayed_repeat	124	12	7	f011.bmp
+416.5243636364	n/a	104131.0909	right_press	n/a	n/a	124	n/a	4096	n/a
+416.88709090910004	n/a	104221.7727	show_circle	n/a	n/a	124	n/a	0	circle.bmp
+418.5870909091	n/a	104646.7727	show_cross	n/a	n/a	125	n/a	n/a	cross.bmp
+419.0952727273	n/a	104773.8182	show_face	unfamiliar_face	first_show	125	n/a	13	u071.bmp
+419.6570909091	n/a	104914.2727	right_press	n/a	n/a	125	n/a	4096	n/a
+420.01890909089997	n/a	105004.7273	show_circle	n/a	n/a	125	n/a	0	circle.bmp
+421.71890909089996	n/a	105429.7273	show_cross	n/a	n/a	126	n/a	n/a	cross.bmp
+422.2698181818	n/a	105567.4545	show_face	unfamiliar_face	first_show	126	n/a	13	u090.bmp
+423.2198181818	n/a	105804.9545	show_circle	n/a	n/a	126	n/a	0	circle.bmp
+424.9198181818	n/a	106229.9545	show_cross	n/a	n/a	127	n/a	n/a	cross.bmp
+425.5434545455	n/a	106385.8636	show_face	unfamiliar_face	immediate_repeat	127	1	14	u090.bmp
+426.5007272727	n/a	106625.1818	show_circle	n/a	n/a	127	n/a	0	circle.bmp
+428.20072727269996	n/a	107050.1818	show_cross	n/a	n/a	128	n/a	n/a	cross.bmp
+428.6834545455	n/a	107170.8636	show_face	famous_face	first_show	128	n/a	5	f069.bmp
+429.5643636364	n/a	107391.0909	show_circle	n/a	n/a	128	n/a	0	circle.bmp
+431.2643636364	n/a	107816.0909	show_cross	n/a	n/a	129	n/a	n/a	cross.bmp
+431.908	n/a	107977.0	show_face	famous_face	immediate_repeat	129	1	6	f069.bmp
+432.8298181818	n/a	108207.4545	show_circle	n/a	n/a	129	n/a	0	circle.bmp
+434.5298181818	n/a	108632.4545	show_cross	n/a	n/a	130	n/a	n/a	cross.bmp
+435.098	n/a	108774.5	show_face	scrambled_face	delayed_repeat	130	11	19	s059.bmp
+435.948	n/a	108987.0	show_circle	n/a	n/a	130	n/a	0	circle.bmp
+436.1061818182	n/a	109026.5455	right_press	n/a	n/a	130	n/a	4096	n/a
+437.648	n/a	109412.0	show_cross	n/a	n/a	131	n/a	n/a	cross.bmp
+438.23890909089994	n/a	109559.7273	show_face	famous_face	first_show	131	n/a	5	f078.bmp
+439.2398181818	n/a	109809.9545	show_circle	n/a	n/a	131	n/a	0	circle.bmp
+440.9398181818	n/a	110234.9545	show_cross	n/a	n/a	132	n/a	n/a	cross.bmp
+441.4298181818	n/a	110357.4545	show_face	famous_face	immediate_repeat	132	1	6	f078.bmp
+442.3843636364	n/a	110596.0909	show_circle	n/a	n/a	132	n/a	0	circle.bmp
+444.0843636364	n/a	111021.0909	show_cross	n/a	n/a	133	n/a	n/a	cross.bmp
+444.63709090910004	n/a	111159.2727	show_face	famous_face	first_show	133	n/a	5	f090.bmp
+445.58254545449995	n/a	111395.6364	show_circle	n/a	n/a	133	n/a	0	circle.bmp
+447.2825454545	n/a	111820.6364	show_cross	n/a	n/a	134	n/a	n/a	cross.bmp
+447.8943636364	n/a	111973.5909	show_face	famous_face	immediate_repeat	134	1	6	f090.bmp
+448.8134545455	n/a	112203.3636	show_circle	n/a	n/a	134	n/a	0	circle.bmp
+450.51345454550005	n/a	112628.3636	show_cross	n/a	n/a	135	n/a	n/a	cross.bmp
+450.9852727273	n/a	112746.3182	show_face	unfamiliar_face	delayed_repeat	135	12	15	u007.bmp
+451.92709090910006	n/a	112981.7727	show_circle	n/a	n/a	135	n/a	0	circle.bmp
+453.62709090910005	n/a	113406.7727	show_cross	n/a	n/a	136	n/a	n/a	cross.bmp
+454.10890909089994	n/a	113527.2273	show_face	unfamiliar_face	first_show	136	n/a	13	u110.bmp
+454.77890909089996	n/a	113694.7273	right_press	n/a	n/a	136	n/a	4096	n/a
+455.1207272727	n/a	113780.1818	show_circle	n/a	n/a	136	n/a	0	circle.bmp
+456.82072727269997	n/a	114205.1818	show_cross	n/a	n/a	137	n/a	n/a	cross.bmp
+457.46618181819997	n/a	114366.5455	show_face	unfamiliar_face	immediate_repeat	137	1	14	u110.bmp
+458.028	n/a	114507.0	right_press	n/a	n/a	137	n/a	4096	n/a
+458.4798181818	n/a	114619.9545	show_circle	n/a	n/a	137	n/a	0	circle.bmp
+460.1798181818	n/a	115044.9545	show_cross	n/a	n/a	138	n/a	n/a	cross.bmp
+460.6907272727	n/a	115172.6818	show_face	unfamiliar_face	delayed_repeat	138	13	15	u071.bmp
+461.40890909089995	n/a	115352.2273	right_press	n/a	n/a	138	n/a	4096	n/a
+461.67709090910006	n/a	115419.2727	show_circle	n/a	n/a	138	n/a	0	circle.bmp
+463.37709090910005	n/a	115844.2727	show_cross	n/a	n/a	139	n/a	n/a	cross.bmp
+463.9152727273	n/a	115978.8182	show_face	unfamiliar_face	first_show	139	n/a	13	u104.bmp
+464.91072727269994	n/a	116227.6818	show_circle	n/a	n/a	139	n/a	0	circle.bmp
+466.6107272727	n/a	116652.6818	show_cross	n/a	n/a	140	n/a	n/a	cross.bmp
+467.12254545449997	n/a	116780.6364	show_face	unfamiliar_face	first_show	140	n/a	13	u043.bmp
+467.988	n/a	116997.0	show_circle	n/a	n/a	140	n/a	0	circle.bmp
+469.688	n/a	117422.0	show_cross	n/a	n/a	141	n/a	n/a	cross.bmp
+470.31254545449997	n/a	117578.1364	show_face	unfamiliar_face	immediate_repeat	141	1	14	u043.bmp
+471.2261818182	n/a	117806.5455	show_circle	n/a	n/a	141	n/a	0	circle.bmp
+472.9261818182	n/a	118231.5455	show_cross	n/a	n/a	142	n/a	n/a	cross.bmp
+473.40345454550004	n/a	118350.8636	show_face	famous_face	first_show	142	n/a	5	f116.bmp
+474.0116363636	n/a	118502.9091	right_press	n/a	n/a	142	n/a	4096	n/a
+474.3098181818	n/a	118577.4545	show_circle	n/a	n/a	142	n/a	0	circle.bmp
+476.00981818180003	n/a	119002.4545	show_cross	n/a	n/a	143	n/a	n/a	cross.bmp
+476.578	n/a	119144.5	show_face	famous_face	first_show	143	n/a	5	f142.bmp
+477.21254545449995	n/a	119303.1364	right_press	n/a	n/a	143	n/a	4096	n/a
+477.4825454545	n/a	119370.6364	show_circle	n/a	n/a	143	n/a	0	circle.bmp
+479.1825454545	n/a	119795.6364	show_cross	n/a	n/a	144	n/a	n/a	cross.bmp
+479.818	n/a	119954.5	show_face	famous_face	immediate_repeat	144	1	6	f142.bmp
+480.32345454550006	n/a	120080.8636	right_press	n/a	n/a	144	n/a	4096	n/a
+480.7416363636	n/a	120185.4091	show_circle	n/a	n/a	144	n/a	0	circle.bmp
+482.4416363636	n/a	120610.4091	show_cross	n/a	n/a	145	n/a	n/a	cross.bmp
+482.9261818182	n/a	120731.5455	show_face	scrambled_face	first_show	145	n/a	17	s117.bmp
+483.8961818182	n/a	120974.0455	show_circle	n/a	n/a	145	n/a	0	circle.bmp
+485.5961818182	n/a	121399.0455	show_cross	n/a	n/a	146	n/a	n/a	cross.bmp
+486.1998181818	n/a	121549.9545	show_face	famous_face	first_show	146	n/a	5	f084.bmp
+486.77890909089996	n/a	121694.7273	right_press	n/a	n/a	146	n/a	4096	n/a
+487.1834545455	n/a	121795.8636	show_circle	n/a	n/a	146	n/a	0	circle.bmp
+488.88345454550006	n/a	122220.8636	show_cross	n/a	n/a	147	n/a	n/a	cross.bmp
+489.47436363639997	n/a	122368.5909	show_face	unfamiliar_face	delayed_repeat	147	8	15	u104.bmp
+490.1134545455	n/a	122528.3636	right_press	n/a	n/a	147	n/a	4096	n/a
+490.3343636364	n/a	122583.5909	show_circle	n/a	n/a	147	n/a	0	circle.bmp
+492.0343636364	n/a	123008.5909	show_cross	n/a	n/a	148	n/a	n/a	cross.bmp

--- a/eeg_hed_small/sub-002/eeg/sub-002_task-FacePerception_run-5_events.tsv
+++ b/eeg_hed_small/sub-002/eeg/sub-002_task-FacePerception_run-5_events.tsv
@@ -1,548 +1,548 @@
-onset	duration	sample	event_type	face_type	repetition_type	trigger	stim_file
-0.0040000000	n/a	1	setup	n/a	n/a	n/a	n/a
-0.0040000000	n/a	1	right_sym	n/a	n/a	n/a	n/a
-25.3443636364	n/a	6336.0909	show_face	unfamiliar_face	first_show	13	u082.bmp
-26.3389090909	n/a	6584.7273	show_circle	n/a	n/a	0	circle.bmp
-28.0389090909	n/a	7009.7273	show_cross	n/a	n/a	n/a	cross.bmp
-28.6189090909	n/a	7154.7273	show_face	famous_face	first_show	5	f088.bmp
-29.3434545455	n/a	7335.8636	right_press	n/a	n/a	4096	n/a
-29.4843636364	n/a	7371.0909	show_circle	n/a	n/a	0	circle.bmp
-31.1843636364	n/a	7796.0909	show_cross	n/a	n/a	n/a	cross.bmp
-31.6752727273	n/a	7918.8182	show_face	famous_face	first_show	5	f022.bmp
-32.5189090909	n/a	8129.7273	right_press	n/a	n/a	4096	n/a
-32.6152727273	n/a	8153.8182	show_circle	n/a	n/a	0	circle.bmp
-34.3152727273	n/a	8578.8182	show_cross	n/a	n/a	n/a	cross.bmp
-34.8998181818	n/a	8724.9545	show_face	unfamiliar_face	first_show	13	u011.bmp
-35.8570909091	n/a	8964.2727	show_circle	n/a	n/a	0	circle.bmp
-37.5570909091	n/a	9389.2727	show_cross	n/a	n/a	n/a	cross.bmp
-38.0734545455	n/a	9518.3636	show_face	unfamiliar_face	first_show	13	u074.bmp
-38.8970909091	n/a	9724.2727	show_circle	n/a	n/a	0	circle.bmp
-40.5970909091	n/a	10149.2727	show_cross	n/a	n/a	n/a	cross.bmp
-41.1143636364	n/a	10278.5909	show_face	unfamiliar_face	immediate_repeat	14	u074.bmp
-41.9407272727	n/a	10485.1818	show_circle	n/a	n/a	0	circle.bmp
-43.6407272727	n/a	10910.1818	show_cross	n/a	n/a	n/a	cross.bmp
-44.1207272727	n/a	11030.1818	show_face	unfamiliar_face	first_show	13	u046.bmp
-44.9389090909	n/a	11234.7273	show_circle	n/a	n/a	0	circle.bmp
-46.6389090909	n/a	11659.7273	show_cross	n/a	n/a	n/a	cross.bmp
-47.2780000000	n/a	11819.5	show_face	unfamiliar_face	immediate_repeat	14	u046.bmp
-48.2307272727	n/a	12057.6818	show_circle	n/a	n/a	0	circle.bmp
-49.9307272727	n/a	12482.6818	show_cross	n/a	n/a	n/a	cross.bmp
-50.3852727273	n/a	12596.3182	show_face	unfamiliar_face	delayed_repeat	15	u082.bmp
-51.2643636364	n/a	12816.0909	show_circle	n/a	n/a	0	circle.bmp
-52.9643636364	n/a	13241.0909	show_cross	n/a	n/a	n/a	cross.bmp
-53.4425454545	n/a	13360.6364	show_face	famous_face	first_show	5	f120.bmp
-54.1289090909	n/a	13532.2273	right_press	n/a	n/a	4096	n/a
-54.3634545455	n/a	13590.8636	show_circle	n/a	n/a	0	circle.bmp
-56.0634545455	n/a	14015.8636	show_cross	n/a	n/a	n/a	cross.bmp
-56.6834545455	n/a	14170.8636	show_face	famous_face	immediate_repeat	6	f120.bmp
-57.6080000000	n/a	14402	right_press	n/a	n/a	4096	n/a
-57.6707272727	n/a	14417.6818	show_circle	n/a	n/a	0	circle.bmp
-59.3707272727	n/a	14842.6818	show_cross	n/a	n/a	n/a	cross.bmp
-59.9570909091	n/a	14989.2727	show_face	famous_face	delayed_repeat	7	f088.bmp
-60.7761818182	n/a	15194.0455	right_press	n/a	n/a	4096	n/a
-60.8180000000	n/a	15204.5	show_circle	n/a	n/a	0	circle.bmp
-62.5180000000	n/a	15629.5	show_cross	n/a	n/a	n/a	cross.bmp
-63.0980000000	n/a	15774.5	show_face	scrambled_face	first_show	17	s075.bmp
-63.9316363636	n/a	15982.9091	show_circle	n/a	n/a	0	circle.bmp
-64.0298181818	n/a	16007.4545	right_press	n/a	n/a	4096	n/a
-65.6316363636	n/a	16407.9091	show_cross	n/a	n/a	n/a	cross.bmp
-66.2552727273	n/a	16563.8182	show_face	scrambled_face	immediate_repeat	18	s075.bmp
-66.9316363636	n/a	16732.9091	right_press	n/a	n/a	4096	n/a
-67.1189090909	n/a	16779.7273	show_circle	n/a	n/a	0	circle.bmp
-68.8189090909	n/a	17204.7273	show_cross	n/a	n/a	n/a	cross.bmp
-69.3289090909	n/a	17332.2273	show_face	famous_face	delayed_repeat	7	f022.bmp
-70.0034545455	n/a	17500.8636	right_press	n/a	n/a	4096	n/a
-70.2261818182	n/a	17556.5455	show_circle	n/a	n/a	0	circle.bmp
-71.9261818182	n/a	17981.5455	show_cross	n/a	n/a	n/a	cross.bmp
-72.5198181818	n/a	18129.9545	show_face	scrambled_face	first_show	17	s141.bmp
-73.4461818182	n/a	18361.5455	show_circle	n/a	n/a	0	circle.bmp
-75.1461818182	n/a	18786.5455	show_cross	n/a	n/a	n/a	cross.bmp
-75.7434545455	n/a	18935.8636	show_face	unfamiliar_face	delayed_repeat	15	u011.bmp
-76.7480000000	n/a	19187	show_circle	n/a	n/a	0	circle.bmp
-78.4480000000	n/a	19612	show_cross	n/a	n/a	n/a	cross.bmp
-78.9343636364	n/a	19733.5909	show_face	famous_face	first_show	5	f107.bmp
-79.6470909091	n/a	19911.7727	right_press	n/a	n/a	4096	n/a
-79.9134545455	n/a	19978.3636	show_circle	n/a	n/a	0	circle.bmp
-81.6134545455	n/a	20403.3636	show_cross	n/a	n/a	n/a	cross.bmp
-82.0916363636	n/a	20522.9091	show_face	unfamiliar_face	first_show	13	u060.bmp
-82.6989090909	n/a	20674.7273	right_press	n/a	n/a	4096	n/a
-82.9980000000	n/a	20749.5	show_circle	n/a	n/a	0	circle.bmp
-84.6980000000	n/a	21174.5	show_cross	n/a	n/a	n/a	cross.bmp
-85.3489090909	n/a	21337.2273	show_face	unfamiliar_face	immediate_repeat	14	u060.bmp
-85.9625454545	n/a	21490.6364	right_press	n/a	n/a	4096	n/a
-86.2180000000	n/a	21554.5	show_circle	n/a	n/a	0	circle.bmp
-87.9180000000	n/a	21979.5	show_cross	n/a	n/a	n/a	cross.bmp
-88.5398181818	n/a	22134.9545	show_face	scrambled_face	first_show	17	s007.bmp
-89.4089090909	n/a	22352.2273	right_press	n/a	n/a	4096	n/a
-89.4098181818	n/a	22352.4545	show_circle	n/a	n/a	0	circle.bmp
-91.1098181818	n/a	22777.4545	show_cross	n/a	n/a	n/a	cross.bmp
-91.5634545455	n/a	22890.8636	show_face	unfamiliar_face	first_show	13	u080.bmp
-92.3298181818	n/a	23082.4545	right_press	n/a	n/a	4096	n/a
-92.5725454545	n/a	23143.1364	show_circle	n/a	n/a	0	circle.bmp
-94.2725454545	n/a	23568.1364	show_cross	n/a	n/a	n/a	cross.bmp
-94.7543636364	n/a	23688.5909	show_face	famous_face	first_show	5	f144.bmp
-95.4480000000	n/a	23862	right_press	n/a	n/a	4096	n/a
-95.7634545455	n/a	23940.8636	show_circle	n/a	n/a	0	circle.bmp
-97.4634545455	n/a	24365.8636	show_cross	n/a	n/a	n/a	cross.bmp
-98.0789090909	n/a	24519.7273	show_face	scrambled_face	delayed_repeat	19	s141.bmp
-98.8807272727	n/a	24720.1818	right_press	n/a	n/a	4096	n/a
-99.0280000000	n/a	24757	show_circle	n/a	n/a	0	circle.bmp
-100.7280000000	n/a	25182	show_cross	n/a	n/a	n/a	cross.bmp
-101.2525454545	n/a	25313.1364	show_face	scrambled_face	first_show	17	s091.bmp
-101.9198181818	n/a	25479.9545	right_press	n/a	n/a	4096	n/a
-102.2243636364	n/a	25556.0909	show_circle	n/a	n/a	0	circle.bmp
-103.9243636364	n/a	25981.0909	show_cross	n/a	n/a	n/a	cross.bmp
-104.4434545455	n/a	26110.8636	show_face	famous_face	delayed_repeat	7	f107.bmp
-105.2798181818	n/a	26319.9545	show_circle	n/a	n/a	0	circle.bmp
-105.3116363636	n/a	26327.9091	right_press	n/a	n/a	4096	n/a
-106.9798181818	n/a	26744.9545	show_cross	n/a	n/a	n/a	cross.bmp
-107.4334545455	n/a	26858.3636	show_face	scrambled_face	first_show	17	s133.bmp
-108.1034545455	n/a	27025.8636	right_press	n/a	n/a	4096	n/a
-108.3452727273	n/a	27086.3182	show_circle	n/a	n/a	0	circle.bmp
-110.0452727273	n/a	27511.3182	show_cross	n/a	n/a	n/a	cross.bmp
-110.5743636364	n/a	27643.5909	show_face	scrambled_face	immediate_repeat	18	s133.bmp
-111.2589090909	n/a	27814.7273	right_press	n/a	n/a	4096	n/a
-111.4334545455	n/a	27858.3636	show_circle	n/a	n/a	0	circle.bmp
-113.1334545455	n/a	28283.3636	show_cross	n/a	n/a	n/a	cross.bmp
-113.7643636364	n/a	28441.0909	show_face	unfamiliar_face	first_show	13	u148.bmp
-114.5216363636	n/a	28630.4091	right_press	n/a	n/a	4096	n/a
-114.6189090909	n/a	28654.7273	show_circle	n/a	n/a	0	circle.bmp
-116.3189090909	n/a	29079.7273	show_cross	n/a	n/a	n/a	cross.bmp
-116.8889090909	n/a	29222.2273	show_face	unfamiliar_face	immediate_repeat	14	u148.bmp
-117.6943636364	n/a	29423.5909	right_press	n/a	n/a	4096	n/a
-117.8261818182	n/a	29456.5455	show_circle	n/a	n/a	0	circle.bmp
-119.5261818182	n/a	29881.5455	show_cross	n/a	n/a	n/a	cross.bmp
-119.9789090909	n/a	29994.7273	show_face	scrambled_face	delayed_repeat	19	s007.bmp
-120.7707272727	n/a	30192.6818	right_press	n/a	n/a	4096	n/a
-120.8943636364	n/a	30223.5909	show_circle	n/a	n/a	0	circle.bmp
-122.5943636364	n/a	30648.5909	show_cross	n/a	n/a	n/a	cross.bmp
-123.0698181818	n/a	30767.4545	show_face	famous_face	first_show	5	f079.bmp
-123.9361818182	n/a	30984.0455	show_circle	n/a	n/a	0	circle.bmp
-125.6361818182	n/a	31409.0455	show_cross	n/a	n/a	n/a	cross.bmp
-126.2434545455	n/a	31560.8636	show_face	famous_face	immediate_repeat	6	f079.bmp
-127.1098181818	n/a	31777.4545	show_circle	n/a	n/a	0	circle.bmp
-128.8098181818	n/a	32202.4545	show_cross	n/a	n/a	n/a	cross.bmp
-129.4343636364	n/a	32358.5909	show_face	unfamiliar_face	delayed_repeat	15	u080.bmp
-130.4070909091	n/a	32601.7727	show_circle	n/a	n/a	0	circle.bmp
-132.1070909091	n/a	33026.7727	show_cross	n/a	n/a	n/a	cross.bmp
-132.6916363636	n/a	33172.9091	show_face	unfamiliar_face	first_show	13	u107.bmp
-133.3661818182	n/a	33341.5455	right_press	n/a	n/a	4096	n/a
-133.6216363636	n/a	33405.4091	show_circle	n/a	n/a	0	circle.bmp
-135.3216363636	n/a	33830.4091	show_cross	n/a	n/a	n/a	cross.bmp
-135.8825454545	n/a	33970.6364	show_face	unfamiliar_face	immediate_repeat	14	u107.bmp
-136.7389090909	n/a	34184.7273	right_press	n/a	n/a	4096	n/a
-136.7607272727	n/a	34190.1818	show_circle	n/a	n/a	0	circle.bmp
-138.4607272727	n/a	34615.1818	show_cross	n/a	n/a	n/a	cross.bmp
-139.1061818182	n/a	34776.5455	show_face	famous_face	delayed_repeat	7	f144.bmp
-139.8352727273	n/a	34958.8182	right_press	n/a	n/a	4096	n/a
-139.9880000000	n/a	34997	show_circle	n/a	n/a	0	circle.bmp
-141.6880000000	n/a	35422	show_cross	n/a	n/a	n/a	cross.bmp
-142.3470909091	n/a	35586.7727	show_face	unfamiliar_face	first_show	13	u054.bmp
-143.1980000000	n/a	35799.5	show_circle	n/a	n/a	0	circle.bmp
-144.8980000000	n/a	36224.5	show_cross	n/a	n/a	n/a	cross.bmp
-145.5380000000	n/a	36384.5	show_face	unfamiliar_face	immediate_repeat	14	u054.bmp
-146.4934545455	n/a	36623.3636	show_circle	n/a	n/a	0	circle.bmp
-148.1934545455	n/a	37048.3636	show_cross	n/a	n/a	n/a	cross.bmp
-148.7625454545	n/a	37190.6364	show_face	scrambled_face	delayed_repeat	19	s091.bmp
-149.4452727273	n/a	37361.3182	right_press	n/a	n/a	4096	n/a
-149.6016363636	n/a	37400.4091	show_circle	n/a	n/a	0	circle.bmp
-151.3016363636	n/a	37825.4091	show_cross	n/a	n/a	n/a	cross.bmp
-151.7861818182	n/a	37946.5455	show_face	unfamiliar_face	first_show	13	u087.bmp
-152.6034545455	n/a	38150.8636	show_circle	n/a	n/a	0	circle.bmp
-152.8307272727	n/a	38207.6818	right_press	n/a	n/a	4096	n/a
-154.3034545455	n/a	38575.8636	show_cross	n/a	n/a	n/a	cross.bmp
-154.8925454545	n/a	38723.1364	show_face	famous_face	first_show	5	f099.bmp
-155.5489090909	n/a	38887.2273	right_press	n/a	n/a	4096	n/a
-155.7970909091	n/a	38949.2727	show_circle	n/a	n/a	0	circle.bmp
-157.4970909091	n/a	39374.2727	show_cross	n/a	n/a	n/a	cross.bmp
-158.0834545455	n/a	39520.8636	show_face	famous_face	first_show	5	f039.bmp
-158.6698181818	n/a	39667.4545	right_press	n/a	n/a	4096	n/a
-159.0870909091	n/a	39771.7727	show_circle	n/a	n/a	0	circle.bmp
-160.7870909091	n/a	40196.7727	show_cross	n/a	n/a	n/a	cross.bmp
-161.2907272727	n/a	40322.6818	show_face	scrambled_face	first_show	17	s051.bmp
-162.2880000000	n/a	40572	show_circle	n/a	n/a	0	circle.bmp
-163.9880000000	n/a	40997	show_cross	n/a	n/a	n/a	cross.bmp
-164.5652727273	n/a	41141.3182	show_face	scrambled_face	immediate_repeat	18	s051.bmp
-165.5280000000	n/a	41382	show_circle	n/a	n/a	0	circle.bmp
-167.2280000000	n/a	41807	show_cross	n/a	n/a	n/a	cross.bmp
-167.8725454545	n/a	41968.1364	show_face	unfamiliar_face	first_show	13	u144.bmp
-168.4398181818	n/a	42109.9545	right_press	n/a	n/a	4096	n/a
-168.8034545455	n/a	42200.8636	show_circle	n/a	n/a	0	circle.bmp
-170.5034545455	n/a	42625.8636	show_cross	n/a	n/a	n/a	cross.bmp
-171.0970909091	n/a	42774.2727	show_face	unfamiliar_face	immediate_repeat	14	u144.bmp
-171.6352727273	n/a	42908.8182	right_press	n/a	n/a	4096	n/a
-172.0425454545	n/a	43010.6364	show_circle	n/a	n/a	0	circle.bmp
-173.7425454545	n/a	43435.6364	show_cross	n/a	n/a	n/a	cross.bmp
-174.2707272727	n/a	43567.6818	show_face	famous_face	first_show	5	f044.bmp
-174.9416363636	n/a	43735.4091	right_press	n/a	n/a	4096	n/a
-175.1980000000	n/a	43799.5	show_circle	n/a	n/a	0	circle.bmp
-176.8980000000	n/a	44224.5	show_cross	n/a	n/a	n/a	cross.bmp
-177.3452727273	n/a	44336.3182	show_face	unfamiliar_face	delayed_repeat	15	u087.bmp
-178.0625454545	n/a	44515.6364	right_press	n/a	n/a	4096	n/a
-178.2998181818	n/a	44574.9545	show_circle	n/a	n/a	0	circle.bmp
-179.9998181818	n/a	44999.9545	show_cross	n/a	n/a	n/a	cross.bmp
-180.6352727273	n/a	45158.8182	show_face	unfamiliar_face	first_show	13	u053.bmp
-181.5134545455	n/a	45378.3636	show_circle	n/a	n/a	0	circle.bmp
-183.2134545455	n/a	45803.3636	show_cross	n/a	n/a	n/a	cross.bmp
-183.7425454545	n/a	45935.6364	show_face	unfamiliar_face	immediate_repeat	14	u053.bmp
-184.6734545455	n/a	46168.3636	show_circle	n/a	n/a	0	circle.bmp
-186.3734545455	n/a	46593.3636	show_cross	n/a	n/a	n/a	cross.bmp
-186.9498181818	n/a	46737.4545	show_face	famous_face	delayed_repeat	7	f099.bmp
-187.4389090909	n/a	46859.7273	right_press	n/a	n/a	4096	n/a
-187.7680000000	n/a	46942	show_circle	n/a	n/a	0	circle.bmp
-189.4680000000	n/a	47367	show_cross	n/a	n/a	n/a	cross.bmp
-190.0743636364	n/a	47518.5909	show_face	famous_face	first_show	5	f113.bmp
-191.0607272727	n/a	47765.1818	show_circle	n/a	n/a	0	circle.bmp
-192.7607272727	n/a	48190.1818	show_cross	n/a	n/a	n/a	cross.bmp
-193.2316363636	n/a	48307.9091	show_face	famous_face	immediate_repeat	6	f113.bmp
-194.2116363636	n/a	48552.9091	show_circle	n/a	n/a	0	circle.bmp
-195.9116363636	n/a	48977.9091	show_cross	n/a	n/a	n/a	cross.bmp
-196.5052727273	n/a	49126.3182	show_face	famous_face	delayed_repeat	7	f039.bmp
-197.0880000000	n/a	49272	right_press	n/a	n/a	4096	n/a
-197.4034545455	n/a	49350.8636	show_circle	n/a	n/a	0	circle.bmp
-199.1034545455	n/a	49775.8636	show_cross	n/a	n/a	n/a	cross.bmp
-199.7298181818	n/a	49932.4545	show_face	famous_face	first_show	5	f001.bmp
-200.3470909091	n/a	50086.7727	right_press	n/a	n/a	4096	n/a
-200.6870909091	n/a	50171.7727	show_circle	n/a	n/a	0	circle.bmp
-202.3870909091	n/a	50596.7727	show_cross	n/a	n/a	n/a	cross.bmp
-202.8534545455	n/a	50713.3636	show_face	scrambled_face	first_show	17	s063.bmp
-203.6834545455	n/a	50920.8636	show_circle	n/a	n/a	0	circle.bmp
-205.3834545455	n/a	51345.8636	show_cross	n/a	n/a	n/a	cross.bmp
-205.9270909091	n/a	51481.7727	show_face	scrambled_face	immediate_repeat	18	s063.bmp
-206.8089090909	n/a	51702.2273	show_circle	n/a	n/a	0	circle.bmp
-208.5089090909	n/a	52127.2273	show_cross	n/a	n/a	n/a	cross.bmp
-209.1343636364	n/a	52283.5909	show_face	scrambled_face	first_show	17	s033.bmp
-210.0007272727	n/a	52500.1818	right_press	n/a	n/a	4096	n/a
-210.0416363636	n/a	52510.4091	show_circle	n/a	n/a	0	circle.bmp
-211.7416363636	n/a	52935.4091	show_cross	n/a	n/a	n/a	cross.bmp
-212.3752727273	n/a	53093.8182	show_face	scrambled_face	immediate_repeat	18	s033.bmp
-212.9261818182	n/a	53231.5455	right_press	n/a	n/a	4096	n/a
-213.2607272727	n/a	53315.1818	show_circle	n/a	n/a	0	circle.bmp
-214.9607272727	n/a	53740.1818	show_cross	n/a	n/a	n/a	cross.bmp
-215.4661818182	n/a	53866.5455	show_face	famous_face	delayed_repeat	7	f044.bmp
-216.1980000000	n/a	54049.5	right_press	n/a	n/a	4096	n/a
-216.4225454545	n/a	54105.6364	show_circle	n/a	n/a	0	circle.bmp
-218.1225454545	n/a	54530.6364	show_cross	n/a	n/a	n/a	cross.bmp
-218.6234545455	n/a	54655.8636	show_face	unfamiliar_face	first_show	13	u128.bmp
-219.5961818182	n/a	54899.0455	show_circle	n/a	n/a	0	circle.bmp
-221.2961818182	n/a	55324.0455	show_cross	n/a	n/a	n/a	cross.bmp
-221.9143636364	n/a	55478.5909	show_face	unfamiliar_face	immediate_repeat	14	u128.bmp
-222.9170909091	n/a	55729.2727	show_circle	n/a	n/a	0	circle.bmp
-224.6170909091	n/a	56154.2727	show_cross	n/a	n/a	n/a	cross.bmp
-225.2380000000	n/a	56309.5	show_face	famous_face	first_show	5	f133.bmp
-225.9134545455	n/a	56478.3636	right_press	n/a	n/a	4096	n/a
-226.0607272727	n/a	56515.1818	show_circle	n/a	n/a	0	circle.bmp
-227.7607272727	n/a	56940.1818	show_cross	n/a	n/a	n/a	cross.bmp
-228.3952727273	n/a	57098.8182	show_face	famous_face	immediate_repeat	6	f133.bmp
-228.8770909091	n/a	57219.2727	right_press	n/a	n/a	4096	n/a
-229.2880000000	n/a	57322	show_circle	n/a	n/a	0	circle.bmp
-230.9880000000	n/a	57747	show_cross	n/a	n/a	n/a	cross.bmp
-231.4861818182	n/a	57871.5455	show_face	scrambled_face	first_show	17	s069.bmp
-232.4980000000	n/a	58124.5	show_circle	n/a	n/a	0	circle.bmp
-234.1980000000	n/a	58549.5	show_cross	n/a	n/a	n/a	cross.bmp
-234.8280000000	n/a	58707	show_face	famous_face	delayed_repeat	7	f001.bmp
-235.7698181818	n/a	58942.4545	show_circle	n/a	n/a	0	circle.bmp
-237.4698181818	n/a	59367.4545	show_cross	n/a	n/a	n/a	cross.bmp
-238.1016363636	n/a	59525.4091	show_face	unfamiliar_face	first_show	13	u075.bmp
-238.7289090909	n/a	59682.2273	right_press	n/a	n/a	4096	n/a
-239.0789090909	n/a	59769.7273	show_circle	n/a	n/a	0	circle.bmp
-240.7789090909	n/a	60194.7273	show_cross	n/a	n/a	n/a	cross.bmp
-241.2589090909	n/a	60314.7273	show_face	scrambled_face	first_show	17	s060.bmp
-241.8098181818	n/a	60452.4545	right_press	n/a	n/a	4096	n/a
-242.1270909091	n/a	60531.7727	show_circle	n/a	n/a	0	circle.bmp
-243.8270909091	n/a	60956.7727	show_cross	n/a	n/a	n/a	cross.bmp
-244.3661818182	n/a	61091.5455	show_face	famous_face	first_show	5	f092.bmp
-244.9498181818	n/a	61237.4545	right_press	n/a	n/a	4096	n/a
-245.2080000000	n/a	61302	show_circle	n/a	n/a	0	circle.bmp
-246.9080000000	n/a	61727	show_cross	n/a	n/a	n/a	cross.bmp
-247.5234545455	n/a	61880.8636	show_face	famous_face	immediate_repeat	6	f092.bmp
-248.1280000000	n/a	62032	right_press	n/a	n/a	4096	n/a
-248.4534545455	n/a	62113.3636	show_circle	n/a	n/a	0	circle.bmp
-250.1534545455	n/a	62538.3636	show_cross	n/a	n/a	n/a	cross.bmp
-250.6634545455	n/a	62665.8636	show_face	famous_face	first_show	5	f064.bmp
-251.3034545455	n/a	62825.8636	right_press	n/a	n/a	4096	n/a
-251.5652727273	n/a	62891.3182	show_circle	n/a	n/a	0	circle.bmp
-253.2652727273	n/a	63316.3182	show_cross	n/a	n/a	n/a	cross.bmp
-253.7707272727	n/a	63442.6818	show_face	famous_face	immediate_repeat	6	f064.bmp
-254.2670909091	n/a	63566.7727	right_press	n/a	n/a	4096	n/a
-254.6598181818	n/a	63664.9545	show_circle	n/a	n/a	0	circle.bmp
-256.3598181818	n/a	64089.9545	show_cross	n/a	n/a	n/a	cross.bmp
-256.8780000000	n/a	64219.5	show_face	unfamiliar_face	first_show	13	u119.bmp
-257.8007272727	n/a	64450.1818	show_circle	n/a	n/a	0	circle.bmp
-259.5007272727	n/a	64875.1818	show_cross	n/a	n/a	n/a	cross.bmp
-260.0852727273	n/a	65021.3182	show_face	scrambled_face	delayed_repeat	19	s069.bmp
-260.9125454545	n/a	65228.1364	right_press	n/a	n/a	4096	n/a
-261.0789090909	n/a	65269.7273	show_circle	n/a	n/a	0	circle.bmp
-262.7789090909	n/a	65694.7273	show_cross	n/a	n/a	n/a	cross.bmp
-263.2761818182	n/a	65819.0455	show_face	scrambled_face	first_show	17	s013.bmp
-263.8961818182	n/a	65974.0455	right_press	n/a	n/a	4096	n/a
-264.2080000000	n/a	66052	show_circle	n/a	n/a	0	circle.bmp
-265.9080000000	n/a	66477	show_cross	n/a	n/a	n/a	cross.bmp
-266.4161818182	n/a	66604.0455	show_face	unfamiliar_face	delayed_repeat	15	u075.bmp
-267.0952727273	n/a	66773.8182	right_press	n/a	n/a	4096	n/a
-267.2543636364	n/a	66813.5909	show_circle	n/a	n/a	0	circle.bmp
-268.9543636364	n/a	67238.5909	show_cross	n/a	n/a	n/a	cross.bmp
-269.5407272727	n/a	67385.1818	show_face	unfamiliar_face	first_show	13	u026.bmp
-270.3680000000	n/a	67592	show_circle	n/a	n/a	0	circle.bmp
-272.0680000000	n/a	68017	show_cross	n/a	n/a	n/a	cross.bmp
-272.5643636364	n/a	68141.0909	show_face	scrambled_face	delayed_repeat	19	s060.bmp
-273.1180000000	n/a	68279.5	right_press	n/a	n/a	4096	n/a
-273.5489090909	n/a	68387.2273	show_circle	n/a	n/a	0	circle.bmp
-275.2489090909	n/a	68812.2273	show_cross	n/a	n/a	n/a	cross.bmp
-275.8052727273	n/a	68951.3182	show_face	scrambled_face	first_show	17	s042.bmp
-276.2570909091	n/a	69064.2727	right_press	n/a	n/a	4096	n/a
-276.6716363636	n/a	69167.9091	show_circle	n/a	n/a	0	circle.bmp
-278.3716363636	n/a	69592.9091	show_cross	n/a	n/a	n/a	cross.bmp
-278.8952727273	n/a	69723.8182	show_face	famous_face	first_show	5	f003.bmp
-279.4507272727	n/a	69862.6818	right_press	n/a	n/a	4096	n/a
-279.8680000000	n/a	69967	show_circle	n/a	n/a	0	circle.bmp
-281.5680000000	n/a	70392	show_cross	n/a	n/a	n/a	cross.bmp
-282.1361818182	n/a	70534.0455	show_face	scrambled_face	first_show	17	s053.bmp
-283.1289090909	n/a	70782.2273	show_circle	n/a	n/a	0	circle.bmp
-284.8289090909	n/a	71207.2273	show_cross	n/a	n/a	n/a	cross.bmp
-285.4770909091	n/a	71369.2727	show_face	unfamiliar_face	delayed_repeat	15	u119.bmp
-286.4952727273	n/a	71623.8182	show_circle	n/a	n/a	0	circle.bmp
-288.1952727273	n/a	72048.8182	show_cross	n/a	n/a	n/a	cross.bmp
-288.6680000000	n/a	72167	show_face	scrambled_face	first_show	17	s093.bmp
-289.3089090909	n/a	72327.2273	right_press	n/a	n/a	4096	n/a
-289.6098181818	n/a	72402.4545	show_circle	n/a	n/a	0	circle.bmp
-291.3098181818	n/a	72827.4545	show_cross	n/a	n/a	n/a	cross.bmp
-291.7916363636	n/a	72947.9091	show_face	scrambled_face	immediate_repeat	18	s093.bmp
-292.3280000000	n/a	73082	right_press	n/a	n/a	4096	n/a
-292.7625454545	n/a	73190.6364	show_circle	n/a	n/a	0	circle.bmp
-294.4625454545	n/a	73615.6364	show_cross	n/a	n/a	n/a	cross.bmp
-294.9152727273	n/a	73728.8182	show_face	scrambled_face	delayed_repeat	19	s013.bmp
-295.4907272727	n/a	73872.6818	right_press	n/a	n/a	4096	n/a
-295.8234545455	n/a	73955.8636	show_circle	n/a	n/a	0	circle.bmp
-297.5234545455	n/a	74380.8636	show_cross	n/a	n/a	n/a	cross.bmp
-298.0398181818	n/a	74509.9545	show_face	unfamiliar_face	first_show	13	u096.bmp
-298.7780000000	n/a	74694.5	right_press	n/a	n/a	4096	n/a
-298.9780000000	n/a	74744.5	show_circle	n/a	n/a	0	circle.bmp
-300.6780000000	n/a	75169.5	show_cross	n/a	n/a	n/a	cross.bmp
-301.2970909091	n/a	75324.2727	show_face	unfamiliar_face	immediate_repeat	14	u096.bmp
-301.8898181818	n/a	75472.4545	right_press	n/a	n/a	4096	n/a
-302.2489090909	n/a	75562.2273	show_circle	n/a	n/a	0	circle.bmp
-303.9489090909	n/a	75987.2273	show_cross	n/a	n/a	n/a	cross.bmp
-304.4707272727	n/a	76117.6818	show_face	unfamiliar_face	delayed_repeat	15	u026.bmp
-305.4298181818	n/a	76357.4545	show_circle	n/a	n/a	0	circle.bmp
-307.1298181818	n/a	76782.4545	show_cross	n/a	n/a	n/a	cross.bmp
-307.6452727273	n/a	76911.3182	show_face	famous_face	first_show	5	f061.bmp
-308.2898181818	n/a	77072.4545	right_press	n/a	n/a	4096	n/a
-308.5707272727	n/a	77142.6818	show_circle	n/a	n/a	0	circle.bmp
-310.2707272727	n/a	77567.6818	show_cross	n/a	n/a	n/a	cross.bmp
-310.7852727273	n/a	77696.3182	show_face	famous_face	immediate_repeat	6	f061.bmp
-311.3752727273	n/a	77843.8182	right_press	n/a	n/a	4096	n/a
-311.7152727273	n/a	77928.8182	show_circle	n/a	n/a	0	circle.bmp
-313.4152727273	n/a	78353.8182	show_cross	n/a	n/a	n/a	cross.bmp
-313.9598181818	n/a	78489.9545	show_face	scrambled_face	delayed_repeat	19	s042.bmp
-314.5552727273	n/a	78638.8182	right_press	n/a	n/a	4096	n/a
-314.8707272727	n/a	78717.6818	show_circle	n/a	n/a	0	circle.bmp
-316.5707272727	n/a	79142.6818	show_cross	n/a	n/a	n/a	cross.bmp
-317.2170909091	n/a	79304.2727	show_face	unfamiliar_face	first_show	13	u108.bmp
-318.1852727273	n/a	79546.3182	show_circle	n/a	n/a	0	circle.bmp
-319.8852727273	n/a	79971.3182	show_cross	n/a	n/a	n/a	cross.bmp
-320.3416363636	n/a	80085.4091	show_face	famous_face	delayed_repeat	7	f003.bmp
-321.1061818182	n/a	80276.5455	right_press	n/a	n/a	4096	n/a
-321.2943636364	n/a	80323.5909	show_circle	n/a	n/a	0	circle.bmp
-322.9943636364	n/a	80748.5909	show_cross	n/a	n/a	n/a	cross.bmp
-323.4980000000	n/a	80874.5	show_face	scrambled_face	first_show	17	s082.bmp
-324.1843636364	n/a	81046.0909	right_press	n/a	n/a	4096	n/a
-324.4698181818	n/a	81117.4545	show_circle	n/a	n/a	0	circle.bmp
-326.1698181818	n/a	81542.4545	show_cross	n/a	n/a	n/a	cross.bmp
-326.7052727273	n/a	81676.3182	show_face	scrambled_face	delayed_repeat	19	s053.bmp
-327.7125454545	n/a	81928.1364	show_circle	n/a	n/a	0	circle.bmp
-329.4125454545	n/a	82353.1364	show_cross	n/a	n/a	n/a	cross.bmp
-329.9298181818	n/a	82482.4545	show_face	unfamiliar_face	first_show	13	u126.bmp
-330.7752727273	n/a	82693.8182	show_circle	n/a	n/a	0	circle.bmp
-332.4752727273	n/a	83118.8182	show_cross	n/a	n/a	n/a	cross.bmp
-333.0698181818	n/a	83267.4545	show_face	unfamiliar_face	immediate_repeat	14	u126.bmp
-333.9070909091	n/a	83476.7727	show_circle	n/a	n/a	0	circle.bmp
-335.6070909091	n/a	83901.7727	show_cross	n/a	n/a	n/a	cross.bmp
-336.0607272727	n/a	84015.1818	show_face	scrambled_face	first_show	17	s035.bmp
-336.6570909091	n/a	84164.2727	right_press	n/a	n/a	4096	n/a
-336.8961818182	n/a	84224.0455	show_circle	n/a	n/a	0	circle.bmp
-338.5961818182	n/a	84649.0455	show_cross	n/a	n/a	n/a	cross.bmp
-339.1007272727	n/a	84775.1818	show_face	scrambled_face	first_show	17	s145.bmp
-339.7234545455	n/a	84930.8636	right_press	n/a	n/a	4096	n/a
-339.9507272727	n/a	84987.6818	show_circle	n/a	n/a	0	circle.bmp
-341.6507272727	n/a	85412.6818	show_cross	n/a	n/a	n/a	cross.bmp
-342.1580000000	n/a	85539.5	show_face	scrambled_face	first_show	17	s032.bmp
-342.7243636364	n/a	85681.0909	right_press	n/a	n/a	4096	n/a
-343.0507272727	n/a	85762.6818	show_circle	n/a	n/a	0	circle.bmp
-344.7507272727	n/a	86187.6818	show_cross	n/a	n/a	n/a	cross.bmp
-345.3652727273	n/a	86341.3182	show_face	scrambled_face	immediate_repeat	18	s032.bmp
-345.9070909091	n/a	86476.7727	right_press	n/a	n/a	4096	n/a
-346.3052727273	n/a	86576.3182	show_circle	n/a	n/a	0	circle.bmp
-348.0052727273	n/a	87001.3182	show_cross	n/a	n/a	n/a	cross.bmp
-348.4561818182	n/a	87114.0455	show_face	unfamiliar_face	delayed_repeat	15	u108.bmp
-349.3880000000	n/a	87347	show_circle	n/a	n/a	0	circle.bmp
-351.0880000000	n/a	87772	show_cross	n/a	n/a	n/a	cross.bmp
-351.6125454545	n/a	87903.1364	show_face	unfamiliar_face	first_show	13	u143.bmp
-352.3234545455	n/a	88080.8636	right_press	n/a	n/a	4096	n/a
-352.4398181818	n/a	88109.9545	show_circle	n/a	n/a	0	circle.bmp
-354.1398181818	n/a	88534.9545	show_cross	n/a	n/a	n/a	cross.bmp
-354.7698181818	n/a	88692.4545	show_face	unfamiliar_face	immediate_repeat	14	u143.bmp
-355.6652727273	n/a	88916.3182	show_circle	n/a	n/a	0	circle.bmp
-357.3652727273	n/a	89341.3182	show_cross	n/a	n/a	n/a	cross.bmp
-357.8443636364	n/a	89461.0909	show_face	scrambled_face	delayed_repeat	19	s082.bmp
-358.8280000000	n/a	89707	show_circle	n/a	n/a	0	circle.bmp
-360.5280000000	n/a	90132	show_cross	n/a	n/a	n/a	cross.bmp
-361.0016363636	n/a	90250.4091	show_face	unfamiliar_face	first_show	13	u039.bmp
-361.5934545455	n/a	90398.3636	right_press	n/a	n/a	4096	n/a
-361.9743636364	n/a	90493.5909	show_circle	n/a	n/a	0	circle.bmp
-363.6743636364	n/a	90918.5909	show_cross	n/a	n/a	n/a	cross.bmp
-364.2425454545	n/a	91060.6364	show_face	unfamiliar_face	immediate_repeat	14	u039.bmp
-364.8316363636	n/a	91207.9091	right_press	n/a	n/a	4096	n/a
-365.2252727273	n/a	91306.3182	show_circle	n/a	n/a	0	circle.bmp
-366.9252727273	n/a	91731.3182	show_cross	n/a	n/a	n/a	cross.bmp
-367.4498181818	n/a	91862.4545	show_face	famous_face	first_show	5	f043.bmp
-367.8734545455	n/a	91968.3636	right_press	n/a	n/a	4096	n/a
-368.3580000000	n/a	92089.5	show_circle	n/a	n/a	0	circle.bmp
-370.0580000000	n/a	92514.5	show_cross	n/a	n/a	n/a	cross.bmp
-370.7070909091	n/a	92676.7727	show_face	scrambled_face	delayed_repeat	19	s035.bmp
-371.3498181818	n/a	92837.4545	right_press	n/a	n/a	4096	n/a
-371.7143636364	n/a	92928.5909	show_circle	n/a	n/a	0	circle.bmp
-373.4143636364	n/a	93353.5909	show_cross	n/a	n/a	n/a	cross.bmp
-373.9980000000	n/a	93499.5	show_face	famous_face	first_show	5	f138.bmp
-374.7561818182	n/a	93689.0455	right_press	n/a	n/a	4096	n/a
-374.9361818182	n/a	93734.0455	show_circle	n/a	n/a	0	circle.bmp
-376.6361818182	n/a	94159.0455	show_cross	n/a	n/a	n/a	cross.bmp
-377.1552727273	n/a	94288.8182	show_face	scrambled_face	delayed_repeat	19	s145.bmp
-377.8480000000	n/a	94462	right_press	n/a	n/a	4096	n/a
-377.9734545455	n/a	94493.3636	show_circle	n/a	n/a	0	circle.bmp
-379.6734545455	n/a	94918.3636	show_cross	n/a	n/a	n/a	cross.bmp
-380.2452727273	n/a	95061.3182	show_face	scrambled_face	first_show	17	s085.bmp
-380.9434545455	n/a	95235.8636	right_press	n/a	n/a	4096	n/a
-381.1080000000	n/a	95277	show_circle	n/a	n/a	0	circle.bmp
-382.8080000000	n/a	95702	show_cross	n/a	n/a	n/a	cross.bmp
-383.3698181818	n/a	95842.4545	show_face	famous_face	first_show	5	f118.bmp
-383.9425454545	n/a	95985.6364	right_press	n/a	n/a	4096	n/a
-384.2507272727	n/a	96062.6818	show_circle	n/a	n/a	0	circle.bmp
-385.9507272727	n/a	96487.6818	show_cross	n/a	n/a	n/a	cross.bmp
-386.5098181818	n/a	96627.4545	show_face	famous_face	immediate_repeat	6	f118.bmp
-387.4989090909	n/a	96874.7273	show_circle	n/a	n/a	0	circle.bmp
-387.5534545455	n/a	96888.3636	right_press	n/a	n/a	4096	n/a
-389.1989090909	n/a	97299.7273	show_cross	n/a	n/a	n/a	cross.bmp
-389.8680000000	n/a	97467	show_face	famous_face	first_show	5	f087.bmp
-390.6170909091	n/a	97654.2727	right_press	n/a	n/a	4096	n/a
-390.7870909091	n/a	97696.7727	show_circle	n/a	n/a	0	circle.bmp
-392.4870909091	n/a	98121.7727	show_cross	n/a	n/a	n/a	cross.bmp
-393.0416363636	n/a	98260.4091	show_face	famous_face	immediate_repeat	6	f087.bmp
-393.6352727273	n/a	98408.8182	right_press	n/a	n/a	4096	n/a
-394.0361818182	n/a	98509.0455	show_circle	n/a	n/a	0	circle.bmp
-395.7361818182	n/a	98934.0455	show_cross	n/a	n/a	n/a	cross.bmp
-396.3661818182	n/a	99091.5455	show_face	famous_face	first_show	5	f042.bmp
-396.9752727273	n/a	99243.8182	right_press	n/a	n/a	4096	n/a
-397.2743636364	n/a	99318.5909	show_circle	n/a	n/a	0	circle.bmp
-398.9743636364	n/a	99743.5909	show_cross	n/a	n/a	n/a	cross.bmp
-399.6234545455	n/a	99905.8636	show_face	famous_face	immediate_repeat	6	f042.bmp
-400.3434545455	n/a	100085.8636	right_press	n/a	n/a	4096	n/a
-400.5043636364	n/a	100126.0909	show_circle	n/a	n/a	0	circle.bmp
-402.2043636364	n/a	100551.0909	show_cross	n/a	n/a	n/a	cross.bmp
-402.6970909091	n/a	100674.2727	show_face	famous_face	delayed_repeat	7	f043.bmp
-403.2698181818	n/a	100817.4545	right_press	n/a	n/a	4096	n/a
-403.5934545455	n/a	100898.3636	show_circle	n/a	n/a	0	circle.bmp
-405.2934545455	n/a	101323.3636	show_cross	n/a	n/a	n/a	cross.bmp
-405.8880000000	n/a	101472	show_face	scrambled_face	first_show	17	s012.bmp
-406.3734545455	n/a	101593.3636	right_press	n/a	n/a	4096	n/a
-406.8170909091	n/a	101704.2727	show_circle	n/a	n/a	0	circle.bmp
-408.5170909091	n/a	102129.2727	show_cross	n/a	n/a	n/a	cross.bmp
-409.0116363636	n/a	102252.9091	show_face	famous_face	delayed_repeat	7	f138.bmp
-409.5570909091	n/a	102389.2727	right_press	n/a	n/a	4096	n/a
-409.9161818182	n/a	102479.0455	show_circle	n/a	n/a	0	circle.bmp
-411.6161818182	n/a	102904.0455	show_cross	n/a	n/a	n/a	cross.bmp
-412.1361818182	n/a	103034.0455	show_face	famous_face	first_show	5	f136.bmp
-412.6334545455	n/a	103158.3636	right_press	n/a	n/a	4096	n/a
-413.0116363636	n/a	103252.9091	show_circle	n/a	n/a	0	circle.bmp
-414.7116363636	n/a	103677.9091	show_cross	n/a	n/a	n/a	cross.bmp
-415.2598181818	n/a	103814.9545	show_face	famous_face	immediate_repeat	6	f136.bmp
-415.7789090909	n/a	103944.7273	right_press	n/a	n/a	4096	n/a
-416.2543636364	n/a	104063.5909	show_circle	n/a	n/a	0	circle.bmp
-417.9543636364	n/a	104488.5909	show_cross	n/a	n/a	n/a	cross.bmp
-418.4670909091	n/a	104616.7727	show_face	scrambled_face	delayed_repeat	19	s085.bmp
-419.0689090909	n/a	104767.2273	right_press	n/a	n/a	4096	n/a
-419.3361818182	n/a	104834.0455	show_circle	n/a	n/a	0	circle.bmp
-420.3934545455	n/a	105098.3636	right_press	n/a	n/a	4096	n/a
-421.0361818182	n/a	105259.0455	show_cross	n/a	n/a	n/a	cross.bmp
-421.5570909091	n/a	105389.2727	show_face	scrambled_face	first_show	17	s044.bmp
-422.4343636364	n/a	105608.5909	right_press	n/a	n/a	4096	n/a
-422.5498181818	n/a	105637.4545	show_circle	n/a	n/a	0	circle.bmp
-424.2498181818	n/a	106062.4545	show_cross	n/a	n/a	n/a	cross.bmp
-424.8825454545	n/a	106220.6364	show_face	unfamiliar_face	first_show	13	u109.bmp
-425.7107272727	n/a	106427.6818	show_circle	n/a	n/a	0	circle.bmp
-427.4107272727	n/a	106852.6818	show_cross	n/a	n/a	n/a	cross.bmp
-427.8889090909	n/a	106972.2273	show_face	unfamiliar_face	first_show	13	u050.bmp
-428.8216363636	n/a	107205.4091	show_circle	n/a	n/a	0	circle.bmp
-430.5216363636	n/a	107630.4091	show_cross	n/a	n/a	n/a	cross.bmp
-431.1634545455	n/a	107790.8636	show_face	scrambled_face	first_show	17	s134.bmp
-431.9725454545	n/a	107993.1364	right_press	n/a	n/a	4096	n/a
-432.1143636364	n/a	108028.5909	show_circle	n/a	n/a	0	circle.bmp
-433.8143636364	n/a	108453.5909	show_cross	n/a	n/a	n/a	cross.bmp
-434.3207272727	n/a	108580.1818	show_face	scrambled_face	immediate_repeat	18	s134.bmp
-435.0843636364	n/a	108771.0909	right_press	n/a	n/a	4096	n/a
-435.2707272727	n/a	108817.6818	show_circle	n/a	n/a	0	circle.bmp
-436.9707272727	n/a	109242.6818	show_cross	n/a	n/a	n/a	cross.bmp
-437.4780000000	n/a	109369.5	show_face	scrambled_face	delayed_repeat	19	s012.bmp
-438.1998181818	n/a	109549.9545	right_press	n/a	n/a	4096	n/a
-438.4843636364	n/a	109621.0909	show_circle	n/a	n/a	0	circle.bmp
-440.1843636364	n/a	110046.0909	show_cross	n/a	n/a	n/a	cross.bmp
-440.7180000000	n/a	110179.5	show_face	unfamiliar_face	first_show	13	u130.bmp
-441.6134545455	n/a	110403.3636	show_circle	n/a	n/a	0	circle.bmp
-443.3134545455	n/a	110828.3636	show_cross	n/a	n/a	n/a	cross.bmp
-443.8425454545	n/a	110960.6364	show_face	unfamiliar_face	first_show	13	u079.bmp
-444.7816363636	n/a	111195.4091	show_circle	n/a	n/a	0	circle.bmp
-446.4816363636	n/a	111620.4091	show_cross	n/a	n/a	n/a	cross.bmp
-446.9825454545	n/a	111745.6364	show_face	scrambled_face	delayed_repeat	19	s044.bmp
-447.7343636364	n/a	111933.5909	right_press	n/a	n/a	4096	n/a
-447.8534545455	n/a	111963.3636	show_circle	n/a	n/a	0	circle.bmp
-449.5534545455	n/a	112388.3636	show_cross	n/a	n/a	n/a	cross.bmp
-450.1070909091	n/a	112526.7727	show_face	scrambled_face	first_show	17	s089.bmp
-450.6352727273	n/a	112658.8182	right_press	n/a	n/a	4096	n/a
-451.0952727273	n/a	112773.8182	show_circle	n/a	n/a	0	circle.bmp
-452.7952727273	n/a	113198.8182	show_cross	n/a	n/a	n/a	cross.bmp
-453.3470909091	n/a	113336.7727	show_face	scrambled_face	immediate_repeat	18	s089.bmp
-453.9061818182	n/a	113476.5455	right_press	n/a	n/a	4096	n/a
-454.2916363636	n/a	113572.9091	show_circle	n/a	n/a	0	circle.bmp
-455.9916363636	n/a	113997.9091	show_cross	n/a	n/a	n/a	cross.bmp
-456.5043636364	n/a	114126.0909	show_face	unfamiliar_face	delayed_repeat	15	u109.bmp
-457.4370909091	n/a	114359.2727	show_circle	n/a	n/a	0	circle.bmp
-459.1370909091	n/a	114784.2727	show_cross	n/a	n/a	n/a	cross.bmp
-459.7625454545	n/a	114940.6364	show_face	scrambled_face	first_show	17	s030.bmp
-460.7489090909	n/a	115187.2273	show_circle	n/a	n/a	0	circle.bmp
-462.4489090909	n/a	115612.2273	show_cross	n/a	n/a	n/a	cross.bmp
-462.9698181818	n/a	115742.4545	show_face	unfamiliar_face	delayed_repeat	15	u050.bmp
-463.9007272727	n/a	115975.1818	show_circle	n/a	n/a	0	circle.bmp
-465.6007272727	n/a	116400.1818	show_cross	n/a	n/a	n/a	cross.bmp
-466.1098181818	n/a	116527.4545	show_face	scrambled_face	first_show	17	s100.bmp
-466.7125454545	n/a	116678.1364	right_press	n/a	n/a	4096	n/a
-467.0843636364	n/a	116771.0909	show_circle	n/a	n/a	0	circle.bmp
-468.7843636364	n/a	117196.0909	show_cross	n/a	n/a	n/a	cross.bmp
-469.3843636364	n/a	117346.0909	show_face	scrambled_face	immediate_repeat	18	s100.bmp
-469.9070909091	n/a	117476.7727	right_press	n/a	n/a	4096	n/a
-470.3043636364	n/a	117576.0909	show_circle	n/a	n/a	0	circle.bmp
-472.0043636364	n/a	118001.0909	show_cross	n/a	n/a	n/a	cross.bmp
-472.5916363636	n/a	118147.9091	show_face	famous_face	first_show	5	f109.bmp
-473.3416363636	n/a	118335.4091	right_press	n/a	n/a	4096	n/a
-473.5425454545	n/a	118385.6364	show_circle	n/a	n/a	0	circle.bmp
-475.2425454545	n/a	118810.6364	show_cross	n/a	n/a	n/a	cross.bmp
-475.8825454545	n/a	118970.6364	show_face	famous_face	immediate_repeat	6	f109.bmp
-476.5834545455	n/a	119145.8636	right_press	n/a	n/a	4096	n/a
-476.7307272727	n/a	119182.6818	show_circle	n/a	n/a	0	circle.bmp
-478.4307272727	n/a	119607.6818	show_cross	n/a	n/a	n/a	cross.bmp
-479.0234545455	n/a	119755.8636	show_face	unfamiliar_face	delayed_repeat	15	u130.bmp
-479.9943636364	n/a	119998.5909	show_circle	n/a	n/a	0	circle.bmp
-481.6943636364	n/a	120423.5909	show_cross	n/a	n/a	n/a	cross.bmp
-482.3307272727	n/a	120582.6818	show_face	famous_face	first_show	5	f095.bmp
-483.2116363636	n/a	120802.9091	show_circle	n/a	n/a	0	circle.bmp
-484.9116363636	n/a	121227.9091	show_cross	n/a	n/a	n/a	cross.bmp
-485.5552727273	n/a	121388.8182	show_face	unfamiliar_face	delayed_repeat	15	u079.bmp
-486.4461818182	n/a	121611.5455	show_circle	n/a	n/a	0	circle.bmp
-488.1461818182	n/a	122036.5455	show_cross	n/a	n/a	n/a	cross.bmp
-488.8125454545	n/a	122203.1364	show_face	famous_face	first_show	5	f017.bmp
-489.5252727273	n/a	122381.3182	right_press	n/a	n/a	4096	n/a
-489.6780000000	n/a	122419.5	show_circle	n/a	n/a	0	circle.bmp
-491.3780000000	n/a	122844.5	show_cross	n/a	n/a	n/a	cross.bmp
-492.0198181818	n/a	123004.9545	show_face	famous_face	immediate_repeat	6	f017.bmp
-492.5616363636	n/a	123140.4091	right_press	n/a	n/a	4096	n/a
-492.9261818182	n/a	123231.5455	show_circle	n/a	n/a	0	circle.bmp
-494.6261818182	n/a	123656.5455	show_cross	n/a	n/a	n/a	cross.bmp
+onset	duration	sample	event_type	face_type	repetition_type	trial	trial_lag	trigger	stim_file
+0.004	n/a	1.0	setup	n/a	n/a	n/a	n/a	n/a	n/a
+0.004	n/a	1.0	right_sym	n/a	n/a	n/a	n/a	n/a	n/a
+25.344363636399997	n/a	6336.0909	show_face	unfamiliar_face	first_show	1	n/a	13	u082.bmp
+26.338909090900003	n/a	6584.7273	show_circle	n/a	n/a	1	n/a	0	circle.bmp
+28.038909090900002	n/a	7009.7273	show_cross	n/a	n/a	2	n/a	n/a	cross.bmp
+28.6189090909	n/a	7154.7273	show_face	famous_face	first_show	2	n/a	5	f088.bmp
+29.343454545500002	n/a	7335.8636	right_press	n/a	n/a	2	n/a	4096	n/a
+29.484363636399998	n/a	7371.0909	show_circle	n/a	n/a	2	n/a	0	circle.bmp
+31.184363636399997	n/a	7796.0909	show_cross	n/a	n/a	3	n/a	n/a	cross.bmp
+31.6752727273	n/a	7918.8182	show_face	famous_face	first_show	3	n/a	5	f022.bmp
+32.5189090909	n/a	8129.7273	right_press	n/a	n/a	3	n/a	4096	n/a
+32.6152727273	n/a	8153.8182	show_circle	n/a	n/a	3	n/a	0	circle.bmp
+34.3152727273	n/a	8578.8182	show_cross	n/a	n/a	4	n/a	n/a	cross.bmp
+34.8998181818	n/a	8724.9545	show_face	unfamiliar_face	first_show	4	n/a	13	u011.bmp
+35.8570909091	n/a	8964.2727	show_circle	n/a	n/a	4	n/a	0	circle.bmp
+37.5570909091	n/a	9389.2727	show_cross	n/a	n/a	5	n/a	n/a	cross.bmp
+38.0734545455	n/a	9518.3636	show_face	unfamiliar_face	first_show	5	n/a	13	u074.bmp
+38.8970909091	n/a	9724.2727	show_circle	n/a	n/a	5	n/a	0	circle.bmp
+40.5970909091	n/a	10149.2727	show_cross	n/a	n/a	6	n/a	n/a	cross.bmp
+41.1143636364	n/a	10278.5909	show_face	unfamiliar_face	immediate_repeat	6	1	14	u074.bmp
+41.9407272727	n/a	10485.1818	show_circle	n/a	n/a	6	n/a	0	circle.bmp
+43.640727272700005	n/a	10910.1818	show_cross	n/a	n/a	7	n/a	n/a	cross.bmp
+44.1207272727	n/a	11030.1818	show_face	unfamiliar_face	first_show	7	n/a	13	u046.bmp
+44.938909090900005	n/a	11234.7273	show_circle	n/a	n/a	7	n/a	0	circle.bmp
+46.6389090909	n/a	11659.7273	show_cross	n/a	n/a	8	n/a	n/a	cross.bmp
+47.278	n/a	11819.5	show_face	unfamiliar_face	immediate_repeat	8	1	14	u046.bmp
+48.2307272727	n/a	12057.6818	show_circle	n/a	n/a	8	n/a	0	circle.bmp
+49.930727272700004	n/a	12482.6818	show_cross	n/a	n/a	9	n/a	n/a	cross.bmp
+50.3852727273	n/a	12596.3182	show_face	unfamiliar_face	delayed_repeat	9	8	15	u082.bmp
+51.264363636400006	n/a	12816.0909	show_circle	n/a	n/a	9	n/a	0	circle.bmp
+52.9643636364	n/a	13241.0909	show_cross	n/a	n/a	10	n/a	n/a	cross.bmp
+53.4425454545	n/a	13360.6364	show_face	famous_face	first_show	10	n/a	5	f120.bmp
+54.1289090909	n/a	13532.2273	right_press	n/a	n/a	10	n/a	4096	n/a
+54.363454545500005	n/a	13590.8636	show_circle	n/a	n/a	10	n/a	0	circle.bmp
+56.0634545455	n/a	14015.8636	show_cross	n/a	n/a	11	n/a	n/a	cross.bmp
+56.683454545500005	n/a	14170.8636	show_face	famous_face	immediate_repeat	11	1	6	f120.bmp
+57.608	n/a	14402.0	right_press	n/a	n/a	11	n/a	4096	n/a
+57.670727272700006	n/a	14417.6818	show_circle	n/a	n/a	11	n/a	0	circle.bmp
+59.3707272727	n/a	14842.6818	show_cross	n/a	n/a	12	n/a	n/a	cross.bmp
+59.957090909099996	n/a	14989.2727	show_face	famous_face	delayed_repeat	12	10	7	f088.bmp
+60.776181818199994	n/a	15194.0455	right_press	n/a	n/a	12	n/a	4096	n/a
+60.818	n/a	15204.5	show_circle	n/a	n/a	12	n/a	0	circle.bmp
+62.518	n/a	15629.5	show_cross	n/a	n/a	13	n/a	n/a	cross.bmp
+63.098	n/a	15774.5	show_face	scrambled_face	first_show	13	n/a	17	s075.bmp
+63.9316363636	n/a	15982.9091	show_circle	n/a	n/a	13	n/a	0	circle.bmp
+64.0298181818	n/a	16007.4545	right_press	n/a	n/a	13	n/a	4096	n/a
+65.6316363636	n/a	16407.9091	show_cross	n/a	n/a	14	n/a	n/a	cross.bmp
+66.2552727273	n/a	16563.8182	show_face	scrambled_face	immediate_repeat	14	1	18	s075.bmp
+66.93163636359999	n/a	16732.9091	right_press	n/a	n/a	14	n/a	4096	n/a
+67.1189090909	n/a	16779.7273	show_circle	n/a	n/a	14	n/a	0	circle.bmp
+68.81890909090001	n/a	17204.7273	show_cross	n/a	n/a	15	n/a	n/a	cross.bmp
+69.3289090909	n/a	17332.2273	show_face	famous_face	delayed_repeat	15	12	7	f022.bmp
+70.0034545455	n/a	17500.8636	right_press	n/a	n/a	15	n/a	4096	n/a
+70.22618181819999	n/a	17556.5455	show_circle	n/a	n/a	15	n/a	0	circle.bmp
+71.92618181819999	n/a	17981.5455	show_cross	n/a	n/a	16	n/a	n/a	cross.bmp
+72.5198181818	n/a	18129.9545	show_face	scrambled_face	first_show	16	n/a	17	s141.bmp
+73.4461818182	n/a	18361.5455	show_circle	n/a	n/a	16	n/a	0	circle.bmp
+75.14618181819999	n/a	18786.5455	show_cross	n/a	n/a	17	n/a	n/a	cross.bmp
+75.7434545455	n/a	18935.8636	show_face	unfamiliar_face	delayed_repeat	17	13	15	u011.bmp
+76.748	n/a	19187.0	show_circle	n/a	n/a	17	n/a	0	circle.bmp
+78.448	n/a	19612.0	show_cross	n/a	n/a	18	n/a	n/a	cross.bmp
+78.93436363640001	n/a	19733.5909	show_face	famous_face	first_show	18	n/a	5	f107.bmp
+79.6470909091	n/a	19911.7727	right_press	n/a	n/a	18	n/a	4096	n/a
+79.9134545455	n/a	19978.3636	show_circle	n/a	n/a	18	n/a	0	circle.bmp
+81.6134545455	n/a	20403.3636	show_cross	n/a	n/a	19	n/a	n/a	cross.bmp
+82.0916363636	n/a	20522.9091	show_face	unfamiliar_face	first_show	19	n/a	13	u060.bmp
+82.6989090909	n/a	20674.7273	right_press	n/a	n/a	19	n/a	4096	n/a
+82.998	n/a	20749.5	show_circle	n/a	n/a	19	n/a	0	circle.bmp
+84.698	n/a	21174.5	show_cross	n/a	n/a	20	n/a	n/a	cross.bmp
+85.34890909090001	n/a	21337.2273	show_face	unfamiliar_face	immediate_repeat	20	1	14	u060.bmp
+85.9625454545	n/a	21490.6364	right_press	n/a	n/a	20	n/a	4096	n/a
+86.218	n/a	21554.5	show_circle	n/a	n/a	20	n/a	0	circle.bmp
+87.918	n/a	21979.5	show_cross	n/a	n/a	21	n/a	n/a	cross.bmp
+88.5398181818	n/a	22134.9545	show_face	scrambled_face	first_show	21	n/a	17	s007.bmp
+89.4089090909	n/a	22352.2273	right_press	n/a	n/a	21	n/a	4096	n/a
+89.4098181818	n/a	22352.4545	show_circle	n/a	n/a	21	n/a	0	circle.bmp
+91.10981818180001	n/a	22777.4545	show_cross	n/a	n/a	22	n/a	n/a	cross.bmp
+91.5634545455	n/a	22890.8636	show_face	unfamiliar_face	first_show	22	n/a	13	u080.bmp
+92.32981818180001	n/a	23082.4545	right_press	n/a	n/a	22	n/a	4096	n/a
+92.5725454545	n/a	23143.1364	show_circle	n/a	n/a	22	n/a	0	circle.bmp
+94.2725454545	n/a	23568.1364	show_cross	n/a	n/a	23	n/a	n/a	cross.bmp
+94.7543636364	n/a	23688.5909	show_face	famous_face	first_show	23	n/a	5	f144.bmp
+95.448	n/a	23862.0	right_press	n/a	n/a	23	n/a	4096	n/a
+95.7634545455	n/a	23940.8636	show_circle	n/a	n/a	23	n/a	0	circle.bmp
+97.4634545455	n/a	24365.8636	show_cross	n/a	n/a	24	n/a	n/a	cross.bmp
+98.0789090909	n/a	24519.7273	show_face	scrambled_face	delayed_repeat	24	8	19	s141.bmp
+98.8807272727	n/a	24720.1818	right_press	n/a	n/a	24	n/a	4096	n/a
+99.028	n/a	24757.0	show_circle	n/a	n/a	24	n/a	0	circle.bmp
+100.728	n/a	25182.0	show_cross	n/a	n/a	25	n/a	n/a	cross.bmp
+101.25254545450001	n/a	25313.1364	show_face	scrambled_face	first_show	25	n/a	17	s091.bmp
+101.9198181818	n/a	25479.9545	right_press	n/a	n/a	25	n/a	4096	n/a
+102.2243636364	n/a	25556.0909	show_circle	n/a	n/a	25	n/a	0	circle.bmp
+103.92436363639999	n/a	25981.0909	show_cross	n/a	n/a	26	n/a	n/a	cross.bmp
+104.44345454549999	n/a	26110.8636	show_face	famous_face	delayed_repeat	26	8	7	f107.bmp
+105.2798181818	n/a	26319.9545	show_circle	n/a	n/a	26	n/a	0	circle.bmp
+105.3116363636	n/a	26327.9091	right_press	n/a	n/a	26	n/a	4096	n/a
+106.9798181818	n/a	26744.9545	show_cross	n/a	n/a	27	n/a	n/a	cross.bmp
+107.4334545455	n/a	26858.3636	show_face	scrambled_face	first_show	27	n/a	17	s133.bmp
+108.10345454549999	n/a	27025.8636	right_press	n/a	n/a	27	n/a	4096	n/a
+108.3452727273	n/a	27086.3182	show_circle	n/a	n/a	27	n/a	0	circle.bmp
+110.0452727273	n/a	27511.3182	show_cross	n/a	n/a	28	n/a	n/a	cross.bmp
+110.5743636364	n/a	27643.5909	show_face	scrambled_face	immediate_repeat	28	1	18	s133.bmp
+111.2589090909	n/a	27814.7273	right_press	n/a	n/a	28	n/a	4096	n/a
+111.4334545455	n/a	27858.3636	show_circle	n/a	n/a	28	n/a	0	circle.bmp
+113.13345454549999	n/a	28283.3636	show_cross	n/a	n/a	29	n/a	n/a	cross.bmp
+113.76436363639999	n/a	28441.0909	show_face	unfamiliar_face	first_show	29	n/a	13	u148.bmp
+114.52163636360001	n/a	28630.4091	right_press	n/a	n/a	29	n/a	4096	n/a
+114.6189090909	n/a	28654.7273	show_circle	n/a	n/a	29	n/a	0	circle.bmp
+116.31890909090001	n/a	29079.7273	show_cross	n/a	n/a	30	n/a	n/a	cross.bmp
+116.8889090909	n/a	29222.2273	show_face	unfamiliar_face	immediate_repeat	30	1	14	u148.bmp
+117.6943636364	n/a	29423.5909	right_press	n/a	n/a	30	n/a	4096	n/a
+117.8261818182	n/a	29456.5455	show_circle	n/a	n/a	30	n/a	0	circle.bmp
+119.5261818182	n/a	29881.5455	show_cross	n/a	n/a	31	n/a	n/a	cross.bmp
+119.9789090909	n/a	29994.7273	show_face	scrambled_face	delayed_repeat	31	10	19	s007.bmp
+120.7707272727	n/a	30192.6818	right_press	n/a	n/a	31	n/a	4096	n/a
+120.89436363639999	n/a	30223.5909	show_circle	n/a	n/a	31	n/a	0	circle.bmp
+122.59436363639999	n/a	30648.5909	show_cross	n/a	n/a	32	n/a	n/a	cross.bmp
+123.0698181818	n/a	30767.4545	show_face	famous_face	first_show	32	n/a	5	f079.bmp
+123.9361818182	n/a	30984.0455	show_circle	n/a	n/a	32	n/a	0	circle.bmp
+125.6361818182	n/a	31409.0455	show_cross	n/a	n/a	33	n/a	n/a	cross.bmp
+126.24345454549999	n/a	31560.8636	show_face	famous_face	immediate_repeat	33	1	6	f079.bmp
+127.10981818180001	n/a	31777.4545	show_circle	n/a	n/a	33	n/a	0	circle.bmp
+128.8098181818	n/a	32202.4545	show_cross	n/a	n/a	34	n/a	n/a	cross.bmp
+129.4343636364	n/a	32358.5909	show_face	unfamiliar_face	delayed_repeat	34	12	15	u080.bmp
+130.4070909091	n/a	32601.7727	show_circle	n/a	n/a	34	n/a	0	circle.bmp
+132.1070909091	n/a	33026.7727	show_cross	n/a	n/a	35	n/a	n/a	cross.bmp
+132.6916363636	n/a	33172.9091	show_face	unfamiliar_face	first_show	35	n/a	13	u107.bmp
+133.3661818182	n/a	33341.5455	right_press	n/a	n/a	35	n/a	4096	n/a
+133.6216363636	n/a	33405.4091	show_circle	n/a	n/a	35	n/a	0	circle.bmp
+135.3216363636	n/a	33830.4091	show_cross	n/a	n/a	36	n/a	n/a	cross.bmp
+135.88254545450002	n/a	33970.6364	show_face	unfamiliar_face	immediate_repeat	36	1	14	u107.bmp
+136.7389090909	n/a	34184.7273	right_press	n/a	n/a	36	n/a	4096	n/a
+136.7607272727	n/a	34190.1818	show_circle	n/a	n/a	36	n/a	0	circle.bmp
+138.4607272727	n/a	34615.1818	show_cross	n/a	n/a	37	n/a	n/a	cross.bmp
+139.10618181819999	n/a	34776.5455	show_face	famous_face	delayed_repeat	37	14	7	f144.bmp
+139.8352727273	n/a	34958.8182	right_press	n/a	n/a	37	n/a	4096	n/a
+139.988	n/a	34997.0	show_circle	n/a	n/a	37	n/a	0	circle.bmp
+141.688	n/a	35422.0	show_cross	n/a	n/a	38	n/a	n/a	cross.bmp
+142.3470909091	n/a	35586.7727	show_face	unfamiliar_face	first_show	38	n/a	13	u054.bmp
+143.198	n/a	35799.5	show_circle	n/a	n/a	38	n/a	0	circle.bmp
+144.898	n/a	36224.5	show_cross	n/a	n/a	39	n/a	n/a	cross.bmp
+145.538	n/a	36384.5	show_face	unfamiliar_face	immediate_repeat	39	1	14	u054.bmp
+146.4934545455	n/a	36623.3636	show_circle	n/a	n/a	39	n/a	0	circle.bmp
+148.1934545455	n/a	37048.3636	show_cross	n/a	n/a	40	n/a	n/a	cross.bmp
+148.7625454545	n/a	37190.6364	show_face	scrambled_face	delayed_repeat	40	15	19	s091.bmp
+149.4452727273	n/a	37361.3182	right_press	n/a	n/a	40	n/a	4096	n/a
+149.6016363636	n/a	37400.4091	show_circle	n/a	n/a	40	n/a	0	circle.bmp
+151.3016363636	n/a	37825.4091	show_cross	n/a	n/a	41	n/a	n/a	cross.bmp
+151.7861818182	n/a	37946.5455	show_face	unfamiliar_face	first_show	41	n/a	13	u087.bmp
+152.6034545455	n/a	38150.8636	show_circle	n/a	n/a	41	n/a	0	circle.bmp
+152.83072727270002	n/a	38207.6818	right_press	n/a	n/a	41	n/a	4096	n/a
+154.3034545455	n/a	38575.8636	show_cross	n/a	n/a	42	n/a	n/a	cross.bmp
+154.8925454545	n/a	38723.1364	show_face	famous_face	first_show	42	n/a	5	f099.bmp
+155.5489090909	n/a	38887.2273	right_press	n/a	n/a	42	n/a	4096	n/a
+155.7970909091	n/a	38949.2727	show_circle	n/a	n/a	42	n/a	0	circle.bmp
+157.4970909091	n/a	39374.2727	show_cross	n/a	n/a	43	n/a	n/a	cross.bmp
+158.0834545455	n/a	39520.8636	show_face	famous_face	first_show	43	n/a	5	f039.bmp
+158.6698181818	n/a	39667.4545	right_press	n/a	n/a	43	n/a	4096	n/a
+159.0870909091	n/a	39771.7727	show_circle	n/a	n/a	43	n/a	0	circle.bmp
+160.7870909091	n/a	40196.7727	show_cross	n/a	n/a	44	n/a	n/a	cross.bmp
+161.2907272727	n/a	40322.6818	show_face	scrambled_face	first_show	44	n/a	17	s051.bmp
+162.288	n/a	40572.0	show_circle	n/a	n/a	44	n/a	0	circle.bmp
+163.988	n/a	40997.0	show_cross	n/a	n/a	45	n/a	n/a	cross.bmp
+164.5652727273	n/a	41141.3182	show_face	scrambled_face	immediate_repeat	45	1	18	s051.bmp
+165.528	n/a	41382.0	show_circle	n/a	n/a	45	n/a	0	circle.bmp
+167.228	n/a	41807.0	show_cross	n/a	n/a	46	n/a	n/a	cross.bmp
+167.8725454545	n/a	41968.1364	show_face	unfamiliar_face	first_show	46	n/a	13	u144.bmp
+168.4398181818	n/a	42109.9545	right_press	n/a	n/a	46	n/a	4096	n/a
+168.8034545455	n/a	42200.8636	show_circle	n/a	n/a	46	n/a	0	circle.bmp
+170.5034545455	n/a	42625.8636	show_cross	n/a	n/a	47	n/a	n/a	cross.bmp
+171.0970909091	n/a	42774.2727	show_face	unfamiliar_face	immediate_repeat	47	1	14	u144.bmp
+171.6352727273	n/a	42908.8182	right_press	n/a	n/a	47	n/a	4096	n/a
+172.04254545450002	n/a	43010.6364	show_circle	n/a	n/a	47	n/a	0	circle.bmp
+173.7425454545	n/a	43435.6364	show_cross	n/a	n/a	48	n/a	n/a	cross.bmp
+174.27072727270001	n/a	43567.6818	show_face	famous_face	first_show	48	n/a	5	f044.bmp
+174.9416363636	n/a	43735.4091	right_press	n/a	n/a	48	n/a	4096	n/a
+175.198	n/a	43799.5	show_circle	n/a	n/a	48	n/a	0	circle.bmp
+176.898	n/a	44224.5	show_cross	n/a	n/a	49	n/a	n/a	cross.bmp
+177.3452727273	n/a	44336.3182	show_face	unfamiliar_face	delayed_repeat	49	8	15	u087.bmp
+178.0625454545	n/a	44515.6364	right_press	n/a	n/a	49	n/a	4096	n/a
+178.2998181818	n/a	44574.9545	show_circle	n/a	n/a	49	n/a	0	circle.bmp
+179.9998181818	n/a	44999.9545	show_cross	n/a	n/a	50	n/a	n/a	cross.bmp
+180.6352727273	n/a	45158.8182	show_face	unfamiliar_face	first_show	50	n/a	13	u053.bmp
+181.5134545455	n/a	45378.3636	show_circle	n/a	n/a	50	n/a	0	circle.bmp
+183.21345454549999	n/a	45803.3636	show_cross	n/a	n/a	51	n/a	n/a	cross.bmp
+183.7425454545	n/a	45935.6364	show_face	unfamiliar_face	immediate_repeat	51	1	14	u053.bmp
+184.6734545455	n/a	46168.3636	show_circle	n/a	n/a	51	n/a	0	circle.bmp
+186.37345454549998	n/a	46593.3636	show_cross	n/a	n/a	52	n/a	n/a	cross.bmp
+186.9498181818	n/a	46737.4545	show_face	famous_face	delayed_repeat	52	10	7	f099.bmp
+187.4389090909	n/a	46859.7273	right_press	n/a	n/a	52	n/a	4096	n/a
+187.768	n/a	46942.0	show_circle	n/a	n/a	52	n/a	0	circle.bmp
+189.468	n/a	47367.0	show_cross	n/a	n/a	53	n/a	n/a	cross.bmp
+190.0743636364	n/a	47518.5909	show_face	famous_face	first_show	53	n/a	5	f113.bmp
+191.0607272727	n/a	47765.1818	show_circle	n/a	n/a	53	n/a	0	circle.bmp
+192.7607272727	n/a	48190.1818	show_cross	n/a	n/a	54	n/a	n/a	cross.bmp
+193.23163636360002	n/a	48307.9091	show_face	famous_face	immediate_repeat	54	1	6	f113.bmp
+194.2116363636	n/a	48552.9091	show_circle	n/a	n/a	54	n/a	0	circle.bmp
+195.9116363636	n/a	48977.9091	show_cross	n/a	n/a	55	n/a	n/a	cross.bmp
+196.5052727273	n/a	49126.3182	show_face	famous_face	delayed_repeat	55	12	7	f039.bmp
+197.088	n/a	49272.0	right_press	n/a	n/a	55	n/a	4096	n/a
+197.40345454549998	n/a	49350.8636	show_circle	n/a	n/a	55	n/a	0	circle.bmp
+199.1034545455	n/a	49775.8636	show_cross	n/a	n/a	56	n/a	n/a	cross.bmp
+199.7298181818	n/a	49932.4545	show_face	famous_face	first_show	56	n/a	5	f001.bmp
+200.3470909091	n/a	50086.7727	right_press	n/a	n/a	56	n/a	4096	n/a
+200.6870909091	n/a	50171.7727	show_circle	n/a	n/a	56	n/a	0	circle.bmp
+202.3870909091	n/a	50596.7727	show_cross	n/a	n/a	57	n/a	n/a	cross.bmp
+202.8534545455	n/a	50713.3636	show_face	scrambled_face	first_show	57	n/a	17	s063.bmp
+203.68345454549998	n/a	50920.8636	show_circle	n/a	n/a	57	n/a	0	circle.bmp
+205.3834545455	n/a	51345.8636	show_cross	n/a	n/a	58	n/a	n/a	cross.bmp
+205.9270909091	n/a	51481.7727	show_face	scrambled_face	immediate_repeat	58	1	18	s063.bmp
+206.8089090909	n/a	51702.2273	show_circle	n/a	n/a	58	n/a	0	circle.bmp
+208.5089090909	n/a	52127.2273	show_cross	n/a	n/a	59	n/a	n/a	cross.bmp
+209.1343636364	n/a	52283.5909	show_face	scrambled_face	first_show	59	n/a	17	s033.bmp
+210.0007272727	n/a	52500.1818	right_press	n/a	n/a	59	n/a	4096	n/a
+210.04163636360002	n/a	52510.4091	show_circle	n/a	n/a	59	n/a	0	circle.bmp
+211.7416363636	n/a	52935.4091	show_cross	n/a	n/a	60	n/a	n/a	cross.bmp
+212.3752727273	n/a	53093.8182	show_face	scrambled_face	immediate_repeat	60	1	18	s033.bmp
+212.9261818182	n/a	53231.5455	right_press	n/a	n/a	60	n/a	4096	n/a
+213.2607272727	n/a	53315.1818	show_circle	n/a	n/a	60	n/a	0	circle.bmp
+214.9607272727	n/a	53740.1818	show_cross	n/a	n/a	61	n/a	n/a	cross.bmp
+215.4661818182	n/a	53866.5455	show_face	famous_face	delayed_repeat	61	13	7	f044.bmp
+216.198	n/a	54049.5	right_press	n/a	n/a	61	n/a	4096	n/a
+216.4225454545	n/a	54105.6364	show_circle	n/a	n/a	61	n/a	0	circle.bmp
+218.1225454545	n/a	54530.6364	show_cross	n/a	n/a	62	n/a	n/a	cross.bmp
+218.62345454549998	n/a	54655.8636	show_face	unfamiliar_face	first_show	62	n/a	13	u128.bmp
+219.5961818182	n/a	54899.0455	show_circle	n/a	n/a	62	n/a	0	circle.bmp
+221.29618181819998	n/a	55324.0455	show_cross	n/a	n/a	63	n/a	n/a	cross.bmp
+221.9143636364	n/a	55478.5909	show_face	unfamiliar_face	immediate_repeat	63	1	14	u128.bmp
+222.9170909091	n/a	55729.2727	show_circle	n/a	n/a	63	n/a	0	circle.bmp
+224.6170909091	n/a	56154.2727	show_cross	n/a	n/a	64	n/a	n/a	cross.bmp
+225.238	n/a	56309.5	show_face	famous_face	first_show	64	n/a	5	f133.bmp
+225.9134545455	n/a	56478.3636	right_press	n/a	n/a	64	n/a	4096	n/a
+226.0607272727	n/a	56515.1818	show_circle	n/a	n/a	64	n/a	0	circle.bmp
+227.7607272727	n/a	56940.1818	show_cross	n/a	n/a	65	n/a	n/a	cross.bmp
+228.39527272729998	n/a	57098.8182	show_face	famous_face	immediate_repeat	65	1	6	f133.bmp
+228.8770909091	n/a	57219.2727	right_press	n/a	n/a	65	n/a	4096	n/a
+229.288	n/a	57322.0	show_circle	n/a	n/a	65	n/a	0	circle.bmp
+230.988	n/a	57747.0	show_cross	n/a	n/a	66	n/a	n/a	cross.bmp
+231.4861818182	n/a	57871.5455	show_face	scrambled_face	first_show	66	n/a	17	s069.bmp
+232.498	n/a	58124.5	show_circle	n/a	n/a	66	n/a	0	circle.bmp
+234.198	n/a	58549.5	show_cross	n/a	n/a	67	n/a	n/a	cross.bmp
+234.828	n/a	58707.0	show_face	famous_face	delayed_repeat	67	11	7	f001.bmp
+235.7698181818	n/a	58942.4545	show_circle	n/a	n/a	67	n/a	0	circle.bmp
+237.4698181818	n/a	59367.4545	show_cross	n/a	n/a	68	n/a	n/a	cross.bmp
+238.1016363636	n/a	59525.4091	show_face	unfamiliar_face	first_show	68	n/a	13	u075.bmp
+238.7289090909	n/a	59682.2273	right_press	n/a	n/a	68	n/a	4096	n/a
+239.0789090909	n/a	59769.7273	show_circle	n/a	n/a	68	n/a	0	circle.bmp
+240.77890909090002	n/a	60194.7273	show_cross	n/a	n/a	69	n/a	n/a	cross.bmp
+241.2589090909	n/a	60314.7273	show_face	scrambled_face	first_show	69	n/a	17	s060.bmp
+241.8098181818	n/a	60452.4545	right_press	n/a	n/a	69	n/a	4096	n/a
+242.1270909091	n/a	60531.7727	show_circle	n/a	n/a	69	n/a	0	circle.bmp
+243.8270909091	n/a	60956.7727	show_cross	n/a	n/a	70	n/a	n/a	cross.bmp
+244.3661818182	n/a	61091.5455	show_face	famous_face	first_show	70	n/a	5	f092.bmp
+244.9498181818	n/a	61237.4545	right_press	n/a	n/a	70	n/a	4096	n/a
+245.208	n/a	61302.0	show_circle	n/a	n/a	70	n/a	0	circle.bmp
+246.908	n/a	61727.0	show_cross	n/a	n/a	71	n/a	n/a	cross.bmp
+247.5234545455	n/a	61880.8636	show_face	famous_face	immediate_repeat	71	1	6	f092.bmp
+248.128	n/a	62032.0	right_press	n/a	n/a	71	n/a	4096	n/a
+248.4534545455	n/a	62113.3636	show_circle	n/a	n/a	71	n/a	0	circle.bmp
+250.15345454549998	n/a	62538.3636	show_cross	n/a	n/a	72	n/a	n/a	cross.bmp
+250.6634545455	n/a	62665.8636	show_face	famous_face	first_show	72	n/a	5	f064.bmp
+251.3034545455	n/a	62825.8636	right_press	n/a	n/a	72	n/a	4096	n/a
+251.5652727273	n/a	62891.3182	show_circle	n/a	n/a	72	n/a	0	circle.bmp
+253.2652727273	n/a	63316.3182	show_cross	n/a	n/a	73	n/a	n/a	cross.bmp
+253.77072727270001	n/a	63442.6818	show_face	famous_face	immediate_repeat	73	1	6	f064.bmp
+254.2670909091	n/a	63566.7727	right_press	n/a	n/a	73	n/a	4096	n/a
+254.6598181818	n/a	63664.9545	show_circle	n/a	n/a	73	n/a	0	circle.bmp
+256.3598181818	n/a	64089.9545	show_cross	n/a	n/a	74	n/a	n/a	cross.bmp
+256.878	n/a	64219.5	show_face	unfamiliar_face	first_show	74	n/a	13	u119.bmp
+257.8007272727	n/a	64450.1818	show_circle	n/a	n/a	74	n/a	0	circle.bmp
+259.50072727270003	n/a	64875.1818	show_cross	n/a	n/a	75	n/a	n/a	cross.bmp
+260.0852727273	n/a	65021.3182	show_face	scrambled_face	delayed_repeat	75	9	19	s069.bmp
+260.9125454545	n/a	65228.1364	right_press	n/a	n/a	75	n/a	4096	n/a
+261.0789090909	n/a	65269.7273	show_circle	n/a	n/a	75	n/a	0	circle.bmp
+262.7789090909	n/a	65694.7273	show_cross	n/a	n/a	76	n/a	n/a	cross.bmp
+263.2761818182	n/a	65819.0455	show_face	scrambled_face	first_show	76	n/a	17	s013.bmp
+263.8961818182	n/a	65974.0455	right_press	n/a	n/a	76	n/a	4096	n/a
+264.208	n/a	66052.0	show_circle	n/a	n/a	76	n/a	0	circle.bmp
+265.908	n/a	66477.0	show_cross	n/a	n/a	77	n/a	n/a	cross.bmp
+266.4161818182	n/a	66604.0455	show_face	unfamiliar_face	delayed_repeat	77	9	15	u075.bmp
+267.09527272729997	n/a	66773.8182	right_press	n/a	n/a	77	n/a	4096	n/a
+267.2543636364	n/a	66813.5909	show_circle	n/a	n/a	77	n/a	0	circle.bmp
+268.9543636364	n/a	67238.5909	show_cross	n/a	n/a	78	n/a	n/a	cross.bmp
+269.5407272727	n/a	67385.1818	show_face	unfamiliar_face	first_show	78	n/a	13	u026.bmp
+270.368	n/a	67592.0	show_circle	n/a	n/a	78	n/a	0	circle.bmp
+272.068	n/a	68017.0	show_cross	n/a	n/a	79	n/a	n/a	cross.bmp
+272.5643636364	n/a	68141.0909	show_face	scrambled_face	delayed_repeat	79	10	19	s060.bmp
+273.118	n/a	68279.5	right_press	n/a	n/a	79	n/a	4096	n/a
+273.5489090909	n/a	68387.2273	show_circle	n/a	n/a	79	n/a	0	circle.bmp
+275.2489090909	n/a	68812.2273	show_cross	n/a	n/a	80	n/a	n/a	cross.bmp
+275.8052727273	n/a	68951.3182	show_face	scrambled_face	first_show	80	n/a	17	s042.bmp
+276.2570909091	n/a	69064.2727	right_press	n/a	n/a	80	n/a	4096	n/a
+276.6716363636	n/a	69167.9091	show_circle	n/a	n/a	80	n/a	0	circle.bmp
+278.37163636360003	n/a	69592.9091	show_cross	n/a	n/a	81	n/a	n/a	cross.bmp
+278.8952727273	n/a	69723.8182	show_face	famous_face	first_show	81	n/a	5	f003.bmp
+279.4507272727	n/a	69862.6818	right_press	n/a	n/a	81	n/a	4096	n/a
+279.868	n/a	69967.0	show_circle	n/a	n/a	81	n/a	0	circle.bmp
+281.568	n/a	70392.0	show_cross	n/a	n/a	82	n/a	n/a	cross.bmp
+282.1361818182	n/a	70534.0455	show_face	scrambled_face	first_show	82	n/a	17	s053.bmp
+283.1289090909	n/a	70782.2273	show_circle	n/a	n/a	82	n/a	0	circle.bmp
+284.8289090909	n/a	71207.2273	show_cross	n/a	n/a	83	n/a	n/a	cross.bmp
+285.4770909091	n/a	71369.2727	show_face	unfamiliar_face	delayed_repeat	83	9	15	u119.bmp
+286.4952727273	n/a	71623.8182	show_circle	n/a	n/a	83	n/a	0	circle.bmp
+288.1952727273	n/a	72048.8182	show_cross	n/a	n/a	84	n/a	n/a	cross.bmp
+288.668	n/a	72167.0	show_face	scrambled_face	first_show	84	n/a	17	s093.bmp
+289.3089090909	n/a	72327.2273	right_press	n/a	n/a	84	n/a	4096	n/a
+289.6098181818	n/a	72402.4545	show_circle	n/a	n/a	84	n/a	0	circle.bmp
+291.3098181818	n/a	72827.4545	show_cross	n/a	n/a	85	n/a	n/a	cross.bmp
+291.7916363636	n/a	72947.9091	show_face	scrambled_face	immediate_repeat	85	1	18	s093.bmp
+292.328	n/a	73082.0	right_press	n/a	n/a	85	n/a	4096	n/a
+292.7625454545	n/a	73190.6364	show_circle	n/a	n/a	85	n/a	0	circle.bmp
+294.4625454545	n/a	73615.6364	show_cross	n/a	n/a	86	n/a	n/a	cross.bmp
+294.9152727273	n/a	73728.8182	show_face	scrambled_face	delayed_repeat	86	10	19	s013.bmp
+295.4907272727	n/a	73872.6818	right_press	n/a	n/a	86	n/a	4096	n/a
+295.8234545455	n/a	73955.8636	show_circle	n/a	n/a	86	n/a	0	circle.bmp
+297.5234545455	n/a	74380.8636	show_cross	n/a	n/a	87	n/a	n/a	cross.bmp
+298.0398181818	n/a	74509.9545	show_face	unfamiliar_face	first_show	87	n/a	13	u096.bmp
+298.778	n/a	74694.5	right_press	n/a	n/a	87	n/a	4096	n/a
+298.978	n/a	74744.5	show_circle	n/a	n/a	87	n/a	0	circle.bmp
+300.678	n/a	75169.5	show_cross	n/a	n/a	88	n/a	n/a	cross.bmp
+301.2970909091	n/a	75324.2727	show_face	unfamiliar_face	immediate_repeat	88	1	14	u096.bmp
+301.8898181818	n/a	75472.4545	right_press	n/a	n/a	88	n/a	4096	n/a
+302.2489090909	n/a	75562.2273	show_circle	n/a	n/a	88	n/a	0	circle.bmp
+303.9489090909	n/a	75987.2273	show_cross	n/a	n/a	89	n/a	n/a	cross.bmp
+304.4707272727	n/a	76117.6818	show_face	unfamiliar_face	delayed_repeat	89	11	15	u026.bmp
+305.4298181818	n/a	76357.4545	show_circle	n/a	n/a	89	n/a	0	circle.bmp
+307.1298181818	n/a	76782.4545	show_cross	n/a	n/a	90	n/a	n/a	cross.bmp
+307.6452727273	n/a	76911.3182	show_face	famous_face	first_show	90	n/a	5	f061.bmp
+308.2898181818	n/a	77072.4545	right_press	n/a	n/a	90	n/a	4096	n/a
+308.5707272727	n/a	77142.6818	show_circle	n/a	n/a	90	n/a	0	circle.bmp
+310.2707272727	n/a	77567.6818	show_cross	n/a	n/a	91	n/a	n/a	cross.bmp
+310.78527272729997	n/a	77696.3182	show_face	famous_face	immediate_repeat	91	1	6	f061.bmp
+311.3752727273	n/a	77843.8182	right_press	n/a	n/a	91	n/a	4096	n/a
+311.7152727273	n/a	77928.8182	show_circle	n/a	n/a	91	n/a	0	circle.bmp
+313.4152727273	n/a	78353.8182	show_cross	n/a	n/a	92	n/a	n/a	cross.bmp
+313.9598181818	n/a	78489.9545	show_face	scrambled_face	delayed_repeat	92	12	19	s042.bmp
+314.5552727273	n/a	78638.8182	right_press	n/a	n/a	92	n/a	4096	n/a
+314.8707272727	n/a	78717.6818	show_circle	n/a	n/a	92	n/a	0	circle.bmp
+316.5707272727	n/a	79142.6818	show_cross	n/a	n/a	93	n/a	n/a	cross.bmp
+317.2170909091	n/a	79304.2727	show_face	unfamiliar_face	first_show	93	n/a	13	u108.bmp
+318.1852727273	n/a	79546.3182	show_circle	n/a	n/a	93	n/a	0	circle.bmp
+319.8852727273	n/a	79971.3182	show_cross	n/a	n/a	94	n/a	n/a	cross.bmp
+320.3416363636	n/a	80085.4091	show_face	famous_face	delayed_repeat	94	13	7	f003.bmp
+321.1061818182	n/a	80276.5455	right_press	n/a	n/a	94	n/a	4096	n/a
+321.2943636364	n/a	80323.5909	show_circle	n/a	n/a	94	n/a	0	circle.bmp
+322.9943636364	n/a	80748.5909	show_cross	n/a	n/a	95	n/a	n/a	cross.bmp
+323.498	n/a	80874.5	show_face	scrambled_face	first_show	95	n/a	17	s082.bmp
+324.1843636364	n/a	81046.0909	right_press	n/a	n/a	95	n/a	4096	n/a
+324.4698181818	n/a	81117.4545	show_circle	n/a	n/a	95	n/a	0	circle.bmp
+326.1698181818	n/a	81542.4545	show_cross	n/a	n/a	96	n/a	n/a	cross.bmp
+326.7052727273	n/a	81676.3182	show_face	scrambled_face	delayed_repeat	96	14	19	s053.bmp
+327.7125454545	n/a	81928.1364	show_circle	n/a	n/a	96	n/a	0	circle.bmp
+329.4125454545	n/a	82353.1364	show_cross	n/a	n/a	97	n/a	n/a	cross.bmp
+329.9298181818	n/a	82482.4545	show_face	unfamiliar_face	first_show	97	n/a	13	u126.bmp
+330.7752727273	n/a	82693.8182	show_circle	n/a	n/a	97	n/a	0	circle.bmp
+332.4752727273	n/a	83118.8182	show_cross	n/a	n/a	98	n/a	n/a	cross.bmp
+333.06981818180003	n/a	83267.4545	show_face	unfamiliar_face	immediate_repeat	98	1	14	u126.bmp
+333.9070909091	n/a	83476.7727	show_circle	n/a	n/a	98	n/a	0	circle.bmp
+335.6070909091	n/a	83901.7727	show_cross	n/a	n/a	99	n/a	n/a	cross.bmp
+336.0607272727	n/a	84015.1818	show_face	scrambled_face	first_show	99	n/a	17	s035.bmp
+336.6570909091	n/a	84164.2727	right_press	n/a	n/a	99	n/a	4096	n/a
+336.8961818182	n/a	84224.0455	show_circle	n/a	n/a	99	n/a	0	circle.bmp
+338.5961818182	n/a	84649.0455	show_cross	n/a	n/a	100	n/a	n/a	cross.bmp
+339.1007272727	n/a	84775.1818	show_face	scrambled_face	first_show	100	n/a	17	s145.bmp
+339.7234545455	n/a	84930.8636	right_press	n/a	n/a	100	n/a	4096	n/a
+339.9507272727	n/a	84987.6818	show_circle	n/a	n/a	100	n/a	0	circle.bmp
+341.6507272727	n/a	85412.6818	show_cross	n/a	n/a	101	n/a	n/a	cross.bmp
+342.158	n/a	85539.5	show_face	scrambled_face	first_show	101	n/a	17	s032.bmp
+342.72436363639997	n/a	85681.0909	right_press	n/a	n/a	101	n/a	4096	n/a
+343.0507272727	n/a	85762.6818	show_circle	n/a	n/a	101	n/a	0	circle.bmp
+344.7507272727	n/a	86187.6818	show_cross	n/a	n/a	102	n/a	n/a	cross.bmp
+345.3652727273	n/a	86341.3182	show_face	scrambled_face	immediate_repeat	102	1	18	s032.bmp
+345.9070909091	n/a	86476.7727	right_press	n/a	n/a	102	n/a	4096	n/a
+346.3052727273	n/a	86576.3182	show_circle	n/a	n/a	102	n/a	0	circle.bmp
+348.00527272730005	n/a	87001.3182	show_cross	n/a	n/a	103	n/a	n/a	cross.bmp
+348.4561818182	n/a	87114.0455	show_face	unfamiliar_face	delayed_repeat	103	10	15	u108.bmp
+349.388	n/a	87347.0	show_circle	n/a	n/a	103	n/a	0	circle.bmp
+351.088	n/a	87772.0	show_cross	n/a	n/a	104	n/a	n/a	cross.bmp
+351.6125454545	n/a	87903.1364	show_face	unfamiliar_face	first_show	104	n/a	13	u143.bmp
+352.32345454550006	n/a	88080.8636	right_press	n/a	n/a	104	n/a	4096	n/a
+352.4398181818	n/a	88109.9545	show_circle	n/a	n/a	104	n/a	0	circle.bmp
+354.1398181818	n/a	88534.9545	show_cross	n/a	n/a	105	n/a	n/a	cross.bmp
+354.7698181818	n/a	88692.4545	show_face	unfamiliar_face	immediate_repeat	105	1	14	u143.bmp
+355.6652727273	n/a	88916.3182	show_circle	n/a	n/a	105	n/a	0	circle.bmp
+357.3652727273	n/a	89341.3182	show_cross	n/a	n/a	106	n/a	n/a	cross.bmp
+357.8443636364	n/a	89461.0909	show_face	scrambled_face	delayed_repeat	106	11	19	s082.bmp
+358.828	n/a	89707.0	show_circle	n/a	n/a	106	n/a	0	circle.bmp
+360.528	n/a	90132.0	show_cross	n/a	n/a	107	n/a	n/a	cross.bmp
+361.0016363636	n/a	90250.4091	show_face	unfamiliar_face	first_show	107	n/a	13	u039.bmp
+361.59345454550004	n/a	90398.3636	right_press	n/a	n/a	107	n/a	4096	n/a
+361.97436363639997	n/a	90493.5909	show_circle	n/a	n/a	107	n/a	0	circle.bmp
+363.6743636364	n/a	90918.5909	show_cross	n/a	n/a	108	n/a	n/a	cross.bmp
+364.2425454545	n/a	91060.6364	show_face	unfamiliar_face	immediate_repeat	108	1	14	u039.bmp
+364.8316363636	n/a	91207.9091	right_press	n/a	n/a	108	n/a	4096	n/a
+365.2252727273	n/a	91306.3182	show_circle	n/a	n/a	108	n/a	0	circle.bmp
+366.9252727273	n/a	91731.3182	show_cross	n/a	n/a	109	n/a	n/a	cross.bmp
+367.4498181818	n/a	91862.4545	show_face	famous_face	first_show	109	n/a	5	f043.bmp
+367.8734545455	n/a	91968.3636	right_press	n/a	n/a	109	n/a	4096	n/a
+368.358	n/a	92089.5	show_circle	n/a	n/a	109	n/a	0	circle.bmp
+370.058	n/a	92514.5	show_cross	n/a	n/a	110	n/a	n/a	cross.bmp
+370.70709090910003	n/a	92676.7727	show_face	scrambled_face	delayed_repeat	110	11	19	s035.bmp
+371.3498181818	n/a	92837.4545	right_press	n/a	n/a	110	n/a	4096	n/a
+371.7143636364	n/a	92928.5909	show_circle	n/a	n/a	110	n/a	0	circle.bmp
+373.41436363639997	n/a	93353.5909	show_cross	n/a	n/a	111	n/a	n/a	cross.bmp
+373.998	n/a	93499.5	show_face	famous_face	first_show	111	n/a	5	f138.bmp
+374.7561818182	n/a	93689.0455	right_press	n/a	n/a	111	n/a	4096	n/a
+374.9361818182	n/a	93734.0455	show_circle	n/a	n/a	111	n/a	0	circle.bmp
+376.6361818182	n/a	94159.0455	show_cross	n/a	n/a	112	n/a	n/a	cross.bmp
+377.15527272730003	n/a	94288.8182	show_face	scrambled_face	delayed_repeat	112	12	19	s145.bmp
+377.848	n/a	94462.0	right_press	n/a	n/a	112	n/a	4096	n/a
+377.97345454550003	n/a	94493.3636	show_circle	n/a	n/a	112	n/a	0	circle.bmp
+379.6734545455	n/a	94918.3636	show_cross	n/a	n/a	113	n/a	n/a	cross.bmp
+380.24527272730006	n/a	95061.3182	show_face	scrambled_face	first_show	113	n/a	17	s085.bmp
+380.9434545455	n/a	95235.8636	right_press	n/a	n/a	113	n/a	4096	n/a
+381.108	n/a	95277.0	show_circle	n/a	n/a	113	n/a	0	circle.bmp
+382.808	n/a	95702.0	show_cross	n/a	n/a	114	n/a	n/a	cross.bmp
+383.3698181818	n/a	95842.4545	show_face	famous_face	first_show	114	n/a	5	f118.bmp
+383.94254545449996	n/a	95985.6364	right_press	n/a	n/a	114	n/a	4096	n/a
+384.2507272727	n/a	96062.6818	show_circle	n/a	n/a	114	n/a	0	circle.bmp
+385.95072727269996	n/a	96487.6818	show_cross	n/a	n/a	115	n/a	n/a	cross.bmp
+386.50981818180003	n/a	96627.4545	show_face	famous_face	immediate_repeat	115	1	6	f118.bmp
+387.4989090909	n/a	96874.7273	show_circle	n/a	n/a	115	n/a	0	circle.bmp
+387.5534545455	n/a	96888.3636	right_press	n/a	n/a	115	n/a	4096	n/a
+389.1989090909	n/a	97299.7273	show_cross	n/a	n/a	116	n/a	n/a	cross.bmp
+389.868	n/a	97467.0	show_face	famous_face	first_show	116	n/a	5	f087.bmp
+390.61709090910006	n/a	97654.2727	right_press	n/a	n/a	116	n/a	4096	n/a
+390.7870909091	n/a	97696.7727	show_circle	n/a	n/a	116	n/a	0	circle.bmp
+392.48709090910006	n/a	98121.7727	show_cross	n/a	n/a	117	n/a	n/a	cross.bmp
+393.0416363636	n/a	98260.4091	show_face	famous_face	immediate_repeat	117	1	6	f087.bmp
+393.63527272730005	n/a	98408.8182	right_press	n/a	n/a	117	n/a	4096	n/a
+394.0361818182	n/a	98509.0455	show_circle	n/a	n/a	117	n/a	0	circle.bmp
+395.7361818182	n/a	98934.0455	show_cross	n/a	n/a	118	n/a	n/a	cross.bmp
+396.3661818182	n/a	99091.5455	show_face	famous_face	first_show	118	n/a	5	f042.bmp
+396.9752727273	n/a	99243.8182	right_press	n/a	n/a	118	n/a	4096	n/a
+397.2743636364	n/a	99318.5909	show_circle	n/a	n/a	118	n/a	0	circle.bmp
+398.97436363639997	n/a	99743.5909	show_cross	n/a	n/a	119	n/a	n/a	cross.bmp
+399.6234545455	n/a	99905.8636	show_face	famous_face	immediate_repeat	119	1	6	f042.bmp
+400.34345454550004	n/a	100085.8636	right_press	n/a	n/a	119	n/a	4096	n/a
+400.5043636364	n/a	100126.0909	show_circle	n/a	n/a	119	n/a	0	circle.bmp
+402.2043636364	n/a	100551.0909	show_cross	n/a	n/a	120	n/a	n/a	cross.bmp
+402.69709090910004	n/a	100674.2727	show_face	famous_face	delayed_repeat	120	11	7	f043.bmp
+403.2698181818	n/a	100817.4545	right_press	n/a	n/a	120	n/a	4096	n/a
+403.59345454550004	n/a	100898.3636	show_circle	n/a	n/a	120	n/a	0	circle.bmp
+405.2934545455	n/a	101323.3636	show_cross	n/a	n/a	121	n/a	n/a	cross.bmp
+405.888	n/a	101472.0	show_face	scrambled_face	first_show	121	n/a	17	s012.bmp
+406.3734545455	n/a	101593.3636	right_press	n/a	n/a	121	n/a	4096	n/a
+406.81709090910005	n/a	101704.2727	show_circle	n/a	n/a	121	n/a	0	circle.bmp
+408.51709090910003	n/a	102129.2727	show_cross	n/a	n/a	122	n/a	n/a	cross.bmp
+409.0116363636	n/a	102252.9091	show_face	famous_face	delayed_repeat	122	11	7	f138.bmp
+409.55709090910005	n/a	102389.2727	right_press	n/a	n/a	122	n/a	4096	n/a
+409.9161818182	n/a	102479.0455	show_circle	n/a	n/a	122	n/a	0	circle.bmp
+411.6161818182	n/a	102904.0455	show_cross	n/a	n/a	123	n/a	n/a	cross.bmp
+412.1361818182	n/a	103034.0455	show_face	famous_face	first_show	123	n/a	5	f136.bmp
+412.63345454550006	n/a	103158.3636	right_press	n/a	n/a	123	n/a	4096	n/a
+413.0116363636	n/a	103252.9091	show_circle	n/a	n/a	123	n/a	0	circle.bmp
+414.7116363636	n/a	103677.9091	show_cross	n/a	n/a	124	n/a	n/a	cross.bmp
+415.25981818180003	n/a	103814.9545	show_face	famous_face	immediate_repeat	124	1	6	f136.bmp
+415.77890909089996	n/a	103944.7273	right_press	n/a	n/a	124	n/a	4096	n/a
+416.2543636364	n/a	104063.5909	show_circle	n/a	n/a	124	n/a	0	circle.bmp
+417.9543636364	n/a	104488.5909	show_cross	n/a	n/a	125	n/a	n/a	cross.bmp
+418.4670909091	n/a	104616.7727	show_face	scrambled_face	delayed_repeat	125	12	19	s085.bmp
+419.0689090909	n/a	104767.2273	right_press	n/a	n/a	125	n/a	4096	n/a
+419.3361818182	n/a	104834.0455	show_circle	n/a	n/a	125	n/a	0	circle.bmp
+420.39345454550005	n/a	105098.3636	right_press	n/a	n/a	125	n/a	4096	n/a
+421.0361818182	n/a	105259.0455	show_cross	n/a	n/a	126	n/a	n/a	cross.bmp
+421.55709090910005	n/a	105389.2727	show_face	scrambled_face	first_show	126	n/a	17	s044.bmp
+422.4343636364	n/a	105608.5909	right_press	n/a	n/a	126	n/a	4096	n/a
+422.5498181818	n/a	105637.4545	show_circle	n/a	n/a	126	n/a	0	circle.bmp
+424.2498181818	n/a	106062.4545	show_cross	n/a	n/a	127	n/a	n/a	cross.bmp
+424.88254545449996	n/a	106220.6364	show_face	unfamiliar_face	first_show	127	n/a	13	u109.bmp
+425.71072727269996	n/a	106427.6818	show_circle	n/a	n/a	127	n/a	0	circle.bmp
+427.41072727269994	n/a	106852.6818	show_cross	n/a	n/a	128	n/a	n/a	cross.bmp
+427.8889090909	n/a	106972.2273	show_face	unfamiliar_face	first_show	128	n/a	13	u050.bmp
+428.8216363636	n/a	107205.4091	show_circle	n/a	n/a	128	n/a	0	circle.bmp
+430.5216363636	n/a	107630.4091	show_cross	n/a	n/a	129	n/a	n/a	cross.bmp
+431.16345454550003	n/a	107790.8636	show_face	scrambled_face	first_show	129	n/a	17	s134.bmp
+431.9725454545	n/a	107993.1364	right_press	n/a	n/a	129	n/a	4096	n/a
+432.1143636364	n/a	108028.5909	show_circle	n/a	n/a	129	n/a	0	circle.bmp
+433.8143636364	n/a	108453.5909	show_cross	n/a	n/a	130	n/a	n/a	cross.bmp
+434.32072727269997	n/a	108580.1818	show_face	scrambled_face	immediate_repeat	130	1	18	s134.bmp
+435.0843636364	n/a	108771.0909	right_press	n/a	n/a	130	n/a	4096	n/a
+435.27072727269996	n/a	108817.6818	show_circle	n/a	n/a	130	n/a	0	circle.bmp
+436.97072727269995	n/a	109242.6818	show_cross	n/a	n/a	131	n/a	n/a	cross.bmp
+437.478	n/a	109369.5	show_face	scrambled_face	delayed_repeat	131	10	19	s012.bmp
+438.1998181818	n/a	109549.9545	right_press	n/a	n/a	131	n/a	4096	n/a
+438.4843636364	n/a	109621.0909	show_circle	n/a	n/a	131	n/a	0	circle.bmp
+440.1843636364	n/a	110046.0909	show_cross	n/a	n/a	132	n/a	n/a	cross.bmp
+440.718	n/a	110179.5	show_face	unfamiliar_face	first_show	132	n/a	13	u130.bmp
+441.6134545455	n/a	110403.3636	show_circle	n/a	n/a	132	n/a	0	circle.bmp
+443.3134545455	n/a	110828.3636	show_cross	n/a	n/a	133	n/a	n/a	cross.bmp
+443.84254545449994	n/a	110960.6364	show_face	unfamiliar_face	first_show	133	n/a	13	u079.bmp
+444.7816363636	n/a	111195.4091	show_circle	n/a	n/a	133	n/a	0	circle.bmp
+446.4816363636	n/a	111620.4091	show_cross	n/a	n/a	134	n/a	n/a	cross.bmp
+446.9825454545	n/a	111745.6364	show_face	scrambled_face	delayed_repeat	134	8	19	s044.bmp
+447.7343636364	n/a	111933.5909	right_press	n/a	n/a	134	n/a	4096	n/a
+447.8534545455	n/a	111963.3636	show_circle	n/a	n/a	134	n/a	0	circle.bmp
+449.5534545455	n/a	112388.3636	show_cross	n/a	n/a	135	n/a	n/a	cross.bmp
+450.1070909091	n/a	112526.7727	show_face	scrambled_face	first_show	135	n/a	17	s089.bmp
+450.63527272730005	n/a	112658.8182	right_press	n/a	n/a	135	n/a	4096	n/a
+451.0952727273	n/a	112773.8182	show_circle	n/a	n/a	135	n/a	0	circle.bmp
+452.7952727273	n/a	113198.8182	show_cross	n/a	n/a	136	n/a	n/a	cross.bmp
+453.3470909091	n/a	113336.7727	show_face	scrambled_face	immediate_repeat	136	1	18	s089.bmp
+453.9061818182	n/a	113476.5455	right_press	n/a	n/a	136	n/a	4096	n/a
+454.2916363636	n/a	113572.9091	show_circle	n/a	n/a	136	n/a	0	circle.bmp
+455.9916363636	n/a	113997.9091	show_cross	n/a	n/a	137	n/a	n/a	cross.bmp
+456.5043636364	n/a	114126.0909	show_face	unfamiliar_face	delayed_repeat	137	10	15	u109.bmp
+457.43709090910005	n/a	114359.2727	show_circle	n/a	n/a	137	n/a	0	circle.bmp
+459.13709090910004	n/a	114784.2727	show_cross	n/a	n/a	138	n/a	n/a	cross.bmp
+459.76254545449996	n/a	114940.6364	show_face	scrambled_face	first_show	138	n/a	17	s030.bmp
+460.7489090909	n/a	115187.2273	show_circle	n/a	n/a	138	n/a	0	circle.bmp
+462.4489090909	n/a	115612.2273	show_cross	n/a	n/a	139	n/a	n/a	cross.bmp
+462.9698181818	n/a	115742.4545	show_face	unfamiliar_face	delayed_repeat	139	11	15	u050.bmp
+463.90072727269995	n/a	115975.1818	show_circle	n/a	n/a	139	n/a	0	circle.bmp
+465.60072727269994	n/a	116400.1818	show_cross	n/a	n/a	140	n/a	n/a	cross.bmp
+466.1098181818	n/a	116527.4545	show_face	scrambled_face	first_show	140	n/a	17	s100.bmp
+466.71254545449995	n/a	116678.1364	right_press	n/a	n/a	140	n/a	4096	n/a
+467.0843636364	n/a	116771.0909	show_circle	n/a	n/a	140	n/a	0	circle.bmp
+468.7843636364	n/a	117196.0909	show_cross	n/a	n/a	141	n/a	n/a	cross.bmp
+469.3843636364	n/a	117346.0909	show_face	scrambled_face	immediate_repeat	141	1	18	s100.bmp
+469.9070909091	n/a	117476.7727	right_press	n/a	n/a	141	n/a	4096	n/a
+470.3043636364	n/a	117576.0909	show_circle	n/a	n/a	141	n/a	0	circle.bmp
+472.0043636364	n/a	118001.0909	show_cross	n/a	n/a	142	n/a	n/a	cross.bmp
+472.5916363636	n/a	118147.9091	show_face	famous_face	first_show	142	n/a	5	f109.bmp
+473.3416363636	n/a	118335.4091	right_press	n/a	n/a	142	n/a	4096	n/a
+473.5425454545	n/a	118385.6364	show_circle	n/a	n/a	142	n/a	0	circle.bmp
+475.2425454545	n/a	118810.6364	show_cross	n/a	n/a	143	n/a	n/a	cross.bmp
+475.88254545449996	n/a	118970.6364	show_face	famous_face	immediate_repeat	143	1	6	f109.bmp
+476.58345454550005	n/a	119145.8636	right_press	n/a	n/a	143	n/a	4096	n/a
+476.7307272727	n/a	119182.6818	show_circle	n/a	n/a	143	n/a	0	circle.bmp
+478.4307272727	n/a	119607.6818	show_cross	n/a	n/a	144	n/a	n/a	cross.bmp
+479.02345454550004	n/a	119755.8636	show_face	unfamiliar_face	delayed_repeat	144	12	15	u130.bmp
+479.9943636364	n/a	119998.5909	show_circle	n/a	n/a	144	n/a	0	circle.bmp
+481.6943636364	n/a	120423.5909	show_cross	n/a	n/a	145	n/a	n/a	cross.bmp
+482.33072727269996	n/a	120582.6818	show_face	famous_face	first_show	145	n/a	5	f095.bmp
+483.2116363636	n/a	120802.9091	show_circle	n/a	n/a	145	n/a	0	circle.bmp
+484.9116363636	n/a	121227.9091	show_cross	n/a	n/a	146	n/a	n/a	cross.bmp
+485.5552727273	n/a	121388.8182	show_face	unfamiliar_face	delayed_repeat	146	13	15	u079.bmp
+486.4461818182	n/a	121611.5455	show_circle	n/a	n/a	146	n/a	0	circle.bmp
+488.1461818182	n/a	122036.5455	show_cross	n/a	n/a	147	n/a	n/a	cross.bmp
+488.81254545449997	n/a	122203.1364	show_face	famous_face	first_show	147	n/a	5	f017.bmp
+489.52527272730003	n/a	122381.3182	right_press	n/a	n/a	147	n/a	4096	n/a
+489.678	n/a	122419.5	show_circle	n/a	n/a	147	n/a	0	circle.bmp
+491.378	n/a	122844.5	show_cross	n/a	n/a	148	n/a	n/a	cross.bmp
+492.0198181818	n/a	123004.9545	show_face	famous_face	immediate_repeat	148	1	6	f017.bmp
+492.56163636360003	n/a	123140.4091	right_press	n/a	n/a	148	n/a	4096	n/a
+492.9261818182	n/a	123231.5455	show_circle	n/a	n/a	148	n/a	0	circle.bmp
+494.6261818182	n/a	123656.5455	show_cross	n/a	n/a	149	n/a	n/a	cross.bmp

--- a/eeg_hed_small/sub-002/eeg/sub-002_task-FacePerception_run-6_events.tsv
+++ b/eeg_hed_small/sub-002/eeg/sub-002_task-FacePerception_run-6_events.tsv
@@ -1,577 +1,577 @@
-onset	duration	sample	event_type	face_type	repetition_type	trigger	stim_file
-0.0040000000	n/a	1	setup	n/a	n/a	n/a	n/a
-0.0040000000	n/a	1	right_sym	n/a	n/a	n/a	n/a
-23.9261818182	n/a	5981.5455	show_face	famous_face	first_show	5	f127.bmp
-24.6089090909	n/a	6152.2273	right_press	n/a	n/a	4096	n/a
-24.7707272727	n/a	6192.6818	show_circle	n/a	n/a	0	circle.bmp
-26.4707272727	n/a	6617.6818	show_cross	n/a	n/a	n/a	cross.bmp
-26.9161818182	n/a	6729.0455	show_face	famous_face	immediate_repeat	6	f127.bmp
-27.4561818182	n/a	6864.0455	right_press	n/a	n/a	4096	n/a
-27.9161818182	n/a	6979.0455	show_circle	n/a	n/a	0	circle.bmp
-29.6161818182	n/a	7404.0455	show_cross	n/a	n/a	n/a	cross.bmp
-30.1907272727	n/a	7547.6818	show_face	unfamiliar_face	first_show	13	u015.bmp
-31.1652727273	n/a	7791.3182	show_circle	n/a	n/a	0	circle.bmp
-32.8652727273	n/a	8216.3182	show_cross	n/a	n/a	n/a	cross.bmp
-33.4980000000	n/a	8374.5	show_face	unfamiliar_face	first_show	13	u072.bmp
-34.3689090909	n/a	8592.2273	show_circle	n/a	n/a	0	circle.bmp
-36.0689090909	n/a	9017.2273	show_cross	n/a	n/a	n/a	cross.bmp
-36.5716363636	n/a	9142.9091	show_face	unfamiliar_face	first_show	13	u052.bmp
-37.3698181818	n/a	9342.4545	right_press	n/a	n/a	4096	n/a
-37.5580000000	n/a	9389.5	show_circle	n/a	n/a	0	circle.bmp
-39.2580000000	n/a	9814.5	show_cross	n/a	n/a	n/a	cross.bmp
-39.8625454545	n/a	9965.6364	show_face	famous_face	first_show	5	f106.bmp
-40.4643636364	n/a	10116.0909	right_press	n/a	n/a	4096	n/a
-40.7834545455	n/a	10195.8636	show_circle	n/a	n/a	0	circle.bmp
-42.4834545455	n/a	10620.8636	show_cross	n/a	n/a	n/a	cross.bmp
-42.9361818182	n/a	10734.0455	show_face	famous_face	immediate_repeat	6	f106.bmp
-43.4470909091	n/a	10861.7727	right_press	n/a	n/a	4096	n/a
-43.9352727273	n/a	10983.8182	show_circle	n/a	n/a	0	circle.bmp
-45.6352727273	n/a	11408.8182	show_cross	n/a	n/a	n/a	cross.bmp
-46.0934545455	n/a	11523.3636	show_face	unfamiliar_face	first_show	13	u036.bmp
-47.0161818182	n/a	11754.0455	show_circle	n/a	n/a	0	circle.bmp
-48.7161818182	n/a	12179.0455	show_cross	n/a	n/a	n/a	cross.bmp
-49.2843636364	n/a	12321.0909	show_face	unfamiliar_face	first_show	13	u142.bmp
-50.2552727273	n/a	12563.8182	show_circle	n/a	n/a	0	circle.bmp
-51.9552727273	n/a	12988.8182	show_cross	n/a	n/a	n/a	cross.bmp
-52.5252727273	n/a	13131.3182	show_face	unfamiliar_face	immediate_repeat	14	u142.bmp
-53.4570909091	n/a	13364.2727	show_circle	n/a	n/a	0	circle.bmp
-55.1570909091	n/a	13789.2727	show_cross	n/a	n/a	n/a	cross.bmp
-55.7825454545	n/a	13945.6364	show_face	unfamiliar_face	delayed_repeat	15	u015.bmp
-56.7134545455	n/a	14178.3636	show_circle	n/a	n/a	0	circle.bmp
-58.4134545455	n/a	14603.3636	show_cross	n/a	n/a	n/a	cross.bmp
-59.0398181818	n/a	14759.9545	show_face	scrambled_face	first_show	17	s129.bmp
-59.9089090909	n/a	14977.2273	show_circle	n/a	n/a	0	circle.bmp
-61.6089090909	n/a	15402.2273	show_cross	n/a	n/a	n/a	cross.bmp
-62.2143636364	n/a	15553.5909	show_face	scrambled_face	immediate_repeat	18	s129.bmp
-63.1080000000	n/a	15777	show_circle	n/a	n/a	0	circle.bmp
-64.8080000000	n/a	16202	show_cross	n/a	n/a	n/a	cross.bmp
-65.3043636364	n/a	16326.0909	show_face	unfamiliar_face	delayed_repeat	15	u072.bmp
-66.2734545455	n/a	16568.3636	show_circle	n/a	n/a	0	circle.bmp
-67.9734545455	n/a	16993.3636	show_cross	n/a	n/a	n/a	cross.bmp
-68.5452727273	n/a	17136.3182	show_face	scrambled_face	first_show	17	s131.bmp
-69.3061818182	n/a	17326.5455	right_press	n/a	n/a	4096	n/a
-69.5252727273	n/a	17381.3182	show_circle	n/a	n/a	0	circle.bmp
-71.2252727273	n/a	17806.3182	show_cross	n/a	n/a	n/a	cross.bmp
-71.8198181818	n/a	17954.9545	show_face	unfamiliar_face	delayed_repeat	15	u052.bmp
-72.7280000000	n/a	18182	show_circle	n/a	n/a	0	circle.bmp
-74.4280000000	n/a	18607	show_cross	n/a	n/a	n/a	cross.bmp
-74.9598181818	n/a	18739.9545	show_face	scrambled_face	first_show	17	s101.bmp
-75.7025454545	n/a	18925.6364	right_press	n/a	n/a	4096	n/a
-75.9307272727	n/a	18982.6818	show_circle	n/a	n/a	0	circle.bmp
-77.6307272727	n/a	19407.6818	show_cross	n/a	n/a	n/a	cross.bmp
-78.1843636364	n/a	19546.0909	show_face	unfamiliar_face	first_show	13	u040.bmp
-79.0098181818	n/a	19752.4545	show_circle	n/a	n/a	0	circle.bmp
-80.7098181818	n/a	20177.4545	show_cross	n/a	n/a	n/a	cross.bmp
-81.2580000000	n/a	20314.5	show_face	unfamiliar_face	immediate_repeat	14	u040.bmp
-82.1825454545	n/a	20545.6364	show_circle	n/a	n/a	0	circle.bmp
-83.8825454545	n/a	20970.6364	show_cross	n/a	n/a	n/a	cross.bmp
-84.5325454545	n/a	21133.1364	show_face	unfamiliar_face	delayed_repeat	15	u036.bmp
-85.4861818182	n/a	21371.5455	show_circle	n/a	n/a	0	circle.bmp
-87.1861818182	n/a	21796.5455	show_cross	n/a	n/a	n/a	cross.bmp
-87.7061818182	n/a	21926.5455	show_face	famous_face	first_show	5	f080.bmp
-88.2916363636	n/a	22072.9091	right_press	n/a	n/a	4096	n/a
-88.5616363636	n/a	22140.4091	show_circle	n/a	n/a	0	circle.bmp
-90.2616363636	n/a	22565.4091	show_cross	n/a	n/a	n/a	cross.bmp
-90.7298181818	n/a	22682.4545	show_face	famous_face	first_show	5	f134.bmp
-91.6634545455	n/a	22915.8636	show_circle	n/a	n/a	0	circle.bmp
-93.3634545455	n/a	23340.8636	show_cross	n/a	n/a	n/a	cross.bmp
-93.8534545455	n/a	23463.3636	show_face	famous_face	first_show	5	f046.bmp
-94.6689090909	n/a	23667.2273	left_press	n/a	n/a	256	n/a
-94.8107272727	n/a	23702.6818	show_circle	n/a	n/a	0	circle.bmp
-96.5107272727	n/a	24127.6818	show_cross	n/a	n/a	n/a	cross.bmp
-97.0280000000	n/a	24257	show_face	famous_face	immediate_repeat	6	f046.bmp
-97.5689090909	n/a	24392.2273	left_press	n/a	n/a	256	n/a
-97.8661818182	n/a	24466.5455	show_circle	n/a	n/a	0	circle.bmp
-99.5661818182	n/a	24891.5455	show_cross	n/a	n/a	n/a	cross.bmp
-100.1680000000	n/a	25042	show_face	scrambled_face	delayed_repeat	19	s131.bmp
-100.9334545455	n/a	25233.3636	right_press	n/a	n/a	4096	n/a
-101.1180000000	n/a	25279.5	show_circle	n/a	n/a	0	circle.bmp
-102.8180000000	n/a	25704.5	show_cross	n/a	n/a	n/a	cross.bmp
-103.3089090909	n/a	25827.2273	show_face	unfamiliar_face	first_show	13	u059.bmp
-104.2252727273	n/a	26056.3182	show_circle	n/a	n/a	0	circle.bmp
-104.3416363636	n/a	26085.4091	right_press	n/a	n/a	4096	n/a
-105.9252727273	n/a	26481.3182	show_cross	n/a	n/a	n/a	cross.bmp
-106.4170909091	n/a	26604.2727	show_face	scrambled_face	delayed_repeat	19	s101.bmp
-106.9089090909	n/a	26727.2273	right_press	n/a	n/a	4096	n/a
-107.2661818182	n/a	26816.5455	show_circle	n/a	n/a	0	circle.bmp
-108.9661818182	n/a	27241.5455	show_cross	n/a	n/a	n/a	cross.bmp
-109.5561818182	n/a	27389.0455	show_face	unfamiliar_face	first_show	13	u055.bmp
-110.2243636364	n/a	27556.0909	left_press	n/a	n/a	256	n/a
-110.5189090909	n/a	27629.7273	show_circle	n/a	n/a	0	circle.bmp
-112.2189090909	n/a	28054.7273	show_cross	n/a	n/a	n/a	cross.bmp
-112.8307272727	n/a	28207.6818	show_face	unfamiliar_face	first_show	13	u006.bmp
-113.5489090909	n/a	28387.2273	left_press	n/a	n/a	256	n/a
-113.7989090909	n/a	28449.7273	show_circle	n/a	n/a	0	circle.bmp
-115.4989090909	n/a	28874.7273	show_cross	n/a	n/a	n/a	cross.bmp
-116.1380000000	n/a	29034.5	show_face	famous_face	delayed_repeat	7	f080.bmp
-116.8134545455	n/a	29203.3636	right_press	n/a	n/a	4096	n/a
-116.9698181818	n/a	29242.4545	show_circle	n/a	n/a	0	circle.bmp
-118.6698181818	n/a	29667.4545	show_cross	n/a	n/a	n/a	cross.bmp
-119.2789090909	n/a	29819.7273	show_face	unfamiliar_face	first_show	13	u076.bmp
-120.2034545455	n/a	30050.8636	right_press	n/a	n/a	4096	n/a
-120.2252727273	n/a	30056.3182	show_circle	n/a	n/a	0	circle.bmp
-121.9252727273	n/a	30481.3182	show_cross	n/a	n/a	n/a	cross.bmp
-122.5698181818	n/a	30642.4545	show_face	famous_face	delayed_repeat	7	f134.bmp
-123.3916363636	n/a	30847.9091	show_circle	n/a	n/a	0	circle.bmp
-123.6052727273	n/a	30901.3182	left_press	n/a	n/a	256	n/a
-125.0916363636	n/a	31272.9091	show_cross	n/a	n/a	n/a	cross.bmp
-125.5934545455	n/a	31398.3636	show_face	unfamiliar_face	first_show	13	u062.bmp
-126.2270909091	n/a	31556.7727	right_press	n/a	n/a	4096	n/a
-126.5634545455	n/a	31640.8636	show_circle	n/a	n/a	0	circle.bmp
-128.2634545455	n/a	32065.8636	show_cross	n/a	n/a	n/a	cross.bmp
-128.7670909091	n/a	32191.7727	show_face	unfamiliar_face	immediate_repeat	14	u062.bmp
-129.4261818182	n/a	32356.5455	left_press	n/a	n/a	256	n/a
-129.7516363636	n/a	32437.9091	show_circle	n/a	n/a	0	circle.bmp
-131.4516363636	n/a	32862.9091	show_cross	n/a	n/a	n/a	cross.bmp
-132.0416363636	n/a	33010.4091	show_face	unfamiliar_face	first_show	13	u030.bmp
-132.6770909091	n/a	33169.2727	left_press	n/a	n/a	256	n/a
-132.9189090909	n/a	33229.7273	show_circle	n/a	n/a	0	circle.bmp
-134.6189090909	n/a	33654.7273	show_cross	n/a	n/a	n/a	cross.bmp
-135.1825454545	n/a	33795.6364	show_face	unfamiliar_face	immediate_repeat	14	u030.bmp
-135.6680000000	n/a	33917	left_press	n/a	n/a	256	n/a
-136.0298181818	n/a	34007.4545	show_circle	n/a	n/a	0	circle.bmp
-137.7298181818	n/a	34432.4545	show_cross	n/a	n/a	n/a	cross.bmp
-138.2898181818	n/a	34572.4545	show_face	unfamiliar_face	delayed_repeat	15	u059.bmp
-138.7789090909	n/a	34694.7273	left_press	n/a	n/a	256	n/a
-139.1443636364	n/a	34786.0909	show_circle	n/a	n/a	0	circle.bmp
-140.8443636364	n/a	35211.0909	show_cross	n/a	n/a	n/a	cross.bmp
-141.3134545455	n/a	35328.3636	show_face	famous_face	first_show	5	f014.bmp
-142.3016363636	n/a	35575.4091	show_circle	n/a	n/a	0	circle.bmp
-142.5407272727	n/a	35635.1818	left_press	n/a	n/a	256	n/a
-144.0016363636	n/a	36000.4091	show_cross	n/a	n/a	n/a	cross.bmp
-144.5370909091	n/a	36134.2727	show_face	famous_face	immediate_repeat	6	f014.bmp
-145.0961818182	n/a	36274.0455	left_press	n/a	n/a	256	n/a
-145.5043636364	n/a	36376.0909	show_circle	n/a	n/a	0	circle.bmp
-147.2043636364	n/a	36801.0909	show_cross	n/a	n/a	n/a	cross.bmp
-147.8443636364	n/a	36961.0909	show_face	unfamiliar_face	delayed_repeat	15	u055.bmp
-148.6852727273	n/a	37171.3182	left_press	n/a	n/a	256	n/a
-148.8207272727	n/a	37205.1818	show_circle	n/a	n/a	0	circle.bmp
-150.5207272727	n/a	37630.1818	show_cross	n/a	n/a	n/a	cross.bmp
-151.0689090909	n/a	37767.2273	show_face	scrambled_face	first_show	17	s038.bmp
-151.8843636364	n/a	37971.0909	left_press	n/a	n/a	256	n/a
-151.9098181818	n/a	37977.4545	show_circle	n/a	n/a	0	circle.bmp
-153.6098181818	n/a	38402.4545	show_cross	n/a	n/a	n/a	cross.bmp
-154.2425454545	n/a	38560.6364	show_face	scrambled_face	immediate_repeat	18	s038.bmp
-154.7707272727	n/a	38692.6818	left_press	n/a	n/a	256	n/a
-155.1561818182	n/a	38789.0455	show_circle	n/a	n/a	0	circle.bmp
-156.8561818182	n/a	39214.0455	show_cross	n/a	n/a	n/a	cross.bmp
-157.4334545455	n/a	39358.3636	show_face	unfamiliar_face	delayed_repeat	15	u006.bmp
-158.2798181818	n/a	39569.9545	left_press	n/a	n/a	256	n/a
-158.3080000000	n/a	39577	show_circle	n/a	n/a	0	circle.bmp
-160.0080000000	n/a	40002	show_cross	n/a	n/a	n/a	cross.bmp
-160.5907272727	n/a	40147.6818	show_face	unfamiliar_face	first_show	13	u025.bmp
-161.5361818182	n/a	40384.0455	right_press	n/a	n/a	4096	n/a
-161.6034545455	n/a	40400.8636	show_circle	n/a	n/a	0	circle.bmp
-163.3034545455	n/a	40825.8636	show_cross	n/a	n/a	n/a	cross.bmp
-163.9489090909	n/a	40987.2273	show_face	unfamiliar_face	immediate_repeat	14	u025.bmp
-164.5298181818	n/a	41132.4545	right_press	n/a	n/a	4096	n/a
-164.9389090909	n/a	41234.7273	show_circle	n/a	n/a	0	circle.bmp
-166.6389090909	n/a	41659.7273	show_cross	n/a	n/a	n/a	cross.bmp
-167.1725454545	n/a	41793.1364	show_face	unfamiliar_face	delayed_repeat	15	u076.bmp
-168.1052727273	n/a	42026.3182	show_circle	n/a	n/a	0	circle.bmp
-168.2916363636	n/a	42072.9091	left_press	n/a	n/a	256	n/a
-169.8052727273	n/a	42451.3182	show_cross	n/a	n/a	n/a	cross.bmp
-170.4134545455	n/a	42603.3636	show_face	scrambled_face	first_show	17	s135.bmp
-171.4016363636	n/a	42850.4091	right_press	n/a	n/a	4096	n/a
-171.4316363636	n/a	42857.9091	show_circle	n/a	n/a	0	circle.bmp
-173.1316363636	n/a	43282.9091	show_cross	n/a	n/a	n/a	cross.bmp
-173.6543636364	n/a	43413.5909	show_face	scrambled_face	first_show	17	s107.bmp
-174.1170909091	n/a	43529.2727	right_press	n/a	n/a	4096	n/a
-174.5234545455	n/a	43630.8636	show_circle	n/a	n/a	0	circle.bmp
-176.2234545455	n/a	44055.8636	show_cross	n/a	n/a	n/a	cross.bmp
-176.7443636364	n/a	44186.0909	show_face	scrambled_face	immediate_repeat	18	s107.bmp
-177.2243636364	n/a	44306.0909	left_press	n/a	n/a	256	n/a
-177.5998181818	n/a	44399.9545	show_circle	n/a	n/a	0	circle.bmp
-179.2998181818	n/a	44824.9545	show_cross	n/a	n/a	n/a	cross.bmp
-179.8352727273	n/a	44958.8182	show_face	scrambled_face	first_show	17	s022.bmp
-180.6452727273	n/a	45161.3182	right_press	n/a	n/a	4096	n/a
-180.8434545455	n/a	45210.8636	show_circle	n/a	n/a	0	circle.bmp
-182.5434545455	n/a	45635.8636	show_cross	n/a	n/a	n/a	cross.bmp
-183.1261818182	n/a	45781.5455	show_face	scrambled_face	immediate_repeat	18	s022.bmp
-184.0752727273	n/a	46018.8182	show_circle	n/a	n/a	0	circle.bmp
-184.2934545455	n/a	46073.3636	right_press	n/a	n/a	4096	n/a
-185.7752727273	n/a	46443.8182	show_cross	n/a	n/a	n/a	cross.bmp
-186.2998181818	n/a	46574.9545	show_face	scrambled_face	first_show	17	s041.bmp
-187.1807272727	n/a	46795.1818	right_press	n/a	n/a	4096	n/a
-187.2125454545	n/a	46803.1364	show_circle	n/a	n/a	0	circle.bmp
-188.9125454545	n/a	47228.1364	show_cross	n/a	n/a	n/a	cross.bmp
-189.4570909091	n/a	47364.2727	show_face	scrambled_face	immediate_repeat	18	s041.bmp
-190.1861818182	n/a	47546.5455	right_press	n/a	n/a	4096	n/a
-190.3970909091	n/a	47599.2727	show_circle	n/a	n/a	0	circle.bmp
-192.0970909091	n/a	48024.2727	show_cross	n/a	n/a	n/a	cross.bmp
-192.6816363636	n/a	48170.4091	show_face	scrambled_face	first_show	17	s104.bmp
-193.5070909091	n/a	48376.7727	show_circle	n/a	n/a	0	circle.bmp
-195.2070909091	n/a	48801.7727	show_cross	n/a	n/a	n/a	cross.bmp
-195.7216363636	n/a	48930.4091	show_face	unfamiliar_face	first_show	13	u033.bmp
-196.5152727273	n/a	49128.8182	right_press	n/a	n/a	4096	n/a
-196.7289090909	n/a	49182.2273	show_circle	n/a	n/a	0	circle.bmp
-198.4289090909	n/a	49607.2273	show_cross	n/a	n/a	n/a	cross.bmp
-198.9789090909	n/a	49744.7273	show_face	scrambled_face	delayed_repeat	19	s135.bmp
-199.6016363636	n/a	49900.4091	right_press	n/a	n/a	4096	n/a
-199.8498181818	n/a	49962.4545	show_circle	n/a	n/a	0	circle.bmp
-201.5498181818	n/a	50387.4545	show_cross	n/a	n/a	n/a	cross.bmp
-202.0370909091	n/a	50509.2727	show_face	famous_face	first_show	5	f086.bmp
-202.6734545455	n/a	50668.3636	left_press	n/a	n/a	256	n/a
-202.8716363636	n/a	50717.9091	show_circle	n/a	n/a	0	circle.bmp
-204.5716363636	n/a	51142.9091	show_cross	n/a	n/a	n/a	cross.bmp
-205.1098181818	n/a	51277.4545	show_face	famous_face	immediate_repeat	6	f086.bmp
-205.6252727273	n/a	51406.3182	left_press	n/a	n/a	256	n/a
-205.9470909091	n/a	51486.7727	show_circle	n/a	n/a	0	circle.bmp
-207.6470909091	n/a	51911.7727	show_cross	n/a	n/a	n/a	cross.bmp
-208.1016363636	n/a	52025.4091	show_face	unfamiliar_face	first_show	13	u065.bmp
-208.9161818182	n/a	52229.0455	right_press	n/a	n/a	4096	n/a
-209.0243636364	n/a	52256.0909	show_circle	n/a	n/a	0	circle.bmp
-210.7243636364	n/a	52681.0909	show_cross	n/a	n/a	n/a	cross.bmp
-211.1907272727	n/a	52797.6818	show_face	scrambled_face	first_show	17	s072.bmp
-211.8734545455	n/a	52968.3636	right_press	n/a	n/a	4096	n/a
-212.1416363636	n/a	53035.4091	show_circle	n/a	n/a	0	circle.bmp
-213.8416363636	n/a	53460.4091	show_cross	n/a	n/a	n/a	cross.bmp
-214.3480000000	n/a	53587	show_face	famous_face	first_show	5	f035.bmp
-215.0834545455	n/a	53770.8636	left_press	n/a	n/a	256	n/a
-215.2680000000	n/a	53817	show_circle	n/a	n/a	0	circle.bmp
-216.9680000000	n/a	54242	show_cross	n/a	n/a	n/a	cross.bmp
-217.5725454545	n/a	54393.1364	show_face	famous_face	immediate_repeat	6	f035.bmp
-218.4152727273	n/a	54603.8182	show_circle	n/a	n/a	0	circle.bmp
-218.4270909091	n/a	54606.7727	right_press	n/a	n/a	4096	n/a
-220.1152727273	n/a	55028.8182	show_cross	n/a	n/a	n/a	cross.bmp
-220.6961818182	n/a	55174.0455	show_face	scrambled_face	delayed_repeat	19	s104.bmp
-221.6925454545	n/a	55423.1364	show_circle	n/a	n/a	0	circle.bmp
-221.7670909091	n/a	55441.7727	left_press	n/a	n/a	256	n/a
-223.3925454545	n/a	55848.1364	show_cross	n/a	n/a	n/a	cross.bmp
-223.8698181818	n/a	55967.4545	show_face	scrambled_face	first_show	17	s014.bmp
-224.6098181818	n/a	56152.4545	right_press	n/a	n/a	4096	n/a
-224.7516363636	n/a	56187.9091	show_circle	n/a	n/a	0	circle.bmp
-226.4516363636	n/a	56612.9091	show_cross	n/a	n/a	n/a	cross.bmp
-227.0443636364	n/a	56761.0909	show_face	unfamiliar_face	delayed_repeat	15	u033.bmp
-227.8543636364	n/a	56963.5909	right_press	n/a	n/a	4096	n/a
-227.9389090909	n/a	56984.7273	show_circle	n/a	n/a	0	circle.bmp
-229.6389090909	n/a	57409.7273	show_cross	n/a	n/a	n/a	cross.bmp
-230.1007272727	n/a	57525.1818	show_face	famous_face	first_show	5	f126.bmp
-230.6752727273	n/a	57668.8182	right_press	n/a	n/a	4096	n/a
-231.0025454545	n/a	57750.6364	show_circle	n/a	n/a	0	circle.bmp
-232.7025454545	n/a	58175.6364	show_cross	n/a	n/a	n/a	cross.bmp
-233.2416363636	n/a	58310.4091	show_face	famous_face	immediate_repeat	6	f126.bmp
-233.8825454545	n/a	58470.6364	right_press	n/a	n/a	4096	n/a
-234.2425454545	n/a	58560.6364	show_circle	n/a	n/a	0	circle.bmp
-235.9425454545	n/a	58985.6364	show_cross	n/a	n/a	n/a	cross.bmp
-236.5325454545	n/a	59133.1364	show_face	scrambled_face	first_show	17	s126.bmp
-237.3643636364	n/a	59341.0909	show_circle	n/a	n/a	0	circle.bmp
-239.0643636364	n/a	59766.0909	show_cross	n/a	n/a	n/a	cross.bmp
-239.5725454545	n/a	59893.1364	show_face	scrambled_face	immediate_repeat	18	s126.bmp
-240.5325454545	n/a	60133.1364	show_circle	n/a	n/a	0	circle.bmp
-240.5870909091	n/a	60146.7727	right_press	n/a	n/a	4096	n/a
-242.2325454545	n/a	60558.1364	show_cross	n/a	n/a	n/a	cross.bmp
-242.7807272727	n/a	60695.1818	show_face	unfamiliar_face	delayed_repeat	15	u065.bmp
-243.4216363636	n/a	60855.4091	left_press	n/a	n/a	256	n/a
-243.6234545455	n/a	60905.8636	show_circle	n/a	n/a	0	circle.bmp
-245.3234545455	n/a	61330.8636	show_cross	n/a	n/a	n/a	cross.bmp
-245.9707272727	n/a	61492.6818	show_face	scrambled_face	first_show	17	s062.bmp
-246.6216363636	n/a	61655.4091	right_press	n/a	n/a	4096	n/a
-246.8370909091	n/a	61709.2727	show_circle	n/a	n/a	0	circle.bmp
-248.5370909091	n/a	62134.2727	show_cross	n/a	n/a	n/a	cross.bmp
-249.0116363636	n/a	62252.9091	show_face	scrambled_face	immediate_repeat	18	s062.bmp
-249.6443636364	n/a	62411.0909	right_press	n/a	n/a	4096	n/a
-249.9025454545	n/a	62475.6364	show_circle	n/a	n/a	0	circle.bmp
-251.6025454545	n/a	62900.6364	show_cross	n/a	n/a	n/a	cross.bmp
-252.2016363636	n/a	63050.4091	show_face	scrambled_face	delayed_repeat	19	s072.bmp
-253.1561818182	n/a	63289.0455	show_circle	n/a	n/a	0	circle.bmp
-253.1661818182	n/a	63291.5455	right_press	n/a	n/a	4096	n/a
-254.8561818182	n/a	63714.0455	show_cross	n/a	n/a	n/a	cross.bmp
-255.4934545455	n/a	63873.3636	show_face	famous_face	first_show	5	f051.bmp
-256.3416363636	n/a	64085.4091	right_press	n/a	n/a	4096	n/a
-256.3961818182	n/a	64099.0455	show_circle	n/a	n/a	0	circle.bmp
-258.0961818182	n/a	64524.0455	show_cross	n/a	n/a	n/a	cross.bmp
-258.7007272727	n/a	64675.1818	show_face	famous_face	immediate_repeat	6	f051.bmp
-259.5270909091	n/a	64881.7727	right_press	n/a	n/a	4096	n/a
-259.6116363636	n/a	64902.9091	show_circle	n/a	n/a	0	circle.bmp
-261.3116363636	n/a	65327.9091	show_cross	n/a	n/a	n/a	cross.bmp
-261.9243636364	n/a	65481.0909	show_face	scrambled_face	first_show	17	s127.bmp
-262.8307272727	n/a	65707.6818	show_circle	n/a	n/a	0	circle.bmp
-262.9580000000	n/a	65739.5	left_press	n/a	n/a	256	n/a
-264.5307272727	n/a	66132.6818	show_cross	n/a	n/a	n/a	cross.bmp
-265.1489090909	n/a	66287.2273	show_face	scrambled_face	delayed_repeat	19	s014.bmp
-265.9352727273	n/a	66483.8182	right_press	n/a	n/a	4096	n/a
-266.0216363636	n/a	66505.4091	show_circle	n/a	n/a	0	circle.bmp
-267.7216363636	n/a	66930.4091	show_cross	n/a	n/a	n/a	cross.bmp
-268.3061818182	n/a	67076.5455	show_face	scrambled_face	first_show	17	s058.bmp
-269.0143636364	n/a	67253.5909	right_press	n/a	n/a	4096	n/a
-269.2389090909	n/a	67309.7273	show_circle	n/a	n/a	0	circle.bmp
-270.9389090909	n/a	67734.7273	show_cross	n/a	n/a	n/a	cross.bmp
-271.5470909091	n/a	67886.7727	show_face	famous_face	first_show	5	f149.bmp
-272.2161818182	n/a	68054.0455	right_press	n/a	n/a	4096	n/a
-272.4198181818	n/a	68104.9545	show_circle	n/a	n/a	0	circle.bmp
-274.1198181818	n/a	68529.9545	show_cross	n/a	n/a	n/a	cross.bmp
-274.5870909091	n/a	68646.7727	show_face	famous_face	immediate_repeat	6	f149.bmp
-275.0780000000	n/a	68769.5	right_press	n/a	n/a	4096	n/a
-275.5270909091	n/a	68881.7727	show_circle	n/a	n/a	0	circle.bmp
-277.2270909091	n/a	69306.7727	show_cross	n/a	n/a	n/a	cross.bmp
-277.7943636364	n/a	69448.5909	show_face	famous_face	first_show	5	f030.bmp
-278.4707272727	n/a	69617.6818	right_press	n/a	n/a	4096	n/a
-278.6598181818	n/a	69664.9545	show_circle	n/a	n/a	0	circle.bmp
-280.3598181818	n/a	70089.9545	show_cross	n/a	n/a	n/a	cross.bmp
-280.9516363636	n/a	70237.9091	show_face	famous_face	immediate_repeat	6	f030.bmp
-281.6889090909	n/a	70422.2273	right_press	n/a	n/a	4096	n/a
-281.8098181818	n/a	70452.4545	show_circle	n/a	n/a	0	circle.bmp
-283.5098181818	n/a	70877.4545	show_cross	n/a	n/a	n/a	cross.bmp
-284.1252727273	n/a	71031.3182	show_face	famous_face	first_show	5	f102.bmp
-284.9161818182	n/a	71229.0455	right_press	n/a	n/a	4096	n/a
-285.1380000000	n/a	71284.5	show_circle	n/a	n/a	0	circle.bmp
-286.8380000000	n/a	71709.5	show_cross	n/a	n/a	n/a	cross.bmp
-287.4834545455	n/a	71870.8636	show_face	famous_face	immediate_repeat	6	f102.bmp
-288.1661818182	n/a	72041.5455	right_press	n/a	n/a	4096	n/a
-288.4389090909	n/a	72109.7273	show_circle	n/a	n/a	0	circle.bmp
-290.1389090909	n/a	72534.7273	show_cross	n/a	n/a	n/a	cross.bmp
-290.6234545455	n/a	72655.8636	show_face	unfamiliar_face	first_show	13	u135.bmp
-291.3061818182	n/a	72826.5455	left_press	n/a	n/a	256	n/a
-291.6180000000	n/a	72904.5	show_circle	n/a	n/a	0	circle.bmp
-293.3180000000	n/a	73329.5	show_cross	n/a	n/a	n/a	cross.bmp
-293.7807272727	n/a	73445.1818	show_face	scrambled_face	delayed_repeat	19	s127.bmp
-294.6289090909	n/a	73657.2273	right_press	n/a	n/a	4096	n/a
-294.6416363636	n/a	73660.4091	show_circle	n/a	n/a	0	circle.bmp
-296.3416363636	n/a	74085.4091	show_cross	n/a	n/a	n/a	cross.bmp
-296.9552727273	n/a	74238.8182	show_face	scrambled_face	first_show	17	s019.bmp
-297.4952727273	n/a	74373.8182	right_press	n/a	n/a	4096	n/a
-297.8725454545	n/a	74468.1364	show_circle	n/a	n/a	0	circle.bmp
-299.5725454545	n/a	74893.1364	show_cross	n/a	n/a	n/a	cross.bmp
-300.1961818182	n/a	75049.0455	show_face	scrambled_face	immediate_repeat	18	s019.bmp
-300.6707272727	n/a	75167.6818	right_press	n/a	n/a	4096	n/a
-301.1480000000	n/a	75287	show_circle	n/a	n/a	0	circle.bmp
-302.8480000000	n/a	75712	show_cross	n/a	n/a	n/a	cross.bmp
-303.3361818182	n/a	75834.0455	show_face	scrambled_face	delayed_repeat	19	s058.bmp
-303.8152727273	n/a	75953.8182	right_press	n/a	n/a	4096	n/a
-304.3270909091	n/a	76081.7727	show_circle	n/a	n/a	0	circle.bmp
-306.0270909091	n/a	76506.7727	show_cross	n/a	n/a	n/a	cross.bmp
-306.5770909091	n/a	76644.2727	show_face	scrambled_face	first_show	17	s105.bmp
-307.3125454545	n/a	76828.1364	right_press	n/a	n/a	4096	n/a
-307.5934545455	n/a	76898.3636	show_circle	n/a	n/a	0	circle.bmp
-309.2934545455	n/a	77323.3636	show_cross	n/a	n/a	n/a	cross.bmp
-309.7516363636	n/a	77437.9091	show_face	scrambled_face	first_show	17	s079.bmp
-310.4734545455	n/a	77618.3636	right_press	n/a	n/a	4096	n/a
-310.7225454545	n/a	77680.6364	show_circle	n/a	n/a	0	circle.bmp
-312.4225454545	n/a	78105.6364	show_cross	n/a	n/a	n/a	cross.bmp
-313.0425454545	n/a	78260.6364	show_face	famous_face	first_show	5	f117.bmp
-313.7525454545	n/a	78438.1364	left_press	n/a	n/a	256	n/a
-314.0007272727	n/a	78500.1818	show_circle	n/a	n/a	0	circle.bmp
-315.7007272727	n/a	78925.1818	show_cross	n/a	n/a	n/a	cross.bmp
-316.2007272727	n/a	79050.1818	show_face	unfamiliar_face	first_show	13	u150.bmp
-317.1880000000	n/a	79297	show_circle	n/a	n/a	0	circle.bmp
-318.8880000000	n/a	79722	show_cross	n/a	n/a	n/a	cross.bmp
-319.4407272727	n/a	79860.1818	show_face	unfamiliar_face	delayed_repeat	15	u135.bmp
-320.0952727273	n/a	80023.8182	left_press	n/a	n/a	256	n/a
-320.3180000000	n/a	80079.5	show_circle	n/a	n/a	0	circle.bmp
-322.0180000000	n/a	80504.5	show_cross	n/a	n/a	n/a	cross.bmp
-322.5470909091	n/a	80636.7727	show_face	scrambled_face	first_show	17	s132.bmp
-323.3180000000	n/a	80829.5	right_press	n/a	n/a	4096	n/a
-323.3734545455	n/a	80843.3636	show_circle	n/a	n/a	0	circle.bmp
-325.0734545455	n/a	81268.3636	show_cross	n/a	n/a	n/a	cross.bmp
-325.5380000000	n/a	81384.5	show_face	famous_face	first_show	5	f008.bmp
-326.1543636364	n/a	81538.5909	right_press	n/a	n/a	4096	n/a
-326.3752727273	n/a	81593.8182	show_circle	n/a	n/a	0	circle.bmp
-328.0752727273	n/a	82018.8182	show_cross	n/a	n/a	n/a	cross.bmp
-328.6952727273	n/a	82173.8182	show_face	famous_face	immediate_repeat	6	f008.bmp
-329.2752727273	n/a	82318.8182	right_press	n/a	n/a	4096	n/a
-329.7061818182	n/a	82426.5455	show_circle	n/a	n/a	0	circle.bmp
-331.4061818182	n/a	82851.5455	show_cross	n/a	n/a	n/a	cross.bmp
-331.8689090909	n/a	82967.2273	show_face	scrambled_face	delayed_repeat	19	s105.bmp
-332.6161818182	n/a	83154.0455	right_press	n/a	n/a	4096	n/a
-332.7343636364	n/a	83183.5909	show_circle	n/a	n/a	0	circle.bmp
-334.4343636364	n/a	83608.5909	show_cross	n/a	n/a	n/a	cross.bmp
-335.0934545455	n/a	83773.3636	show_face	scrambled_face	first_show	17	s048.bmp
-335.9143636364	n/a	83978.5909	left_press	n/a	n/a	256	n/a
-336.0080000000	n/a	84002	show_circle	n/a	n/a	0	circle.bmp
-337.7080000000	n/a	84427	show_cross	n/a	n/a	n/a	cross.bmp
-338.3507272727	n/a	84587.6818	show_face	scrambled_face	immediate_repeat	18	s048.bmp
-338.9916363636	n/a	84747.9091	right_press	n/a	n/a	4096	n/a
-339.1770909091	n/a	84794.2727	show_circle	n/a	n/a	0	circle.bmp
-340.8770909091	n/a	85219.2727	show_cross	n/a	n/a	n/a	cross.bmp
-341.4080000000	n/a	85352	show_face	scrambled_face	delayed_repeat	19	s079.bmp
-342.0334545455	n/a	85508.3636	right_press	n/a	n/a	4096	n/a
-342.3289090909	n/a	85582.2273	show_circle	n/a	n/a	0	circle.bmp
-344.0289090909	n/a	86007.2273	show_cross	n/a	n/a	n/a	cross.bmp
-344.5480000000	n/a	86137	show_face	famous_face	first_show	5	f019.bmp
-345.1680000000	n/a	86292	right_press	n/a	n/a	4096	n/a
-345.5461818182	n/a	86386.5455	show_circle	n/a	n/a	0	circle.bmp
-347.2461818182	n/a	86811.5455	show_cross	n/a	n/a	n/a	cross.bmp
-347.7225454545	n/a	86930.6364	show_face	famous_face	delayed_repeat	7	f117.bmp
-348.3716363636	n/a	87092.9091	left_press	n/a	n/a	256	n/a
-348.6334545455	n/a	87158.3636	show_circle	n/a	n/a	0	circle.bmp
-350.3334545455	n/a	87583.3636	show_cross	n/a	n/a	n/a	cross.bmp
-350.8289090909	n/a	87707.2273	show_face	famous_face	first_show	5	f005.bmp
-351.4534545455	n/a	87863.3636	left_press	n/a	n/a	256	n/a
-351.8080000000	n/a	87952	show_circle	n/a	n/a	0	circle.bmp
-353.5080000000	n/a	88377	show_cross	n/a	n/a	n/a	cross.bmp
-354.0370909091	n/a	88509.2727	show_face	famous_face	immediate_repeat	6	f005.bmp
-354.6925454545	n/a	88673.1364	right_press	n/a	n/a	4096	n/a
-354.9043636364	n/a	88726.0909	show_circle	n/a	n/a	0	circle.bmp
-356.6043636364	n/a	89151.0909	show_cross	n/a	n/a	n/a	cross.bmp
-357.2270909091	n/a	89306.7727	show_face	unfamiliar_face	delayed_repeat	15	u150.bmp
-358.0798181818	n/a	89519.9545	show_circle	n/a	n/a	0	circle.bmp
-358.1198181818	n/a	89529.9545	left_press	n/a	n/a	256	n/a
-359.7798181818	n/a	89944.9545	show_cross	n/a	n/a	n/a	cross.bmp
-360.2507272727	n/a	90062.6818	show_face	famous_face	first_show	5	f050.bmp
-360.8880000000	n/a	90222	right_press	n/a	n/a	4096	n/a
-361.1407272727	n/a	90285.1818	show_circle	n/a	n/a	0	circle.bmp
-362.8407272727	n/a	90710.1818	show_cross	n/a	n/a	n/a	cross.bmp
-363.4580000000	n/a	90864.5	show_face	scrambled_face	delayed_repeat	19	s132.bmp
-363.9807272727	n/a	90995.1818	right_press	n/a	n/a	4096	n/a
-364.4643636364	n/a	91116.0909	show_circle	n/a	n/a	0	circle.bmp
-366.1643636364	n/a	91541.0909	show_cross	n/a	n/a	n/a	cross.bmp
-366.8161818182	n/a	91704.0455	show_face	unfamiliar_face	first_show	13	u147.bmp
-367.7489090909	n/a	91937.2273	show_circle	n/a	n/a	0	circle.bmp
-367.9143636364	n/a	91978.5909	left_press	n/a	n/a	256	n/a
-369.4489090909	n/a	92362.2273	show_cross	n/a	n/a	n/a	cross.bmp
-370.0570909091	n/a	92514.2727	show_face	famous_face	first_show	5	f085.bmp
-370.9952727273	n/a	92748.8182	show_circle	n/a	n/a	0	circle.bmp
-371.1370909091	n/a	92784.2727	left_press	n/a	n/a	256	n/a
-372.6952727273	n/a	93173.8182	show_cross	n/a	n/a	n/a	cross.bmp
-373.2143636364	n/a	93303.5909	show_face	unfamiliar_face	first_show	13	u037.bmp
-374.0070909091	n/a	93501.7727	right_press	n/a	n/a	4096	n/a
-374.0589090909	n/a	93514.7273	show_circle	n/a	n/a	0	circle.bmp
-375.7589090909	n/a	93939.7273	show_cross	n/a	n/a	n/a	cross.bmp
-376.2380000000	n/a	94059.5	show_face	unfamiliar_face	immediate_repeat	14	u037.bmp
-376.9643636364	n/a	94241.0909	right_press	n/a	n/a	4096	n/a
-377.0652727273	n/a	94266.3182	show_circle	n/a	n/a	0	circle.bmp
-378.7652727273	n/a	94691.3182	show_cross	n/a	n/a	n/a	cross.bmp
-379.2952727273	n/a	94823.8182	show_face	famous_face	delayed_repeat	7	f019.bmp
-380.0107272727	n/a	95002.6818	right_press	n/a	n/a	4096	n/a
-380.2034545455	n/a	95050.8636	show_circle	n/a	n/a	0	circle.bmp
-381.9034545455	n/a	95475.8636	show_cross	n/a	n/a	n/a	cross.bmp
-382.4698181818	n/a	95617.4545	show_face	scrambled_face	first_show	17	s118.bmp
-383.2725454545	n/a	95818.1364	right_press	n/a	n/a	4096	n/a
-383.3243636364	n/a	95831.0909	show_circle	n/a	n/a	0	circle.bmp
-385.0243636364	n/a	96256.0909	show_cross	n/a	n/a	n/a	cross.bmp
-385.6598181818	n/a	96414.9545	show_face	scrambled_face	first_show	17	s103.bmp
-386.3289090909	n/a	96582.2273	right_press	n/a	n/a	4096	n/a
-386.5589090909	n/a	96639.7273	show_circle	n/a	n/a	0	circle.bmp
-388.2589090909	n/a	97064.7273	show_cross	n/a	n/a	n/a	cross.bmp
-388.8334545455	n/a	97208.3636	show_face	famous_face	delayed_repeat	7	f050.bmp
-389.4798181818	n/a	97369.9545	right_press	n/a	n/a	4096	n/a
-389.7934545455	n/a	97448.3636	show_circle	n/a	n/a	0	circle.bmp
-391.4934545455	n/a	97873.3636	show_cross	n/a	n/a	n/a	cross.bmp
-392.0243636364	n/a	98006.0909	show_face	unfamiliar_face	first_show	13	u103.bmp
-392.6007272727	n/a	98150.1818	right_press	n/a	n/a	4096	n/a
-393.0225454545	n/a	98255.6364	show_circle	n/a	n/a	0	circle.bmp
-394.7225454545	n/a	98680.6364	show_cross	n/a	n/a	n/a	cross.bmp
-395.2152727273	n/a	98803.8182	show_face	unfamiliar_face	delayed_repeat	15	u147.bmp
-395.7489090909	n/a	98937.2273	right_press	n/a	n/a	4096	n/a
-396.1289090909	n/a	99032.2273	show_circle	n/a	n/a	0	circle.bmp
-397.8289090909	n/a	99457.2273	show_cross	n/a	n/a	n/a	cross.bmp
-398.3389090909	n/a	99584.7273	show_face	famous_face	first_show	5	f083.bmp
-398.9116363636	n/a	99727.9091	right_press	n/a	n/a	4096	n/a
-399.1807272727	n/a	99795.1818	show_circle	n/a	n/a	0	circle.bmp
-400.8807272727	n/a	100220.1818	show_cross	n/a	n/a	n/a	cross.bmp
-401.4461818182	n/a	100361.5455	show_face	famous_face	delayed_repeat	7	f085.bmp
-402.3561818182	n/a	100589.0455	show_circle	n/a	n/a	0	circle.bmp
-402.3870909091	n/a	100596.7727	right_press	n/a	n/a	4096	n/a
-404.0561818182	n/a	101014.0455	show_cross	n/a	n/a	n/a	cross.bmp
-404.5861818182	n/a	101146.5455	show_face	unfamiliar_face	first_show	13	u085.bmp
-405.4180000000	n/a	101354.5	right_press	n/a	n/a	4096	n/a
-405.5180000000	n/a	101379.5	show_circle	n/a	n/a	0	circle.bmp
-407.2180000000	n/a	101804.5	show_cross	n/a	n/a	n/a	cross.bmp
-407.8443636364	n/a	101961.0909	show_face	unfamiliar_face	immediate_repeat	14	u085.bmp
-408.5680000000	n/a	102142	right_press	n/a	n/a	4096	n/a
-408.7343636364	n/a	102183.5909	show_circle	n/a	n/a	0	circle.bmp
-410.4343636364	n/a	102608.5909	show_cross	n/a	n/a	n/a	cross.bmp
-411.0680000000	n/a	102767	show_face	famous_face	first_show	5	f072.bmp
-411.8189090909	n/a	102954.7273	left_press	n/a	n/a	256	n/a
-412.0570909091	n/a	103014.2727	show_circle	n/a	n/a	0	circle.bmp
-413.7570909091	n/a	103439.2727	show_cross	n/a	n/a	n/a	cross.bmp
-414.3089090909	n/a	103577.2273	show_face	famous_face	immediate_repeat	6	f072.bmp
-414.9961818182	n/a	103749.0455	left_press	n/a	n/a	256	n/a
-415.3152727273	n/a	103828.8182	show_circle	n/a	n/a	0	circle.bmp
-417.0152727273	n/a	104253.8182	show_cross	n/a	n/a	n/a	cross.bmp
-417.6498181818	n/a	104412.4545	show_face	scrambled_face	delayed_repeat	19	s118.bmp
-418.2852727273	n/a	104571.3182	right_press	n/a	n/a	4096	n/a
-418.5089090909	n/a	104627.2273	show_circle	n/a	n/a	0	circle.bmp
-420.2089090909	n/a	105052.2273	show_cross	n/a	n/a	n/a	cross.bmp
-420.7407272727	n/a	105185.1818	show_face	scrambled_face	first_show	17	s097.bmp
-421.6552727273	n/a	105413.8182	show_circle	n/a	n/a	0	circle.bmp
-421.6561818182	n/a	105414.0455	right_press	n/a	n/a	4096	n/a
-423.3552727273	n/a	105838.8182	show_cross	n/a	n/a	n/a	cross.bmp
-423.9307272727	n/a	105982.6818	show_face	scrambled_face	delayed_repeat	19	s103.bmp
-424.5852727273	n/a	106146.3182	right_press	n/a	n/a	4096	n/a
-424.8261818182	n/a	106206.5455	show_circle	n/a	n/a	0	circle.bmp
-426.5261818182	n/a	106631.5455	show_cross	n/a	n/a	n/a	cross.bmp
-427.1716363636	n/a	106792.9091	show_face	famous_face	first_show	5	f029.bmp
-427.3052727273	n/a	106826.3182	right_press	n/a	n/a	4096	n/a
-428.1125454545	n/a	107028.1364	show_circle	n/a	n/a	0	circle.bmp
-429.8125454545	n/a	107453.1364	show_cross	n/a	n/a	n/a	cross.bmp
-430.2961818182	n/a	107574.0455	show_face	famous_face	immediate_repeat	6	f029.bmp
-430.8734545455	n/a	107718.3636	right_press	n/a	n/a	4096	n/a
-431.2425454545	n/a	107810.6364	show_circle	n/a	n/a	0	circle.bmp
-432.9425454545	n/a	108235.6364	show_cross	n/a	n/a	n/a	cross.bmp
-433.5698181818	n/a	108392.4545	show_face	unfamiliar_face	delayed_repeat	15	u103.bmp
-434.3443636364	n/a	108586.0909	right_press	n/a	n/a	4096	n/a
-434.4916363636	n/a	108622.9091	show_circle	n/a	n/a	0	circle.bmp
-436.1916363636	n/a	109047.9091	show_cross	n/a	n/a	n/a	cross.bmp
-436.6934545455	n/a	109173.3636	show_face	unfamiliar_face	first_show	13	u001.bmp
-437.2534545455	n/a	109313.3636	left_press	n/a	n/a	256	n/a
-437.6889090909	n/a	109422.2273	show_circle	n/a	n/a	0	circle.bmp
-439.3889090909	n/a	109847.2273	show_cross	n/a	n/a	n/a	cross.bmp
-439.8507272727	n/a	109962.6818	show_face	unfamiliar_face	immediate_repeat	14	u001.bmp
-440.3125454545	n/a	110078.1364	left_press	n/a	n/a	256	n/a
-440.8352727273	n/a	110208.8182	show_circle	n/a	n/a	0	circle.bmp
-442.5352727273	n/a	110633.8182	show_cross	n/a	n/a	n/a	cross.bmp
-443.1261818182	n/a	110781.5455	show_face	famous_face	delayed_repeat	7	f083.bmp
-443.6707272727	n/a	110917.6818	right_press	n/a	n/a	4096	n/a
-444.0116363636	n/a	111002.9091	show_circle	n/a	n/a	0	circle.bmp
-445.7116363636	n/a	111427.9091	show_cross	n/a	n/a	n/a	cross.bmp
-446.1989090909	n/a	111549.7273	show_face	scrambled_face	first_show	17	s078.bmp
-446.8625454545	n/a	111715.6364	right_press	n/a	n/a	4096	n/a
-447.0770909091	n/a	111769.2727	show_circle	n/a	n/a	0	circle.bmp
-448.7770909091	n/a	112194.2727	show_cross	n/a	n/a	n/a	cross.bmp
-449.2898181818	n/a	112322.4545	show_face	unfamiliar_face	first_show	13	u122.bmp
-450.0007272727	n/a	112500.1818	left_press	n/a	n/a	256	n/a
-450.2252727273	n/a	112556.3182	show_circle	n/a	n/a	0	circle.bmp
-451.9252727273	n/a	112981.3182	show_cross	n/a	n/a	n/a	cross.bmp
-452.4298181818	n/a	113107.4545	show_face	unfamiliar_face	immediate_repeat	14	u122.bmp
-452.9098181818	n/a	113227.4545	left_press	n/a	n/a	256	n/a
-453.3007272727	n/a	113325.1818	show_circle	n/a	n/a	0	circle.bmp
-455.0007272727	n/a	113750.1818	show_cross	n/a	n/a	n/a	cross.bmp
-455.4534545455	n/a	113863.3636	show_face	famous_face	first_show	5	f150.bmp
-456.0152727273	n/a	114003.8182	right_press	n/a	n/a	4096	n/a
-456.3270909091	n/a	114081.7727	show_circle	n/a	n/a	0	circle.bmp
-458.0270909091	n/a	114506.7727	show_cross	n/a	n/a	n/a	cross.bmp
-458.5607272727	n/a	114640.1818	show_face	scrambled_face	delayed_repeat	19	s097.bmp
-459.4280000000	n/a	114857	show_circle	n/a	n/a	0	circle.bmp
-459.5680000000	n/a	114892	right_press	n/a	n/a	4096	n/a
-461.1280000000	n/a	115282	show_cross	n/a	n/a	n/a	cross.bmp
-461.7680000000	n/a	115442	show_face	unfamiliar_face	first_show	13	u101.bmp
-461.9970909091	n/a	115499.2727	left_press	n/a	n/a	256	n/a
-462.7861818182	n/a	115696.5455	show_circle	n/a	n/a	0	circle.bmp
-464.4861818182	n/a	116121.5455	show_cross	n/a	n/a	n/a	cross.bmp
-465.1098181818	n/a	116277.4545	show_face	unfamiliar_face	first_show	13	u047.bmp
-465.8952727273	n/a	116473.8182	left_press	n/a	n/a	256	n/a
-465.9498181818	n/a	116487.4545	show_circle	n/a	n/a	0	circle.bmp
-467.6498181818	n/a	116912.4545	show_cross	n/a	n/a	n/a	cross.bmp
-468.2498181818	n/a	117062.4545	show_face	unfamiliar_face	immediate_repeat	14	u047.bmp
-468.7834545455	n/a	117195.8636	left_press	n/a	n/a	256	n/a
-469.1289090909	n/a	117282.2273	show_circle	n/a	n/a	0	circle.bmp
-470.8289090909	n/a	117707.2273	show_cross	n/a	n/a	n/a	cross.bmp
-471.4407272727	n/a	117860.1818	show_face	scrambled_face	first_show	17	s054.bmp
-472.2652727273	n/a	118066.3182	show_circle	n/a	n/a	0	circle.bmp
-472.2970909091	n/a	118074.2727	right_press	n/a	n/a	4096	n/a
-473.9652727273	n/a	118491.3182	show_cross	n/a	n/a	n/a	cross.bmp
-474.5816363636	n/a	118645.4091	show_face	scrambled_face	delayed_repeat	19	s078.bmp
-475.2443636364	n/a	118811.0909	right_press	n/a	n/a	4096	n/a
-475.5025454545	n/a	118875.6364	show_circle	n/a	n/a	0	circle.bmp
-477.2025454545	n/a	119300.6364	show_cross	n/a	n/a	n/a	cross.bmp
-477.7889090909	n/a	119447.2273	show_face	famous_face	first_show	5	f016.bmp
-478.3080000000	n/a	119577	right_press	n/a	n/a	4096	n/a
-478.7743636364	n/a	119693.5909	show_circle	n/a	n/a	0	circle.bmp
-480.4743636364	n/a	120118.5909	show_cross	n/a	n/a	n/a	cross.bmp
-481.0798181818	n/a	120269.9545	show_face	famous_face	immediate_repeat	6	f016.bmp
-481.8043636364	n/a	120451.0909	right_press	n/a	n/a	4096	n/a
-481.9298181818	n/a	120482.4545	show_circle	n/a	n/a	0	circle.bmp
-483.6298181818	n/a	120907.4545	show_cross	n/a	n/a	n/a	cross.bmp
-484.1361818182	n/a	121034.0455	show_face	famous_face	first_show	5	f002.bmp
-484.8370909091	n/a	121209.2727	right_press	n/a	n/a	4096	n/a
-484.9743636364	n/a	121243.5909	show_circle	n/a	n/a	0	circle.bmp
-486.6743636364	n/a	121668.5909	show_cross	n/a	n/a	n/a	cross.bmp
-487.2434545455	n/a	121810.8636	show_face	famous_face	immediate_repeat	6	f002.bmp
-487.7361818182	n/a	121934.0455	right_press	n/a	n/a	4096	n/a
-488.1052727273	n/a	122026.3182	show_circle	n/a	n/a	0	circle.bmp
-489.8052727273	n/a	122451.3182	show_cross	n/a	n/a	n/a	cross.bmp
-490.2670909091	n/a	122566.7727	show_face	famous_face	delayed_repeat	7	f150.bmp
-491.1107272727	n/a	122777.6818	show_circle	n/a	n/a	0	circle.bmp
-492.8107272727	n/a	123202.6818	show_cross	n/a	n/a	n/a	cross.bmp
+onset	duration	sample	event_type	face_type	repetition_type	trial	trial_lag	trigger	stim_file
+0.004	n/a	1.0	setup	n/a	n/a	n/a	n/a	n/a	n/a
+0.004	n/a	1.0	right_sym	n/a	n/a	n/a	n/a	n/a	n/a
+23.926181818200003	n/a	5981.5455	show_face	famous_face	first_show	1	n/a	5	f127.bmp
+24.608909090900003	n/a	6152.2273	right_press	n/a	n/a	1	n/a	4096	n/a
+24.7707272727	n/a	6192.6818	show_circle	n/a	n/a	1	n/a	0	circle.bmp
+26.4707272727	n/a	6617.6818	show_cross	n/a	n/a	2	n/a	n/a	cross.bmp
+26.916181818200002	n/a	6729.0455	show_face	famous_face	immediate_repeat	2	1	6	f127.bmp
+27.4561818182	n/a	6864.0455	right_press	n/a	n/a	2	n/a	4096	n/a
+27.916181818200002	n/a	6979.0455	show_circle	n/a	n/a	2	n/a	0	circle.bmp
+29.6161818182	n/a	7404.0455	show_cross	n/a	n/a	3	n/a	n/a	cross.bmp
+30.1907272727	n/a	7547.6818	show_face	unfamiliar_face	first_show	3	n/a	13	u015.bmp
+31.1652727273	n/a	7791.3182	show_circle	n/a	n/a	3	n/a	0	circle.bmp
+32.8652727273	n/a	8216.3182	show_cross	n/a	n/a	4	n/a	n/a	cross.bmp
+33.498	n/a	8374.5	show_face	unfamiliar_face	first_show	4	n/a	13	u072.bmp
+34.368909090900004	n/a	8592.2273	show_circle	n/a	n/a	4	n/a	0	circle.bmp
+36.0689090909	n/a	9017.2273	show_cross	n/a	n/a	5	n/a	n/a	cross.bmp
+36.5716363636	n/a	9142.9091	show_face	unfamiliar_face	first_show	5	n/a	13	u052.bmp
+37.3698181818	n/a	9342.4545	right_press	n/a	n/a	5	n/a	4096	n/a
+37.558	n/a	9389.5	show_circle	n/a	n/a	5	n/a	0	circle.bmp
+39.258	n/a	9814.5	show_cross	n/a	n/a	6	n/a	n/a	cross.bmp
+39.8625454545	n/a	9965.6364	show_face	famous_face	first_show	6	n/a	5	f106.bmp
+40.4643636364	n/a	10116.0909	right_press	n/a	n/a	6	n/a	4096	n/a
+40.7834545455	n/a	10195.8636	show_circle	n/a	n/a	6	n/a	0	circle.bmp
+42.4834545455	n/a	10620.8636	show_cross	n/a	n/a	7	n/a	n/a	cross.bmp
+42.936181818200005	n/a	10734.0455	show_face	famous_face	immediate_repeat	7	1	6	f106.bmp
+43.4470909091	n/a	10861.7727	right_press	n/a	n/a	7	n/a	4096	n/a
+43.935272727299996	n/a	10983.8182	show_circle	n/a	n/a	7	n/a	0	circle.bmp
+45.6352727273	n/a	11408.8182	show_cross	n/a	n/a	8	n/a	n/a	cross.bmp
+46.0934545455	n/a	11523.3636	show_face	unfamiliar_face	first_show	8	n/a	13	u036.bmp
+47.016181818199996	n/a	11754.0455	show_circle	n/a	n/a	8	n/a	0	circle.bmp
+48.7161818182	n/a	12179.0455	show_cross	n/a	n/a	9	n/a	n/a	cross.bmp
+49.2843636364	n/a	12321.0909	show_face	unfamiliar_face	first_show	9	n/a	13	u142.bmp
+50.255272727299996	n/a	12563.8182	show_circle	n/a	n/a	9	n/a	0	circle.bmp
+51.9552727273	n/a	12988.8182	show_cross	n/a	n/a	10	n/a	n/a	cross.bmp
+52.52527272729999	n/a	13131.3182	show_face	unfamiliar_face	immediate_repeat	10	1	14	u142.bmp
+53.457090909099996	n/a	13364.2727	show_circle	n/a	n/a	10	n/a	0	circle.bmp
+55.1570909091	n/a	13789.2727	show_cross	n/a	n/a	11	n/a	n/a	cross.bmp
+55.782545454499996	n/a	13945.6364	show_face	unfamiliar_face	delayed_repeat	11	8	15	u015.bmp
+56.7134545455	n/a	14178.3636	show_circle	n/a	n/a	11	n/a	0	circle.bmp
+58.4134545455	n/a	14603.3636	show_cross	n/a	n/a	12	n/a	n/a	cross.bmp
+59.0398181818	n/a	14759.9545	show_face	scrambled_face	first_show	12	n/a	17	s129.bmp
+59.9089090909	n/a	14977.2273	show_circle	n/a	n/a	12	n/a	0	circle.bmp
+61.6089090909	n/a	15402.2273	show_cross	n/a	n/a	13	n/a	n/a	cross.bmp
+62.2143636364	n/a	15553.5909	show_face	scrambled_face	immediate_repeat	13	1	18	s129.bmp
+63.108	n/a	15777.0	show_circle	n/a	n/a	13	n/a	0	circle.bmp
+64.808	n/a	16202.0	show_cross	n/a	n/a	14	n/a	n/a	cross.bmp
+65.3043636364	n/a	16326.0909	show_face	unfamiliar_face	delayed_repeat	14	10	15	u072.bmp
+66.2734545455	n/a	16568.3636	show_circle	n/a	n/a	14	n/a	0	circle.bmp
+67.9734545455	n/a	16993.3636	show_cross	n/a	n/a	15	n/a	n/a	cross.bmp
+68.5452727273	n/a	17136.3182	show_face	scrambled_face	first_show	15	n/a	17	s131.bmp
+69.3061818182	n/a	17326.5455	right_press	n/a	n/a	15	n/a	4096	n/a
+69.52527272729999	n/a	17381.3182	show_circle	n/a	n/a	15	n/a	0	circle.bmp
+71.2252727273	n/a	17806.3182	show_cross	n/a	n/a	16	n/a	n/a	cross.bmp
+71.8198181818	n/a	17954.9545	show_face	unfamiliar_face	delayed_repeat	16	11	15	u052.bmp
+72.728	n/a	18182.0	show_circle	n/a	n/a	16	n/a	0	circle.bmp
+74.428	n/a	18607.0	show_cross	n/a	n/a	17	n/a	n/a	cross.bmp
+74.9598181818	n/a	18739.9545	show_face	scrambled_face	first_show	17	n/a	17	s101.bmp
+75.7025454545	n/a	18925.6364	right_press	n/a	n/a	17	n/a	4096	n/a
+75.93072727270001	n/a	18982.6818	show_circle	n/a	n/a	17	n/a	0	circle.bmp
+77.6307272727	n/a	19407.6818	show_cross	n/a	n/a	18	n/a	n/a	cross.bmp
+78.18436363640001	n/a	19546.0909	show_face	unfamiliar_face	first_show	18	n/a	13	u040.bmp
+79.0098181818	n/a	19752.4545	show_circle	n/a	n/a	18	n/a	0	circle.bmp
+80.7098181818	n/a	20177.4545	show_cross	n/a	n/a	19	n/a	n/a	cross.bmp
+81.258	n/a	20314.5	show_face	unfamiliar_face	immediate_repeat	19	1	14	u040.bmp
+82.1825454545	n/a	20545.6364	show_circle	n/a	n/a	19	n/a	0	circle.bmp
+83.8825454545	n/a	20970.6364	show_cross	n/a	n/a	20	n/a	n/a	cross.bmp
+84.5325454545	n/a	21133.1364	show_face	unfamiliar_face	delayed_repeat	20	12	15	u036.bmp
+85.4861818182	n/a	21371.5455	show_circle	n/a	n/a	20	n/a	0	circle.bmp
+87.1861818182	n/a	21796.5455	show_cross	n/a	n/a	21	n/a	n/a	cross.bmp
+87.7061818182	n/a	21926.5455	show_face	famous_face	first_show	21	n/a	5	f080.bmp
+88.2916363636	n/a	22072.9091	right_press	n/a	n/a	21	n/a	4096	n/a
+88.5616363636	n/a	22140.4091	show_circle	n/a	n/a	21	n/a	0	circle.bmp
+90.2616363636	n/a	22565.4091	show_cross	n/a	n/a	22	n/a	n/a	cross.bmp
+90.7298181818	n/a	22682.4545	show_face	famous_face	first_show	22	n/a	5	f134.bmp
+91.66345454549999	n/a	22915.8636	show_circle	n/a	n/a	22	n/a	0	circle.bmp
+93.36345454549999	n/a	23340.8636	show_cross	n/a	n/a	23	n/a	n/a	cross.bmp
+93.85345454549999	n/a	23463.3636	show_face	famous_face	first_show	23	n/a	5	f046.bmp
+94.6689090909	n/a	23667.2273	left_press	n/a	n/a	23	n/a	256	n/a
+94.8107272727	n/a	23702.6818	show_circle	n/a	n/a	23	n/a	0	circle.bmp
+96.51072727270001	n/a	24127.6818	show_cross	n/a	n/a	24	n/a	n/a	cross.bmp
+97.028	n/a	24257.0	show_face	famous_face	immediate_repeat	24	1	6	f046.bmp
+97.56890909090001	n/a	24392.2273	left_press	n/a	n/a	24	n/a	256	n/a
+97.86618181819999	n/a	24466.5455	show_circle	n/a	n/a	24	n/a	0	circle.bmp
+99.5661818182	n/a	24891.5455	show_cross	n/a	n/a	25	n/a	n/a	cross.bmp
+100.168	n/a	25042.0	show_face	scrambled_face	delayed_repeat	25	10	19	s131.bmp
+100.9334545455	n/a	25233.3636	right_press	n/a	n/a	25	n/a	4096	n/a
+101.118	n/a	25279.5	show_circle	n/a	n/a	25	n/a	0	circle.bmp
+102.818	n/a	25704.5	show_cross	n/a	n/a	26	n/a	n/a	cross.bmp
+103.3089090909	n/a	25827.2273	show_face	unfamiliar_face	first_show	26	n/a	13	u059.bmp
+104.2252727273	n/a	26056.3182	show_circle	n/a	n/a	26	n/a	0	circle.bmp
+104.3416363636	n/a	26085.4091	right_press	n/a	n/a	26	n/a	4096	n/a
+105.9252727273	n/a	26481.3182	show_cross	n/a	n/a	27	n/a	n/a	cross.bmp
+106.4170909091	n/a	26604.2727	show_face	scrambled_face	delayed_repeat	27	10	19	s101.bmp
+106.9089090909	n/a	26727.2273	right_press	n/a	n/a	27	n/a	4096	n/a
+107.2661818182	n/a	26816.5455	show_circle	n/a	n/a	27	n/a	0	circle.bmp
+108.9661818182	n/a	27241.5455	show_cross	n/a	n/a	28	n/a	n/a	cross.bmp
+109.5561818182	n/a	27389.0455	show_face	unfamiliar_face	first_show	28	n/a	13	u055.bmp
+110.2243636364	n/a	27556.0909	left_press	n/a	n/a	28	n/a	256	n/a
+110.5189090909	n/a	27629.7273	show_circle	n/a	n/a	28	n/a	0	circle.bmp
+112.2189090909	n/a	28054.7273	show_cross	n/a	n/a	29	n/a	n/a	cross.bmp
+112.8307272727	n/a	28207.6818	show_face	unfamiliar_face	first_show	29	n/a	13	u006.bmp
+113.5489090909	n/a	28387.2273	left_press	n/a	n/a	29	n/a	256	n/a
+113.7989090909	n/a	28449.7273	show_circle	n/a	n/a	29	n/a	0	circle.bmp
+115.4989090909	n/a	28874.7273	show_cross	n/a	n/a	30	n/a	n/a	cross.bmp
+116.138	n/a	29034.5	show_face	famous_face	delayed_repeat	30	9	7	f080.bmp
+116.8134545455	n/a	29203.3636	right_press	n/a	n/a	30	n/a	4096	n/a
+116.96981818180001	n/a	29242.4545	show_circle	n/a	n/a	30	n/a	0	circle.bmp
+118.6698181818	n/a	29667.4545	show_cross	n/a	n/a	31	n/a	n/a	cross.bmp
+119.2789090909	n/a	29819.7273	show_face	unfamiliar_face	first_show	31	n/a	13	u076.bmp
+120.2034545455	n/a	30050.8636	right_press	n/a	n/a	31	n/a	4096	n/a
+120.2252727273	n/a	30056.3182	show_circle	n/a	n/a	31	n/a	0	circle.bmp
+121.9252727273	n/a	30481.3182	show_cross	n/a	n/a	32	n/a	n/a	cross.bmp
+122.5698181818	n/a	30642.4545	show_face	famous_face	delayed_repeat	32	10	7	f134.bmp
+123.3916363636	n/a	30847.9091	show_circle	n/a	n/a	32	n/a	0	circle.bmp
+123.60527272729999	n/a	30901.3182	left_press	n/a	n/a	32	n/a	256	n/a
+125.0916363636	n/a	31272.9091	show_cross	n/a	n/a	33	n/a	n/a	cross.bmp
+125.5934545455	n/a	31398.3636	show_face	unfamiliar_face	first_show	33	n/a	13	u062.bmp
+126.2270909091	n/a	31556.7727	right_press	n/a	n/a	33	n/a	4096	n/a
+126.5634545455	n/a	31640.8636	show_circle	n/a	n/a	33	n/a	0	circle.bmp
+128.2634545455	n/a	32065.8636	show_cross	n/a	n/a	34	n/a	n/a	cross.bmp
+128.7670909091	n/a	32191.7727	show_face	unfamiliar_face	immediate_repeat	34	1	14	u062.bmp
+129.4261818182	n/a	32356.5455	left_press	n/a	n/a	34	n/a	256	n/a
+129.7516363636	n/a	32437.9091	show_circle	n/a	n/a	34	n/a	0	circle.bmp
+131.45163636360002	n/a	32862.9091	show_cross	n/a	n/a	35	n/a	n/a	cross.bmp
+132.04163636360002	n/a	33010.4091	show_face	unfamiliar_face	first_show	35	n/a	13	u030.bmp
+132.6770909091	n/a	33169.2727	left_press	n/a	n/a	35	n/a	256	n/a
+132.9189090909	n/a	33229.7273	show_circle	n/a	n/a	35	n/a	0	circle.bmp
+134.6189090909	n/a	33654.7273	show_cross	n/a	n/a	36	n/a	n/a	cross.bmp
+135.1825454545	n/a	33795.6364	show_face	unfamiliar_face	immediate_repeat	36	1	14	u030.bmp
+135.668	n/a	33917.0	left_press	n/a	n/a	36	n/a	256	n/a
+136.0298181818	n/a	34007.4545	show_circle	n/a	n/a	36	n/a	0	circle.bmp
+137.7298181818	n/a	34432.4545	show_cross	n/a	n/a	37	n/a	n/a	cross.bmp
+138.2898181818	n/a	34572.4545	show_face	unfamiliar_face	delayed_repeat	37	11	15	u059.bmp
+138.77890909090002	n/a	34694.7273	left_press	n/a	n/a	37	n/a	256	n/a
+139.1443636364	n/a	34786.0909	show_circle	n/a	n/a	37	n/a	0	circle.bmp
+140.8443636364	n/a	35211.0909	show_cross	n/a	n/a	38	n/a	n/a	cross.bmp
+141.31345454549998	n/a	35328.3636	show_face	famous_face	first_show	38	n/a	5	f014.bmp
+142.3016363636	n/a	35575.4091	show_circle	n/a	n/a	38	n/a	0	circle.bmp
+142.5407272727	n/a	35635.1818	left_press	n/a	n/a	38	n/a	256	n/a
+144.0016363636	n/a	36000.4091	show_cross	n/a	n/a	39	n/a	n/a	cross.bmp
+144.5370909091	n/a	36134.2727	show_face	famous_face	immediate_repeat	39	1	6	f014.bmp
+145.0961818182	n/a	36274.0455	left_press	n/a	n/a	39	n/a	256	n/a
+145.5043636364	n/a	36376.0909	show_circle	n/a	n/a	39	n/a	0	circle.bmp
+147.2043636364	n/a	36801.0909	show_cross	n/a	n/a	40	n/a	n/a	cross.bmp
+147.8443636364	n/a	36961.0909	show_face	unfamiliar_face	delayed_repeat	40	12	15	u055.bmp
+148.6852727273	n/a	37171.3182	left_press	n/a	n/a	40	n/a	256	n/a
+148.8207272727	n/a	37205.1818	show_circle	n/a	n/a	40	n/a	0	circle.bmp
+150.52072727270001	n/a	37630.1818	show_cross	n/a	n/a	41	n/a	n/a	cross.bmp
+151.0689090909	n/a	37767.2273	show_face	scrambled_face	first_show	41	n/a	17	s038.bmp
+151.8843636364	n/a	37971.0909	left_press	n/a	n/a	41	n/a	256	n/a
+151.9098181818	n/a	37977.4545	show_circle	n/a	n/a	41	n/a	0	circle.bmp
+153.6098181818	n/a	38402.4545	show_cross	n/a	n/a	42	n/a	n/a	cross.bmp
+154.2425454545	n/a	38560.6364	show_face	scrambled_face	immediate_repeat	42	1	18	s038.bmp
+154.77072727270001	n/a	38692.6818	left_press	n/a	n/a	42	n/a	256	n/a
+155.1561818182	n/a	38789.0455	show_circle	n/a	n/a	42	n/a	0	circle.bmp
+156.85618181819999	n/a	39214.0455	show_cross	n/a	n/a	43	n/a	n/a	cross.bmp
+157.43345454549998	n/a	39358.3636	show_face	unfamiliar_face	delayed_repeat	43	14	15	u006.bmp
+158.2798181818	n/a	39569.9545	left_press	n/a	n/a	43	n/a	256	n/a
+158.308	n/a	39577.0	show_circle	n/a	n/a	43	n/a	0	circle.bmp
+160.008	n/a	40002.0	show_cross	n/a	n/a	44	n/a	n/a	cross.bmp
+160.5907272727	n/a	40147.6818	show_face	unfamiliar_face	first_show	44	n/a	13	u025.bmp
+161.5361818182	n/a	40384.0455	right_press	n/a	n/a	44	n/a	4096	n/a
+161.6034545455	n/a	40400.8636	show_circle	n/a	n/a	44	n/a	0	circle.bmp
+163.3034545455	n/a	40825.8636	show_cross	n/a	n/a	45	n/a	n/a	cross.bmp
+163.9489090909	n/a	40987.2273	show_face	unfamiliar_face	immediate_repeat	45	1	14	u025.bmp
+164.5298181818	n/a	41132.4545	right_press	n/a	n/a	45	n/a	4096	n/a
+164.9389090909	n/a	41234.7273	show_circle	n/a	n/a	45	n/a	0	circle.bmp
+166.6389090909	n/a	41659.7273	show_cross	n/a	n/a	46	n/a	n/a	cross.bmp
+167.1725454545	n/a	41793.1364	show_face	unfamiliar_face	delayed_repeat	46	15	15	u076.bmp
+168.1052727273	n/a	42026.3182	show_circle	n/a	n/a	46	n/a	0	circle.bmp
+168.29163636360002	n/a	42072.9091	left_press	n/a	n/a	46	n/a	256	n/a
+169.8052727273	n/a	42451.3182	show_cross	n/a	n/a	47	n/a	n/a	cross.bmp
+170.4134545455	n/a	42603.3636	show_face	scrambled_face	first_show	47	n/a	17	s135.bmp
+171.4016363636	n/a	42850.4091	right_press	n/a	n/a	47	n/a	4096	n/a
+171.4316363636	n/a	42857.9091	show_circle	n/a	n/a	47	n/a	0	circle.bmp
+173.1316363636	n/a	43282.9091	show_cross	n/a	n/a	48	n/a	n/a	cross.bmp
+173.6543636364	n/a	43413.5909	show_face	scrambled_face	first_show	48	n/a	17	s107.bmp
+174.1170909091	n/a	43529.2727	right_press	n/a	n/a	48	n/a	4096	n/a
+174.5234545455	n/a	43630.8636	show_circle	n/a	n/a	48	n/a	0	circle.bmp
+176.2234545455	n/a	44055.8636	show_cross	n/a	n/a	49	n/a	n/a	cross.bmp
+176.74436363639998	n/a	44186.0909	show_face	scrambled_face	immediate_repeat	49	1	18	s107.bmp
+177.2243636364	n/a	44306.0909	left_press	n/a	n/a	49	n/a	256	n/a
+177.5998181818	n/a	44399.9545	show_circle	n/a	n/a	49	n/a	0	circle.bmp
+179.2998181818	n/a	44824.9545	show_cross	n/a	n/a	50	n/a	n/a	cross.bmp
+179.8352727273	n/a	44958.8182	show_face	scrambled_face	first_show	50	n/a	17	s022.bmp
+180.64527272729998	n/a	45161.3182	right_press	n/a	n/a	50	n/a	4096	n/a
+180.84345454549998	n/a	45210.8636	show_circle	n/a	n/a	50	n/a	0	circle.bmp
+182.5434545455	n/a	45635.8636	show_cross	n/a	n/a	51	n/a	n/a	cross.bmp
+183.1261818182	n/a	45781.5455	show_face	scrambled_face	immediate_repeat	51	1	18	s022.bmp
+184.0752727273	n/a	46018.8182	show_circle	n/a	n/a	51	n/a	0	circle.bmp
+184.2934545455	n/a	46073.3636	right_press	n/a	n/a	51	n/a	4096	n/a
+185.7752727273	n/a	46443.8182	show_cross	n/a	n/a	52	n/a	n/a	cross.bmp
+186.2998181818	n/a	46574.9545	show_face	scrambled_face	first_show	52	n/a	17	s041.bmp
+187.1807272727	n/a	46795.1818	right_press	n/a	n/a	52	n/a	4096	n/a
+187.2125454545	n/a	46803.1364	show_circle	n/a	n/a	52	n/a	0	circle.bmp
+188.91254545450002	n/a	47228.1364	show_cross	n/a	n/a	53	n/a	n/a	cross.bmp
+189.4570909091	n/a	47364.2727	show_face	scrambled_face	immediate_repeat	53	1	18	s041.bmp
+190.1861818182	n/a	47546.5455	right_press	n/a	n/a	53	n/a	4096	n/a
+190.3970909091	n/a	47599.2727	show_circle	n/a	n/a	53	n/a	0	circle.bmp
+192.0970909091	n/a	48024.2727	show_cross	n/a	n/a	54	n/a	n/a	cross.bmp
+192.6816363636	n/a	48170.4091	show_face	scrambled_face	first_show	54	n/a	17	s104.bmp
+193.5070909091	n/a	48376.7727	show_circle	n/a	n/a	54	n/a	0	circle.bmp
+195.2070909091	n/a	48801.7727	show_cross	n/a	n/a	55	n/a	n/a	cross.bmp
+195.7216363636	n/a	48930.4091	show_face	unfamiliar_face	first_show	55	n/a	13	u033.bmp
+196.5152727273	n/a	49128.8182	right_press	n/a	n/a	55	n/a	4096	n/a
+196.7289090909	n/a	49182.2273	show_circle	n/a	n/a	55	n/a	0	circle.bmp
+198.4289090909	n/a	49607.2273	show_cross	n/a	n/a	56	n/a	n/a	cross.bmp
+198.9789090909	n/a	49744.7273	show_face	scrambled_face	delayed_repeat	56	9	19	s135.bmp
+199.6016363636	n/a	49900.4091	right_press	n/a	n/a	56	n/a	4096	n/a
+199.8498181818	n/a	49962.4545	show_circle	n/a	n/a	56	n/a	0	circle.bmp
+201.5498181818	n/a	50387.4545	show_cross	n/a	n/a	57	n/a	n/a	cross.bmp
+202.0370909091	n/a	50509.2727	show_face	famous_face	first_show	57	n/a	5	f086.bmp
+202.6734545455	n/a	50668.3636	left_press	n/a	n/a	57	n/a	256	n/a
+202.8716363636	n/a	50717.9091	show_circle	n/a	n/a	57	n/a	0	circle.bmp
+204.5716363636	n/a	51142.9091	show_cross	n/a	n/a	58	n/a	n/a	cross.bmp
+205.1098181818	n/a	51277.4545	show_face	famous_face	immediate_repeat	58	1	6	f086.bmp
+205.6252727273	n/a	51406.3182	left_press	n/a	n/a	58	n/a	256	n/a
+205.9470909091	n/a	51486.7727	show_circle	n/a	n/a	58	n/a	0	circle.bmp
+207.6470909091	n/a	51911.7727	show_cross	n/a	n/a	59	n/a	n/a	cross.bmp
+208.1016363636	n/a	52025.4091	show_face	unfamiliar_face	first_show	59	n/a	13	u065.bmp
+208.9161818182	n/a	52229.0455	right_press	n/a	n/a	59	n/a	4096	n/a
+209.02436363639998	n/a	52256.0909	show_circle	n/a	n/a	59	n/a	0	circle.bmp
+210.7243636364	n/a	52681.0909	show_cross	n/a	n/a	60	n/a	n/a	cross.bmp
+211.1907272727	n/a	52797.6818	show_face	scrambled_face	first_show	60	n/a	17	s072.bmp
+211.87345454549998	n/a	52968.3636	right_press	n/a	n/a	60	n/a	4096	n/a
+212.1416363636	n/a	53035.4091	show_circle	n/a	n/a	60	n/a	0	circle.bmp
+213.8416363636	n/a	53460.4091	show_cross	n/a	n/a	61	n/a	n/a	cross.bmp
+214.348	n/a	53587.0	show_face	famous_face	first_show	61	n/a	5	f035.bmp
+215.0834545455	n/a	53770.8636	left_press	n/a	n/a	61	n/a	256	n/a
+215.268	n/a	53817.0	show_circle	n/a	n/a	61	n/a	0	circle.bmp
+216.968	n/a	54242.0	show_cross	n/a	n/a	62	n/a	n/a	cross.bmp
+217.57254545450002	n/a	54393.1364	show_face	famous_face	immediate_repeat	62	1	6	f035.bmp
+218.4152727273	n/a	54603.8182	show_circle	n/a	n/a	62	n/a	0	circle.bmp
+218.4270909091	n/a	54606.7727	right_press	n/a	n/a	62	n/a	4096	n/a
+220.1152727273	n/a	55028.8182	show_cross	n/a	n/a	63	n/a	n/a	cross.bmp
+220.6961818182	n/a	55174.0455	show_face	scrambled_face	delayed_repeat	63	9	19	s104.bmp
+221.69254545450002	n/a	55423.1364	show_circle	n/a	n/a	63	n/a	0	circle.bmp
+221.7670909091	n/a	55441.7727	left_press	n/a	n/a	63	n/a	256	n/a
+223.3925454545	n/a	55848.1364	show_cross	n/a	n/a	64	n/a	n/a	cross.bmp
+223.8698181818	n/a	55967.4545	show_face	scrambled_face	first_show	64	n/a	17	s014.bmp
+224.6098181818	n/a	56152.4545	right_press	n/a	n/a	64	n/a	4096	n/a
+224.7516363636	n/a	56187.9091	show_circle	n/a	n/a	64	n/a	0	circle.bmp
+226.45163636360002	n/a	56612.9091	show_cross	n/a	n/a	65	n/a	n/a	cross.bmp
+227.0443636364	n/a	56761.0909	show_face	unfamiliar_face	delayed_repeat	65	10	15	u033.bmp
+227.8543636364	n/a	56963.5909	right_press	n/a	n/a	65	n/a	4096	n/a
+227.9389090909	n/a	56984.7273	show_circle	n/a	n/a	65	n/a	0	circle.bmp
+229.6389090909	n/a	57409.7273	show_cross	n/a	n/a	66	n/a	n/a	cross.bmp
+230.1007272727	n/a	57525.1818	show_face	famous_face	first_show	66	n/a	5	f126.bmp
+230.67527272729998	n/a	57668.8182	right_press	n/a	n/a	66	n/a	4096	n/a
+231.0025454545	n/a	57750.6364	show_circle	n/a	n/a	66	n/a	0	circle.bmp
+232.7025454545	n/a	58175.6364	show_cross	n/a	n/a	67	n/a	n/a	cross.bmp
+233.2416363636	n/a	58310.4091	show_face	famous_face	immediate_repeat	67	1	6	f126.bmp
+233.88254545450002	n/a	58470.6364	right_press	n/a	n/a	67	n/a	4096	n/a
+234.2425454545	n/a	58560.6364	show_circle	n/a	n/a	67	n/a	0	circle.bmp
+235.94254545450002	n/a	58985.6364	show_cross	n/a	n/a	68	n/a	n/a	cross.bmp
+236.5325454545	n/a	59133.1364	show_face	scrambled_face	first_show	68	n/a	17	s126.bmp
+237.3643636364	n/a	59341.0909	show_circle	n/a	n/a	68	n/a	0	circle.bmp
+239.0643636364	n/a	59766.0909	show_cross	n/a	n/a	69	n/a	n/a	cross.bmp
+239.57254545450002	n/a	59893.1364	show_face	scrambled_face	immediate_repeat	69	1	18	s126.bmp
+240.5325454545	n/a	60133.1364	show_circle	n/a	n/a	69	n/a	0	circle.bmp
+240.5870909091	n/a	60146.7727	right_press	n/a	n/a	69	n/a	4096	n/a
+242.2325454545	n/a	60558.1364	show_cross	n/a	n/a	70	n/a	n/a	cross.bmp
+242.7807272727	n/a	60695.1818	show_face	unfamiliar_face	delayed_repeat	70	11	15	u065.bmp
+243.42163636360002	n/a	60855.4091	left_press	n/a	n/a	70	n/a	256	n/a
+243.62345454549998	n/a	60905.8636	show_circle	n/a	n/a	70	n/a	0	circle.bmp
+245.3234545455	n/a	61330.8636	show_cross	n/a	n/a	71	n/a	n/a	cross.bmp
+245.9707272727	n/a	61492.6818	show_face	scrambled_face	first_show	71	n/a	17	s062.bmp
+246.6216363636	n/a	61655.4091	right_press	n/a	n/a	71	n/a	4096	n/a
+246.8370909091	n/a	61709.2727	show_circle	n/a	n/a	71	n/a	0	circle.bmp
+248.5370909091	n/a	62134.2727	show_cross	n/a	n/a	72	n/a	n/a	cross.bmp
+249.01163636360002	n/a	62252.9091	show_face	scrambled_face	immediate_repeat	72	1	18	s062.bmp
+249.6443636364	n/a	62411.0909	right_press	n/a	n/a	72	n/a	4096	n/a
+249.9025454545	n/a	62475.6364	show_circle	n/a	n/a	72	n/a	0	circle.bmp
+251.60254545450002	n/a	62900.6364	show_cross	n/a	n/a	73	n/a	n/a	cross.bmp
+252.20163636360002	n/a	63050.4091	show_face	scrambled_face	delayed_repeat	73	13	19	s072.bmp
+253.1561818182	n/a	63289.0455	show_circle	n/a	n/a	73	n/a	0	circle.bmp
+253.1661818182	n/a	63291.5455	right_press	n/a	n/a	73	n/a	4096	n/a
+254.85618181819999	n/a	63714.0455	show_cross	n/a	n/a	74	n/a	n/a	cross.bmp
+255.4934545455	n/a	63873.3636	show_face	famous_face	first_show	74	n/a	5	f051.bmp
+256.3416363636	n/a	64085.4091	right_press	n/a	n/a	74	n/a	4096	n/a
+256.3961818182	n/a	64099.0455	show_circle	n/a	n/a	74	n/a	0	circle.bmp
+258.0961818182	n/a	64524.0455	show_cross	n/a	n/a	75	n/a	n/a	cross.bmp
+258.7007272727	n/a	64675.1818	show_face	famous_face	immediate_repeat	75	1	6	f051.bmp
+259.5270909091	n/a	64881.7727	right_press	n/a	n/a	75	n/a	4096	n/a
+259.6116363636	n/a	64902.9091	show_circle	n/a	n/a	75	n/a	0	circle.bmp
+261.31163636360003	n/a	65327.9091	show_cross	n/a	n/a	76	n/a	n/a	cross.bmp
+261.9243636364	n/a	65481.0909	show_face	scrambled_face	first_show	76	n/a	17	s127.bmp
+262.8307272727	n/a	65707.6818	show_circle	n/a	n/a	76	n/a	0	circle.bmp
+262.958	n/a	65739.5	left_press	n/a	n/a	76	n/a	256	n/a
+264.5307272727	n/a	66132.6818	show_cross	n/a	n/a	77	n/a	n/a	cross.bmp
+265.1489090909	n/a	66287.2273	show_face	scrambled_face	delayed_repeat	77	13	19	s014.bmp
+265.9352727273	n/a	66483.8182	right_press	n/a	n/a	77	n/a	4096	n/a
+266.0216363636	n/a	66505.4091	show_circle	n/a	n/a	77	n/a	0	circle.bmp
+267.7216363636	n/a	66930.4091	show_cross	n/a	n/a	78	n/a	n/a	cross.bmp
+268.3061818182	n/a	67076.5455	show_face	scrambled_face	first_show	78	n/a	17	s058.bmp
+269.0143636364	n/a	67253.5909	right_press	n/a	n/a	78	n/a	4096	n/a
+269.2389090909	n/a	67309.7273	show_circle	n/a	n/a	78	n/a	0	circle.bmp
+270.9389090909	n/a	67734.7273	show_cross	n/a	n/a	79	n/a	n/a	cross.bmp
+271.5470909091	n/a	67886.7727	show_face	famous_face	first_show	79	n/a	5	f149.bmp
+272.21618181819997	n/a	68054.0455	right_press	n/a	n/a	79	n/a	4096	n/a
+272.4198181818	n/a	68104.9545	show_circle	n/a	n/a	79	n/a	0	circle.bmp
+274.1198181818	n/a	68529.9545	show_cross	n/a	n/a	80	n/a	n/a	cross.bmp
+274.58709090909997	n/a	68646.7727	show_face	famous_face	immediate_repeat	80	1	6	f149.bmp
+275.078	n/a	68769.5	right_press	n/a	n/a	80	n/a	4096	n/a
+275.5270909091	n/a	68881.7727	show_circle	n/a	n/a	80	n/a	0	circle.bmp
+277.2270909091	n/a	69306.7727	show_cross	n/a	n/a	81	n/a	n/a	cross.bmp
+277.7943636364	n/a	69448.5909	show_face	famous_face	first_show	81	n/a	5	f030.bmp
+278.4707272727	n/a	69617.6818	right_press	n/a	n/a	81	n/a	4096	n/a
+278.6598181818	n/a	69664.9545	show_circle	n/a	n/a	81	n/a	0	circle.bmp
+280.3598181818	n/a	70089.9545	show_cross	n/a	n/a	82	n/a	n/a	cross.bmp
+280.9516363636	n/a	70237.9091	show_face	famous_face	immediate_repeat	82	1	6	f030.bmp
+281.6889090909	n/a	70422.2273	right_press	n/a	n/a	82	n/a	4096	n/a
+281.8098181818	n/a	70452.4545	show_circle	n/a	n/a	82	n/a	0	circle.bmp
+283.50981818180003	n/a	70877.4545	show_cross	n/a	n/a	83	n/a	n/a	cross.bmp
+284.1252727273	n/a	71031.3182	show_face	famous_face	first_show	83	n/a	5	f102.bmp
+284.9161818182	n/a	71229.0455	right_press	n/a	n/a	83	n/a	4096	n/a
+285.138	n/a	71284.5	show_circle	n/a	n/a	83	n/a	0	circle.bmp
+286.838	n/a	71709.5	show_cross	n/a	n/a	84	n/a	n/a	cross.bmp
+287.48345454549997	n/a	71870.8636	show_face	famous_face	immediate_repeat	84	1	6	f102.bmp
+288.1661818182	n/a	72041.5455	right_press	n/a	n/a	84	n/a	4096	n/a
+288.4389090909	n/a	72109.7273	show_circle	n/a	n/a	84	n/a	0	circle.bmp
+290.13890909090003	n/a	72534.7273	show_cross	n/a	n/a	85	n/a	n/a	cross.bmp
+290.6234545455	n/a	72655.8636	show_face	unfamiliar_face	first_show	85	n/a	13	u135.bmp
+291.3061818182	n/a	72826.5455	left_press	n/a	n/a	85	n/a	256	n/a
+291.618	n/a	72904.5	show_circle	n/a	n/a	85	n/a	0	circle.bmp
+293.318	n/a	73329.5	show_cross	n/a	n/a	86	n/a	n/a	cross.bmp
+293.7807272727	n/a	73445.1818	show_face	scrambled_face	delayed_repeat	86	10	19	s127.bmp
+294.6289090909	n/a	73657.2273	right_press	n/a	n/a	86	n/a	4096	n/a
+294.6416363636	n/a	73660.4091	show_circle	n/a	n/a	86	n/a	0	circle.bmp
+296.3416363636	n/a	74085.4091	show_cross	n/a	n/a	87	n/a	n/a	cross.bmp
+296.9552727273	n/a	74238.8182	show_face	scrambled_face	first_show	87	n/a	17	s019.bmp
+297.4952727273	n/a	74373.8182	right_press	n/a	n/a	87	n/a	4096	n/a
+297.8725454545	n/a	74468.1364	show_circle	n/a	n/a	87	n/a	0	circle.bmp
+299.5725454545	n/a	74893.1364	show_cross	n/a	n/a	88	n/a	n/a	cross.bmp
+300.1961818182	n/a	75049.0455	show_face	scrambled_face	immediate_repeat	88	1	18	s019.bmp
+300.6707272727	n/a	75167.6818	right_press	n/a	n/a	88	n/a	4096	n/a
+301.148	n/a	75287.0	show_circle	n/a	n/a	88	n/a	0	circle.bmp
+302.848	n/a	75712.0	show_cross	n/a	n/a	89	n/a	n/a	cross.bmp
+303.3361818182	n/a	75834.0455	show_face	scrambled_face	delayed_repeat	89	11	19	s058.bmp
+303.8152727273	n/a	75953.8182	right_press	n/a	n/a	89	n/a	4096	n/a
+304.3270909091	n/a	76081.7727	show_circle	n/a	n/a	89	n/a	0	circle.bmp
+306.0270909091	n/a	76506.7727	show_cross	n/a	n/a	90	n/a	n/a	cross.bmp
+306.5770909091	n/a	76644.2727	show_face	scrambled_face	first_show	90	n/a	17	s105.bmp
+307.3125454545	n/a	76828.1364	right_press	n/a	n/a	90	n/a	4096	n/a
+307.5934545455	n/a	76898.3636	show_circle	n/a	n/a	90	n/a	0	circle.bmp
+309.29345454549997	n/a	77323.3636	show_cross	n/a	n/a	91	n/a	n/a	cross.bmp
+309.7516363636	n/a	77437.9091	show_face	scrambled_face	first_show	91	n/a	17	s079.bmp
+310.4734545455	n/a	77618.3636	right_press	n/a	n/a	91	n/a	4096	n/a
+310.7225454545	n/a	77680.6364	show_circle	n/a	n/a	91	n/a	0	circle.bmp
+312.4225454545	n/a	78105.6364	show_cross	n/a	n/a	92	n/a	n/a	cross.bmp
+313.0425454545	n/a	78260.6364	show_face	famous_face	first_show	92	n/a	5	f117.bmp
+313.7525454545	n/a	78438.1364	left_press	n/a	n/a	92	n/a	256	n/a
+314.00072727270003	n/a	78500.1818	show_circle	n/a	n/a	92	n/a	0	circle.bmp
+315.7007272727	n/a	78925.1818	show_cross	n/a	n/a	93	n/a	n/a	cross.bmp
+316.2007272727	n/a	79050.1818	show_face	unfamiliar_face	first_show	93	n/a	13	u150.bmp
+317.188	n/a	79297.0	show_circle	n/a	n/a	93	n/a	0	circle.bmp
+318.888	n/a	79722.0	show_cross	n/a	n/a	94	n/a	n/a	cross.bmp
+319.44072727270003	n/a	79860.1818	show_face	unfamiliar_face	delayed_repeat	94	9	15	u135.bmp
+320.09527272729997	n/a	80023.8182	left_press	n/a	n/a	94	n/a	256	n/a
+320.318	n/a	80079.5	show_circle	n/a	n/a	94	n/a	0	circle.bmp
+322.018	n/a	80504.5	show_cross	n/a	n/a	95	n/a	n/a	cross.bmp
+322.5470909091	n/a	80636.7727	show_face	scrambled_face	first_show	95	n/a	17	s132.bmp
+323.318	n/a	80829.5	right_press	n/a	n/a	95	n/a	4096	n/a
+323.3734545455	n/a	80843.3636	show_circle	n/a	n/a	95	n/a	0	circle.bmp
+325.0734545455	n/a	81268.3636	show_cross	n/a	n/a	96	n/a	n/a	cross.bmp
+325.538	n/a	81384.5	show_face	famous_face	first_show	96	n/a	5	f008.bmp
+326.1543636364	n/a	81538.5909	right_press	n/a	n/a	96	n/a	4096	n/a
+326.3752727273	n/a	81593.8182	show_circle	n/a	n/a	96	n/a	0	circle.bmp
+328.0752727273	n/a	82018.8182	show_cross	n/a	n/a	97	n/a	n/a	cross.bmp
+328.6952727273	n/a	82173.8182	show_face	famous_face	immediate_repeat	97	1	6	f008.bmp
+329.2752727273	n/a	82318.8182	right_press	n/a	n/a	97	n/a	4096	n/a
+329.7061818182	n/a	82426.5455	show_circle	n/a	n/a	97	n/a	0	circle.bmp
+331.4061818182	n/a	82851.5455	show_cross	n/a	n/a	98	n/a	n/a	cross.bmp
+331.8689090909	n/a	82967.2273	show_face	scrambled_face	delayed_repeat	98	8	19	s105.bmp
+332.6161818182	n/a	83154.0455	right_press	n/a	n/a	98	n/a	4096	n/a
+332.7343636364	n/a	83183.5909	show_circle	n/a	n/a	98	n/a	0	circle.bmp
+334.4343636364	n/a	83608.5909	show_cross	n/a	n/a	99	n/a	n/a	cross.bmp
+335.0934545455	n/a	83773.3636	show_face	scrambled_face	first_show	99	n/a	17	s048.bmp
+335.91436363639997	n/a	83978.5909	left_press	n/a	n/a	99	n/a	256	n/a
+336.008	n/a	84002.0	show_circle	n/a	n/a	99	n/a	0	circle.bmp
+337.708	n/a	84427.0	show_cross	n/a	n/a	100	n/a	n/a	cross.bmp
+338.3507272727	n/a	84587.6818	show_face	scrambled_face	immediate_repeat	100	1	18	s048.bmp
+338.9916363636	n/a	84747.9091	right_press	n/a	n/a	100	n/a	4096	n/a
+339.1770909091	n/a	84794.2727	show_circle	n/a	n/a	100	n/a	0	circle.bmp
+340.8770909091	n/a	85219.2727	show_cross	n/a	n/a	101	n/a	n/a	cross.bmp
+341.408	n/a	85352.0	show_face	scrambled_face	delayed_repeat	101	10	19	s079.bmp
+342.0334545455	n/a	85508.3636	right_press	n/a	n/a	101	n/a	4096	n/a
+342.3289090909	n/a	85582.2273	show_circle	n/a	n/a	101	n/a	0	circle.bmp
+344.02890909089996	n/a	86007.2273	show_cross	n/a	n/a	102	n/a	n/a	cross.bmp
+344.548	n/a	86137.0	show_face	famous_face	first_show	102	n/a	5	f019.bmp
+345.168	n/a	86292.0	right_press	n/a	n/a	102	n/a	4096	n/a
+345.5461818182	n/a	86386.5455	show_circle	n/a	n/a	102	n/a	0	circle.bmp
+347.2461818182	n/a	86811.5455	show_cross	n/a	n/a	103	n/a	n/a	cross.bmp
+347.7225454545	n/a	86930.6364	show_face	famous_face	delayed_repeat	103	11	7	f117.bmp
+348.37163636360003	n/a	87092.9091	left_press	n/a	n/a	103	n/a	256	n/a
+348.63345454550006	n/a	87158.3636	show_circle	n/a	n/a	103	n/a	0	circle.bmp
+350.33345454550005	n/a	87583.3636	show_cross	n/a	n/a	104	n/a	n/a	cross.bmp
+350.82890909089997	n/a	87707.2273	show_face	famous_face	first_show	104	n/a	5	f005.bmp
+351.45345454550005	n/a	87863.3636	left_press	n/a	n/a	104	n/a	256	n/a
+351.808	n/a	87952.0	show_circle	n/a	n/a	104	n/a	0	circle.bmp
+353.508	n/a	88377.0	show_cross	n/a	n/a	105	n/a	n/a	cross.bmp
+354.0370909091	n/a	88509.2727	show_face	famous_face	immediate_repeat	105	1	6	f005.bmp
+354.69254545449996	n/a	88673.1364	right_press	n/a	n/a	105	n/a	4096	n/a
+354.9043636364	n/a	88726.0909	show_circle	n/a	n/a	105	n/a	0	circle.bmp
+356.60436363639997	n/a	89151.0909	show_cross	n/a	n/a	106	n/a	n/a	cross.bmp
+357.2270909091	n/a	89306.7727	show_face	unfamiliar_face	delayed_repeat	106	13	15	u150.bmp
+358.0798181818	n/a	89519.9545	show_circle	n/a	n/a	106	n/a	0	circle.bmp
+358.1198181818	n/a	89529.9545	left_press	n/a	n/a	106	n/a	256	n/a
+359.7798181818	n/a	89944.9545	show_cross	n/a	n/a	107	n/a	n/a	cross.bmp
+360.2507272727	n/a	90062.6818	show_face	famous_face	first_show	107	n/a	5	f050.bmp
+360.888	n/a	90222.0	right_press	n/a	n/a	107	n/a	4096	n/a
+361.14072727269996	n/a	90285.1818	show_circle	n/a	n/a	107	n/a	0	circle.bmp
+362.84072727269995	n/a	90710.1818	show_cross	n/a	n/a	108	n/a	n/a	cross.bmp
+363.458	n/a	90864.5	show_face	scrambled_face	delayed_repeat	108	13	19	s132.bmp
+363.9807272727	n/a	90995.1818	right_press	n/a	n/a	108	n/a	4096	n/a
+364.4643636364	n/a	91116.0909	show_circle	n/a	n/a	108	n/a	0	circle.bmp
+366.16436363639997	n/a	91541.0909	show_cross	n/a	n/a	109	n/a	n/a	cross.bmp
+366.8161818182	n/a	91704.0455	show_face	unfamiliar_face	first_show	109	n/a	13	u147.bmp
+367.7489090909	n/a	91937.2273	show_circle	n/a	n/a	109	n/a	0	circle.bmp
+367.91436363639997	n/a	91978.5909	left_press	n/a	n/a	109	n/a	256	n/a
+369.4489090909	n/a	92362.2273	show_cross	n/a	n/a	110	n/a	n/a	cross.bmp
+370.05709090910005	n/a	92514.2727	show_face	famous_face	first_show	110	n/a	5	f085.bmp
+370.99527272730006	n/a	92748.8182	show_circle	n/a	n/a	110	n/a	0	circle.bmp
+371.13709090910004	n/a	92784.2727	left_press	n/a	n/a	110	n/a	256	n/a
+372.69527272730005	n/a	93173.8182	show_cross	n/a	n/a	111	n/a	n/a	cross.bmp
+373.2143636364	n/a	93303.5909	show_face	unfamiliar_face	first_show	111	n/a	13	u037.bmp
+374.00709090910004	n/a	93501.7727	right_press	n/a	n/a	111	n/a	4096	n/a
+374.0589090909	n/a	93514.7273	show_circle	n/a	n/a	111	n/a	0	circle.bmp
+375.7589090909	n/a	93939.7273	show_cross	n/a	n/a	112	n/a	n/a	cross.bmp
+376.238	n/a	94059.5	show_face	unfamiliar_face	immediate_repeat	112	1	14	u037.bmp
+376.9643636364	n/a	94241.0909	right_press	n/a	n/a	112	n/a	4096	n/a
+377.06527272730006	n/a	94266.3182	show_circle	n/a	n/a	112	n/a	0	circle.bmp
+378.76527272730004	n/a	94691.3182	show_cross	n/a	n/a	113	n/a	n/a	cross.bmp
+379.2952727273	n/a	94823.8182	show_face	famous_face	delayed_repeat	113	11	7	f019.bmp
+380.01072727269997	n/a	95002.6818	right_press	n/a	n/a	113	n/a	4096	n/a
+380.20345454550005	n/a	95050.8636	show_circle	n/a	n/a	113	n/a	0	circle.bmp
+381.90345454550004	n/a	95475.8636	show_cross	n/a	n/a	114	n/a	n/a	cross.bmp
+382.4698181818	n/a	95617.4545	show_face	scrambled_face	first_show	114	n/a	17	s118.bmp
+383.27254545449995	n/a	95818.1364	right_press	n/a	n/a	114	n/a	4096	n/a
+383.3243636364	n/a	95831.0909	show_circle	n/a	n/a	114	n/a	0	circle.bmp
+385.0243636364	n/a	96256.0909	show_cross	n/a	n/a	115	n/a	n/a	cross.bmp
+385.6598181818	n/a	96414.9545	show_face	scrambled_face	first_show	115	n/a	17	s103.bmp
+386.32890909089997	n/a	96582.2273	right_press	n/a	n/a	115	n/a	4096	n/a
+386.5589090909	n/a	96639.7273	show_circle	n/a	n/a	115	n/a	0	circle.bmp
+388.2589090909	n/a	97064.7273	show_cross	n/a	n/a	116	n/a	n/a	cross.bmp
+388.83345454550005	n/a	97208.3636	show_face	famous_face	delayed_repeat	116	9	7	f050.bmp
+389.4798181818	n/a	97369.9545	right_press	n/a	n/a	116	n/a	4096	n/a
+389.7934545455	n/a	97448.3636	show_circle	n/a	n/a	116	n/a	0	circle.bmp
+391.4934545455	n/a	97873.3636	show_cross	n/a	n/a	117	n/a	n/a	cross.bmp
+392.0243636364	n/a	98006.0909	show_face	unfamiliar_face	first_show	117	n/a	13	u103.bmp
+392.60072727269994	n/a	98150.1818	right_press	n/a	n/a	117	n/a	4096	n/a
+393.02254545449995	n/a	98255.6364	show_circle	n/a	n/a	117	n/a	0	circle.bmp
+394.7225454545	n/a	98680.6364	show_cross	n/a	n/a	118	n/a	n/a	cross.bmp
+395.21527272730003	n/a	98803.8182	show_face	unfamiliar_face	delayed_repeat	118	9	15	u147.bmp
+395.7489090909	n/a	98937.2273	right_press	n/a	n/a	118	n/a	4096	n/a
+396.1289090909	n/a	99032.2273	show_circle	n/a	n/a	118	n/a	0	circle.bmp
+397.82890909089997	n/a	99457.2273	show_cross	n/a	n/a	119	n/a	n/a	cross.bmp
+398.33890909089996	n/a	99584.7273	show_face	famous_face	first_show	119	n/a	5	f083.bmp
+398.9116363636	n/a	99727.9091	right_press	n/a	n/a	119	n/a	4096	n/a
+399.1807272727	n/a	99795.1818	show_circle	n/a	n/a	119	n/a	0	circle.bmp
+400.88072727269997	n/a	100220.1818	show_cross	n/a	n/a	120	n/a	n/a	cross.bmp
+401.4461818182	n/a	100361.5455	show_face	famous_face	delayed_repeat	120	10	7	f085.bmp
+402.3561818182	n/a	100589.0455	show_circle	n/a	n/a	120	n/a	0	circle.bmp
+402.38709090910004	n/a	100596.7727	right_press	n/a	n/a	120	n/a	4096	n/a
+404.0561818182	n/a	101014.0455	show_cross	n/a	n/a	121	n/a	n/a	cross.bmp
+404.5861818182	n/a	101146.5455	show_face	unfamiliar_face	first_show	121	n/a	13	u085.bmp
+405.418	n/a	101354.5	right_press	n/a	n/a	121	n/a	4096	n/a
+405.518	n/a	101379.5	show_circle	n/a	n/a	121	n/a	0	circle.bmp
+407.218	n/a	101804.5	show_cross	n/a	n/a	122	n/a	n/a	cross.bmp
+407.8443636364	n/a	101961.0909	show_face	unfamiliar_face	immediate_repeat	122	1	14	u085.bmp
+408.568	n/a	102142.0	right_press	n/a	n/a	122	n/a	4096	n/a
+408.7343636364	n/a	102183.5909	show_circle	n/a	n/a	122	n/a	0	circle.bmp
+410.4343636364	n/a	102608.5909	show_cross	n/a	n/a	123	n/a	n/a	cross.bmp
+411.068	n/a	102767.0	show_face	famous_face	first_show	123	n/a	5	f072.bmp
+411.8189090909	n/a	102954.7273	left_press	n/a	n/a	123	n/a	256	n/a
+412.05709090910005	n/a	103014.2727	show_circle	n/a	n/a	123	n/a	0	circle.bmp
+413.75709090910004	n/a	103439.2727	show_cross	n/a	n/a	124	n/a	n/a	cross.bmp
+414.3089090909	n/a	103577.2273	show_face	famous_face	immediate_repeat	124	1	6	f072.bmp
+414.9961818182	n/a	103749.0455	left_press	n/a	n/a	124	n/a	256	n/a
+415.31527272730006	n/a	103828.8182	show_circle	n/a	n/a	124	n/a	0	circle.bmp
+417.01527272730004	n/a	104253.8182	show_cross	n/a	n/a	125	n/a	n/a	cross.bmp
+417.6498181818	n/a	104412.4545	show_face	scrambled_face	delayed_repeat	125	11	19	s118.bmp
+418.2852727273	n/a	104571.3182	right_press	n/a	n/a	125	n/a	4096	n/a
+418.5089090909	n/a	104627.2273	show_circle	n/a	n/a	125	n/a	0	circle.bmp
+420.20890909089997	n/a	105052.2273	show_cross	n/a	n/a	126	n/a	n/a	cross.bmp
+420.7407272727	n/a	105185.1818	show_face	scrambled_face	first_show	126	n/a	17	s097.bmp
+421.65527272730003	n/a	105413.8182	show_circle	n/a	n/a	126	n/a	0	circle.bmp
+421.6561818182	n/a	105414.0455	right_press	n/a	n/a	126	n/a	4096	n/a
+423.3552727273	n/a	105838.8182	show_cross	n/a	n/a	127	n/a	n/a	cross.bmp
+423.9307272727	n/a	105982.6818	show_face	scrambled_face	delayed_repeat	127	12	19	s103.bmp
+424.58527272730004	n/a	106146.3182	right_press	n/a	n/a	127	n/a	4096	n/a
+424.8261818182	n/a	106206.5455	show_circle	n/a	n/a	127	n/a	0	circle.bmp
+426.5261818182	n/a	106631.5455	show_cross	n/a	n/a	128	n/a	n/a	cross.bmp
+427.1716363636	n/a	106792.9091	show_face	famous_face	first_show	128	n/a	5	f029.bmp
+427.3052727273	n/a	106826.3182	right_press	n/a	n/a	128	n/a	4096	n/a
+428.1125454545	n/a	107028.1364	show_circle	n/a	n/a	128	n/a	0	circle.bmp
+429.81254545449997	n/a	107453.1364	show_cross	n/a	n/a	129	n/a	n/a	cross.bmp
+430.2961818182	n/a	107574.0455	show_face	famous_face	immediate_repeat	129	1	6	f029.bmp
+430.8734545455	n/a	107718.3636	right_press	n/a	n/a	129	n/a	4096	n/a
+431.2425454545	n/a	107810.6364	show_circle	n/a	n/a	129	n/a	0	circle.bmp
+432.94254545449996	n/a	108235.6364	show_cross	n/a	n/a	130	n/a	n/a	cross.bmp
+433.56981818180003	n/a	108392.4545	show_face	unfamiliar_face	delayed_repeat	130	13	15	u103.bmp
+434.3443636364	n/a	108586.0909	right_press	n/a	n/a	130	n/a	4096	n/a
+434.4916363636	n/a	108622.9091	show_circle	n/a	n/a	130	n/a	0	circle.bmp
+436.1916363636	n/a	109047.9091	show_cross	n/a	n/a	131	n/a	n/a	cross.bmp
+436.6934545455	n/a	109173.3636	show_face	unfamiliar_face	first_show	131	n/a	13	u001.bmp
+437.2534545455	n/a	109313.3636	left_press	n/a	n/a	131	n/a	256	n/a
+437.6889090909	n/a	109422.2273	show_circle	n/a	n/a	131	n/a	0	circle.bmp
+439.3889090909	n/a	109847.2273	show_cross	n/a	n/a	132	n/a	n/a	cross.bmp
+439.85072727269994	n/a	109962.6818	show_face	unfamiliar_face	immediate_repeat	132	1	14	u001.bmp
+440.31254545449997	n/a	110078.1364	left_press	n/a	n/a	132	n/a	256	n/a
+440.83527272730004	n/a	110208.8182	show_circle	n/a	n/a	132	n/a	0	circle.bmp
+442.5352727273	n/a	110633.8182	show_cross	n/a	n/a	133	n/a	n/a	cross.bmp
+443.1261818182	n/a	110781.5455	show_face	famous_face	delayed_repeat	133	14	7	f083.bmp
+443.6707272727	n/a	110917.6818	right_press	n/a	n/a	133	n/a	4096	n/a
+444.0116363636	n/a	111002.9091	show_circle	n/a	n/a	133	n/a	0	circle.bmp
+445.7116363636	n/a	111427.9091	show_cross	n/a	n/a	134	n/a	n/a	cross.bmp
+446.1989090909	n/a	111549.7273	show_face	scrambled_face	first_show	134	n/a	17	s078.bmp
+446.8625454545	n/a	111715.6364	right_press	n/a	n/a	134	n/a	4096	n/a
+447.07709090910004	n/a	111769.2727	show_circle	n/a	n/a	134	n/a	0	circle.bmp
+448.7770909091	n/a	112194.2727	show_cross	n/a	n/a	135	n/a	n/a	cross.bmp
+449.2898181818	n/a	112322.4545	show_face	unfamiliar_face	first_show	135	n/a	13	u122.bmp
+450.0007272727	n/a	112500.1818	left_press	n/a	n/a	135	n/a	256	n/a
+450.2252727273	n/a	112556.3182	show_circle	n/a	n/a	135	n/a	0	circle.bmp
+451.9252727273	n/a	112981.3182	show_cross	n/a	n/a	136	n/a	n/a	cross.bmp
+452.4298181818	n/a	113107.4545	show_face	unfamiliar_face	immediate_repeat	136	1	14	u122.bmp
+452.9098181818	n/a	113227.4545	left_press	n/a	n/a	136	n/a	256	n/a
+453.3007272727	n/a	113325.1818	show_circle	n/a	n/a	136	n/a	0	circle.bmp
+455.0007272727	n/a	113750.1818	show_cross	n/a	n/a	137	n/a	n/a	cross.bmp
+455.45345454550005	n/a	113863.3636	show_face	famous_face	first_show	137	n/a	5	f150.bmp
+456.01527272730004	n/a	114003.8182	right_press	n/a	n/a	137	n/a	4096	n/a
+456.32709090910004	n/a	114081.7727	show_circle	n/a	n/a	137	n/a	0	circle.bmp
+458.0270909091	n/a	114506.7727	show_cross	n/a	n/a	138	n/a	n/a	cross.bmp
+458.5607272727	n/a	114640.1818	show_face	scrambled_face	delayed_repeat	138	12	19	s097.bmp
+459.428	n/a	114857.0	show_circle	n/a	n/a	138	n/a	0	circle.bmp
+459.568	n/a	114892.0	right_press	n/a	n/a	138	n/a	4096	n/a
+461.128	n/a	115282.0	show_cross	n/a	n/a	139	n/a	n/a	cross.bmp
+461.768	n/a	115442.0	show_face	unfamiliar_face	first_show	139	n/a	13	u101.bmp
+461.99709090910005	n/a	115499.2727	left_press	n/a	n/a	139	n/a	256	n/a
+462.7861818182	n/a	115696.5455	show_circle	n/a	n/a	139	n/a	0	circle.bmp
+464.4861818182	n/a	116121.5455	show_cross	n/a	n/a	140	n/a	n/a	cross.bmp
+465.1098181818	n/a	116277.4545	show_face	unfamiliar_face	first_show	140	n/a	13	u047.bmp
+465.89527272730004	n/a	116473.8182	left_press	n/a	n/a	140	n/a	256	n/a
+465.9498181818	n/a	116487.4545	show_circle	n/a	n/a	140	n/a	0	circle.bmp
+467.6498181818	n/a	116912.4545	show_cross	n/a	n/a	141	n/a	n/a	cross.bmp
+468.2498181818	n/a	117062.4545	show_face	unfamiliar_face	immediate_repeat	141	1	14	u047.bmp
+468.78345454550004	n/a	117195.8636	left_press	n/a	n/a	141	n/a	256	n/a
+469.1289090909	n/a	117282.2273	show_circle	n/a	n/a	141	n/a	0	circle.bmp
+470.82890909089997	n/a	117707.2273	show_cross	n/a	n/a	142	n/a	n/a	cross.bmp
+471.4407272727	n/a	117860.1818	show_face	scrambled_face	first_show	142	n/a	17	s054.bmp
+472.26527272730004	n/a	118066.3182	show_circle	n/a	n/a	142	n/a	0	circle.bmp
+472.29709090910006	n/a	118074.2727	right_press	n/a	n/a	142	n/a	4096	n/a
+473.96527272730003	n/a	118491.3182	show_cross	n/a	n/a	143	n/a	n/a	cross.bmp
+474.5816363636	n/a	118645.4091	show_face	scrambled_face	delayed_repeat	143	9	19	s078.bmp
+475.2443636364	n/a	118811.0909	right_press	n/a	n/a	143	n/a	4096	n/a
+475.50254545449997	n/a	118875.6364	show_circle	n/a	n/a	143	n/a	0	circle.bmp
+477.20254545449995	n/a	119300.6364	show_cross	n/a	n/a	144	n/a	n/a	cross.bmp
+477.78890909089995	n/a	119447.2273	show_face	famous_face	first_show	144	n/a	5	f016.bmp
+478.308	n/a	119577.0	right_press	n/a	n/a	144	n/a	4096	n/a
+478.7743636364	n/a	119693.5909	show_circle	n/a	n/a	144	n/a	0	circle.bmp
+480.47436363639997	n/a	120118.5909	show_cross	n/a	n/a	145	n/a	n/a	cross.bmp
+481.0798181818	n/a	120269.9545	show_face	famous_face	immediate_repeat	145	1	6	f016.bmp
+481.8043636364	n/a	120451.0909	right_press	n/a	n/a	145	n/a	4096	n/a
+481.9298181818	n/a	120482.4545	show_circle	n/a	n/a	145	n/a	0	circle.bmp
+483.6298181818	n/a	120907.4545	show_cross	n/a	n/a	146	n/a	n/a	cross.bmp
+484.1361818182	n/a	121034.0455	show_face	famous_face	first_show	146	n/a	5	f002.bmp
+484.8370909091	n/a	121209.2727	right_press	n/a	n/a	146	n/a	4096	n/a
+484.97436363639997	n/a	121243.5909	show_circle	n/a	n/a	146	n/a	0	circle.bmp
+486.6743636364	n/a	121668.5909	show_cross	n/a	n/a	147	n/a	n/a	cross.bmp
+487.2434545455	n/a	121810.8636	show_face	famous_face	immediate_repeat	147	1	6	f002.bmp
+487.7361818182	n/a	121934.0455	right_press	n/a	n/a	147	n/a	4096	n/a
+488.1052727273	n/a	122026.3182	show_circle	n/a	n/a	147	n/a	0	circle.bmp
+489.8052727273	n/a	122451.3182	show_cross	n/a	n/a	148	n/a	n/a	cross.bmp
+490.26709090910003	n/a	122566.7727	show_face	famous_face	delayed_repeat	148	11	7	f150.bmp
+491.1107272727	n/a	122777.6818	show_circle	n/a	n/a	148	n/a	0	circle.bmp
+492.8107272727	n/a	123202.6818	show_cross	n/a	n/a	149	n/a	n/a	cross.bmp

--- a/eeg_hed_small/sub-003/eeg/sub-003_task-FacePerception_run-1_events.tsv
+++ b/eeg_hed_small/sub-003/eeg/sub-003_task-FacePerception_run-1_events.tsv
@@ -1,591 +1,591 @@
-onset	duration	sample	event_type	face_type	repetition_type	trigger	stim_file
-0.0040000000	n/a	1	setup	n/a	n/a	n/a	n/a
-0.0040000000	n/a	1	right_sym	n/a	n/a	n/a	n/a
-25.1161818182	n/a	6279.0455	show_face	famous_face	first_show	5	f074.bmp
-25.9789090909	n/a	6494.7273	show_circle	n/a	n/a	0	circle.bmp
-26.0261818182	n/a	6506.5455	left_press	n/a	n/a	256	n/a
-27.6789090909	n/a	6919.7273	show_cross	n/a	n/a	n/a	cross.bmp
-28.1734545455	n/a	7043.3636	show_face	unfamiliar_face	first_show	13	u011.bmp
-29.0598181818	n/a	7264.9545	show_circle	n/a	n/a	0	circle.bmp
-29.1116363636	n/a	7277.9091	left_press	n/a	n/a	256	n/a
-30.7598181818	n/a	7689.9545	show_cross	n/a	n/a	n/a	cross.bmp
-31.3307272727	n/a	7832.6818	show_face	scrambled_face	first_show	17	s036.bmp
-32.2798181818	n/a	8069.9545	show_circle	n/a	n/a	0	circle.bmp
-32.2952727273	n/a	8073.8182	left_press	n/a	n/a	256	n/a
-33.9798181818	n/a	8494.9545	show_cross	n/a	n/a	n/a	cross.bmp
-34.4380000000	n/a	8609.5	show_face	famous_face	first_show	5	f112.bmp
-35.0207272727	n/a	8755.1818	right_press	n/a	n/a	4096	n/a
-35.4343636364	n/a	8858.5909	show_circle	n/a	n/a	0	circle.bmp
-37.1343636364	n/a	9283.5909	show_cross	n/a	n/a	n/a	cross.bmp
-37.7789090909	n/a	9444.7273	show_face	famous_face	immediate_repeat	6	f112.bmp
-38.3270909091	n/a	9581.7727	right_press	n/a	n/a	4096	n/a
-38.6825454545	n/a	9670.6364	show_circle	n/a	n/a	0	circle.bmp
-40.3825454545	n/a	10095.6364	show_cross	n/a	n/a	n/a	cross.bmp
-40.9698181818	n/a	10242.4545	show_face	unfamiliar_face	first_show	13	u066.bmp
-41.5543636364	n/a	10388.5909	left_press	n/a	n/a	256	n/a
-41.9298181818	n/a	10482.4545	show_circle	n/a	n/a	0	circle.bmp
-43.6298181818	n/a	10907.4545	show_cross	n/a	n/a	n/a	cross.bmp
-44.2770909091	n/a	11069.2727	show_face	unfamiliar_face	immediate_repeat	14	u066.bmp
-44.7452727273	n/a	11186.3182	left_press	n/a	n/a	256	n/a
-45.1461818182	n/a	11286.5455	show_circle	n/a	n/a	0	circle.bmp
-46.8461818182	n/a	11711.5455	show_cross	n/a	n/a	n/a	cross.bmp
-47.3507272727	n/a	11837.6818	show_face	unfamiliar_face	first_show	13	u113.bmp
-47.9570909091	n/a	11989.2727	right_press	n/a	n/a	4096	n/a
-48.2598181818	n/a	12064.9545	show_circle	n/a	n/a	0	circle.bmp
-49.9598181818	n/a	12489.9545	show_cross	n/a	n/a	n/a	cross.bmp
-50.5080000000	n/a	12627	show_face	unfamiliar_face	immediate_repeat	14	u113.bmp
-51.2570909091	n/a	12814.2727	right_press	n/a	n/a	4096	n/a
-51.4098181818	n/a	12852.4545	show_circle	n/a	n/a	0	circle.bmp
-53.1098181818	n/a	13277.4545	show_cross	n/a	n/a	n/a	cross.bmp
-53.5825454545	n/a	13395.6364	show_face	famous_face	delayed_repeat	7	f074.bmp
-54.2698181818	n/a	13567.4545	left_press	n/a	n/a	256	n/a
-54.4843636364	n/a	13621.0909	show_circle	n/a	n/a	0	circle.bmp
-56.1843636364	n/a	14046.0909	show_cross	n/a	n/a	n/a	cross.bmp
-56.6561818182	n/a	14164.0455	show_face	scrambled_face	first_show	17	s100.bmp
-57.5234545455	n/a	14380.8636	show_circle	n/a	n/a	0	circle.bmp
-57.6107272727	n/a	14402.6818	right_press	n/a	n/a	4096	n/a
-59.2234545455	n/a	14805.8636	show_cross	n/a	n/a	n/a	cross.bmp
-59.7798181818	n/a	14944.9545	show_face	scrambled_face	immediate_repeat	18	s100.bmp
-60.3152727273	n/a	15078.8182	right_press	n/a	n/a	4096	n/a
-60.6907272727	n/a	15172.6818	show_circle	n/a	n/a	0	circle.bmp
-62.3907272727	n/a	15597.6818	show_cross	n/a	n/a	n/a	cross.bmp
-62.9370909091	n/a	15734.2727	show_face	unfamiliar_face	delayed_repeat	15	u011.bmp
-63.6552727273	n/a	15913.8182	left_press	n/a	n/a	256	n/a
-63.8470909091	n/a	15961.7727	show_circle	n/a	n/a	0	circle.bmp
-65.5470909091	n/a	16386.7727	show_cross	n/a	n/a	n/a	cross.bmp
-66.1607272727	n/a	16540.1818	show_face	unfamiliar_face	first_show	13	u069.bmp
-67.0743636364	n/a	16768.5909	show_circle	n/a	n/a	0	circle.bmp
-67.2280000000	n/a	16807	right_press	n/a	n/a	4096	n/a
-68.7743636364	n/a	17193.5909	show_cross	n/a	n/a	n/a	cross.bmp
-69.3689090909	n/a	17342.2273	show_face	unfamiliar_face	immediate_repeat	14	u069.bmp
-69.9052727273	n/a	17476.3182	right_press	n/a	n/a	4096	n/a
-70.1970909091	n/a	17549.2727	show_circle	n/a	n/a	0	circle.bmp
-71.8970909091	n/a	17974.2727	show_cross	n/a	n/a	n/a	cross.bmp
-72.3925454545	n/a	18098.1364	show_face	scrambled_face	delayed_repeat	19	s036.bmp
-73.2898181818	n/a	18322.4545	show_circle	n/a	n/a	0	circle.bmp
-73.4643636364	n/a	18366.0909	right_press	n/a	n/a	4096	n/a
-74.9898181818	n/a	18747.4545	show_cross	n/a	n/a	n/a	cross.bmp
-75.6325454545	n/a	18908.1364	show_face	famous_face	first_show	5	f039.bmp
-76.3680000000	n/a	19092	right_press	n/a	n/a	4096	n/a
-76.6343636364	n/a	19158.5909	show_circle	n/a	n/a	0	circle.bmp
-78.3343636364	n/a	19583.5909	show_cross	n/a	n/a	n/a	cross.bmp
-78.9570909091	n/a	19739.2727	show_face	famous_face	first_show	5	f020.bmp
-79.6643636364	n/a	19916.0909	right_press	n/a	n/a	4096	n/a
-79.8807272727	n/a	19970.1818	show_circle	n/a	n/a	0	circle.bmp
-81.5807272727	n/a	20395.1818	show_cross	n/a	n/a	n/a	cross.bmp
-82.1643636364	n/a	20541.0909	show_face	famous_face	first_show	5	f101.bmp
-82.7389090909	n/a	20684.7273	right_press	n/a	n/a	4096	n/a
-83.0752727273	n/a	20768.8182	show_circle	n/a	n/a	0	circle.bmp
-84.7752727273	n/a	21193.8182	show_cross	n/a	n/a	n/a	cross.bmp
-85.3725454545	n/a	21343.1364	show_face	scrambled_face	first_show	17	s058.bmp
-86.0489090909	n/a	21512.2273	left_press	n/a	n/a	256	n/a
-86.2352727273	n/a	21558.8182	show_circle	n/a	n/a	0	circle.bmp
-87.9352727273	n/a	21983.8182	show_cross	n/a	n/a	n/a	cross.bmp
-88.4625454545	n/a	22115.6364	show_face	scrambled_face	immediate_repeat	18	s058.bmp
-89.0125454545	n/a	22253.1364	left_press	n/a	n/a	256	n/a
-89.4780000000	n/a	22369.5	show_circle	n/a	n/a	0	circle.bmp
-91.1780000000	n/a	22794.5	show_cross	n/a	n/a	n/a	cross.bmp
-91.8370909091	n/a	22959.2727	show_face	unfamiliar_face	first_show	13	u061.bmp
-92.4243636364	n/a	23106.0909	right_press	n/a	n/a	4096	n/a
-92.7425454545	n/a	23185.6364	show_circle	n/a	n/a	0	circle.bmp
-94.4425454545	n/a	23610.6364	show_cross	n/a	n/a	n/a	cross.bmp
-94.9270909091	n/a	23731.7727	show_face	unfamiliar_face	immediate_repeat	14	u061.bmp
-95.5016363636	n/a	23875.4091	right_press	n/a	n/a	4096	n/a
-95.8570909091	n/a	23964.2727	show_circle	n/a	n/a	0	circle.bmp
-97.5570909091	n/a	24389.2727	show_cross	n/a	n/a	n/a	cross.bmp
-98.1180000000	n/a	24529.5	show_face	famous_face	first_show	5	f105.bmp
-98.6680000000	n/a	24667	right_press	n/a	n/a	4096	n/a
-99.0398181818	n/a	24759.9545	show_circle	n/a	n/a	0	circle.bmp
-100.7398181818	n/a	25184.9545	show_cross	n/a	n/a	n/a	cross.bmp
-101.3589090909	n/a	25339.7273	show_face	famous_face	delayed_repeat	7	f039.bmp
-102.0052727273	n/a	25501.3182	right_press	n/a	n/a	4096	n/a
-102.2907272727	n/a	25572.6818	show_circle	n/a	n/a	0	circle.bmp
-103.9907272727	n/a	25997.6818	show_cross	n/a	n/a	n/a	cross.bmp
-104.4661818182	n/a	26116.5455	show_face	famous_face	first_show	5	f138.bmp
-105.1780000000	n/a	26294.5	right_press	n/a	n/a	4096	n/a
-105.2889090909	n/a	26322.2273	show_circle	n/a	n/a	0	circle.bmp
-106.9889090909	n/a	26747.2273	show_cross	n/a	n/a	n/a	cross.bmp
-107.5070909091	n/a	26876.7727	show_face	famous_face	delayed_repeat	7	f020.bmp
-108.3252727273	n/a	27081.3182	right_press	n/a	n/a	4096	n/a
-108.4352727273	n/a	27108.8182	show_circle	n/a	n/a	0	circle.bmp
-110.1352727273	n/a	27533.8182	show_cross	n/a	n/a	n/a	cross.bmp
-110.7970909091	n/a	27699.2727	show_face	famous_face	first_show	5	f064.bmp
-111.4734545455	n/a	27868.3636	right_press	n/a	n/a	4096	n/a
-111.6761818182	n/a	27919.0455	show_circle	n/a	n/a	0	circle.bmp
-113.3761818182	n/a	28344.0455	show_cross	n/a	n/a	n/a	cross.bmp
-113.8543636364	n/a	28463.5909	show_face	famous_face	immediate_repeat	6	f064.bmp
-114.4052727273	n/a	28601.3182	right_press	n/a	n/a	4096	n/a
-114.6734545455	n/a	28668.3636	show_circle	n/a	n/a	0	circle.bmp
-116.3734545455	n/a	29093.3636	show_cross	n/a	n/a	n/a	cross.bmp
-116.9289090909	n/a	29232.2273	show_face	famous_face	delayed_repeat	7	f101.bmp
-117.5816363636	n/a	29395.4091	right_press	n/a	n/a	4096	n/a
-117.8807272727	n/a	29470.1818	show_circle	n/a	n/a	0	circle.bmp
-119.5807272727	n/a	29895.1818	show_cross	n/a	n/a	n/a	cross.bmp
-120.1025454545	n/a	30025.6364	show_face	unfamiliar_face	first_show	13	u127.bmp
-120.6807272727	n/a	30170.1818	left_press	n/a	n/a	256	n/a
-120.9898181818	n/a	30247.4545	show_circle	n/a	n/a	0	circle.bmp
-122.6898181818	n/a	30672.4545	show_cross	n/a	n/a	n/a	cross.bmp
-123.2425454545	n/a	30810.6364	show_face	scrambled_face	first_show	17	s103.bmp
-124.1280000000	n/a	31032	show_circle	n/a	n/a	0	circle.bmp
-124.2616363636	n/a	31065.4091	left_press	n/a	n/a	256	n/a
-125.8280000000	n/a	31457	show_cross	n/a	n/a	n/a	cross.bmp
-126.3661818182	n/a	31591.5455	show_face	unfamiliar_face	first_show	13	u143.bmp
-126.9743636364	n/a	31743.5909	left_press	n/a	n/a	256	n/a
-127.2743636364	n/a	31818.5909	show_circle	n/a	n/a	0	circle.bmp
-128.9743636364	n/a	32243.5909	show_cross	n/a	n/a	n/a	cross.bmp
-129.5407272727	n/a	32385.1818	show_face	famous_face	delayed_repeat	7	f105.bmp
-130.1416363636	n/a	32535.4091	right_press	n/a	n/a	4096	n/a
-130.4925454545	n/a	32623.1364	show_circle	n/a	n/a	0	circle.bmp
-132.1925454545	n/a	33048.1364	show_cross	n/a	n/a	n/a	cross.bmp
-132.7643636364	n/a	33191.0909	show_face	famous_face	first_show	5	f119.bmp
-133.3534545455	n/a	33338.3636	left_press	n/a	n/a	256	n/a
-133.6080000000	n/a	33402	show_circle	n/a	n/a	0	circle.bmp
-135.3080000000	n/a	33827	show_cross	n/a	n/a	n/a	cross.bmp
-135.9052727273	n/a	33976.3182	show_face	famous_face	immediate_repeat	6	f119.bmp
-136.4534545455	n/a	34113.3636	left_press	n/a	n/a	256	n/a
-136.9216363636	n/a	34230.4091	show_circle	n/a	n/a	0	circle.bmp
-138.6216363636	n/a	34655.4091	show_cross	n/a	n/a	n/a	cross.bmp
-139.2461818182	n/a	34811.5455	show_face	famous_face	delayed_repeat	7	f138.bmp
-139.8307272727	n/a	34957.6818	right_press	n/a	n/a	4096	n/a
-140.2098181818	n/a	35052.4545	show_circle	n/a	n/a	0	circle.bmp
-141.9098181818	n/a	35477.4545	show_cross	n/a	n/a	n/a	cross.bmp
-142.5543636364	n/a	35638.5909	show_face	unfamiliar_face	first_show	13	u074.bmp
-143.0743636364	n/a	35768.5909	left_press	n/a	n/a	256	n/a
-143.4480000000	n/a	35862	show_circle	n/a	n/a	0	circle.bmp
-145.1480000000	n/a	36287	show_cross	n/a	n/a	n/a	cross.bmp
-145.7443636364	n/a	36436.0909	show_face	unfamiliar_face	immediate_repeat	14	u074.bmp
-146.2316363636	n/a	36557.9091	left_press	n/a	n/a	256	n/a
-146.7252727273	n/a	36681.3182	show_circle	n/a	n/a	0	circle.bmp
-148.4252727273	n/a	37106.3182	show_cross	n/a	n/a	n/a	cross.bmp
-149.0689090909	n/a	37267.2273	show_face	unfamiliar_face	first_show	13	u134.bmp
-149.7352727273	n/a	37433.8182	left_press	n/a	n/a	256	n/a
-149.9625454545	n/a	37490.6364	show_circle	n/a	n/a	0	circle.bmp
-151.6625454545	n/a	37915.6364	show_cross	n/a	n/a	n/a	cross.bmp
-152.1261818182	n/a	38031.5455	show_face	unfamiliar_face	delayed_repeat	15	u127.bmp
-152.6370909091	n/a	38159.2727	right_press	n/a	n/a	4096	n/a
-153.0498181818	n/a	38262.4545	show_circle	n/a	n/a	0	circle.bmp
-154.7498181818	n/a	38687.4545	show_cross	n/a	n/a	n/a	cross.bmp
-155.3834545455	n/a	38845.8636	show_face	scrambled_face	first_show	17	s150.bmp
-156.3143636364	n/a	39078.5909	show_circle	n/a	n/a	0	circle.bmp
-156.5061818182	n/a	39126.5455	right_press	n/a	n/a	4096	n/a
-158.0143636364	n/a	39503.5909	show_cross	n/a	n/a	n/a	cross.bmp
-158.5752727273	n/a	39643.8182	show_face	scrambled_face	delayed_repeat	19	s103.bmp
-159.4952727273	n/a	39873.8182	right_press	n/a	n/a	4096	n/a
-159.4961818182	n/a	39874.0455	show_circle	n/a	n/a	0	circle.bmp
-161.1961818182	n/a	40299.0455	show_cross	n/a	n/a	n/a	cross.bmp
-161.8152727273	n/a	40453.8182	show_face	unfamiliar_face	first_show	13	u077.bmp
-162.3880000000	n/a	40597	left_press	n/a	n/a	256	n/a
-162.6416363636	n/a	40660.4091	show_circle	n/a	n/a	0	circle.bmp
-164.3416363636	n/a	41085.4091	show_cross	n/a	n/a	n/a	cross.bmp
-164.8552727273	n/a	41213.8182	show_face	unfamiliar_face	immediate_repeat	14	u077.bmp
-165.4570909091	n/a	41364.2727	left_press	n/a	n/a	256	n/a
-165.8652727273	n/a	41466.3182	show_circle	n/a	n/a	0	circle.bmp
-167.5652727273	n/a	41891.3182	show_cross	n/a	n/a	n/a	cross.bmp
-168.1298181818	n/a	42032.4545	show_face	unfamiliar_face	delayed_repeat	15	u143.bmp
-168.7543636364	n/a	42188.5909	left_press	n/a	n/a	256	n/a
-168.9934545455	n/a	42248.3636	show_circle	n/a	n/a	0	circle.bmp
-170.6934545455	n/a	42673.3636	show_cross	n/a	n/a	n/a	cross.bmp
-171.3370909091	n/a	42834.2727	show_face	scrambled_face	first_show	17	s026.bmp
-172.1070909091	n/a	43026.7727	right_press	n/a	n/a	4096	n/a
-172.3189090909	n/a	43079.7273	show_circle	n/a	n/a	0	circle.bmp
-174.0189090909	n/a	43504.7273	show_cross	n/a	n/a	n/a	cross.bmp
-174.5280000000	n/a	43632	show_face	scrambled_face	immediate_repeat	18	s026.bmp
-175.1616363636	n/a	43790.4091	right_press	n/a	n/a	4096	n/a
-175.3970909091	n/a	43849.2727	show_circle	n/a	n/a	0	circle.bmp
-177.0970909091	n/a	44274.2727	show_cross	n/a	n/a	n/a	cross.bmp
-177.6016363636	n/a	44400.4091	show_face	famous_face	first_show	5	f036.bmp
-178.2043636364	n/a	44551.0909	left_press	n/a	n/a	256	n/a
-178.5416363636	n/a	44635.4091	show_circle	n/a	n/a	0	circle.bmp
-180.2416363636	n/a	45060.4091	show_cross	n/a	n/a	n/a	cross.bmp
-180.7089090909	n/a	45177.2273	show_face	famous_face	immediate_repeat	6	f036.bmp
-181.2907272727	n/a	45322.6818	left_press	n/a	n/a	256	n/a
-181.7089090909	n/a	45427.2273	show_circle	n/a	n/a	0	circle.bmp
-183.4089090909	n/a	45852.2273	show_cross	n/a	n/a	n/a	cross.bmp
-183.8661818182	n/a	45966.5455	show_face	scrambled_face	first_show	17	s101.bmp
-184.6680000000	n/a	46167	right_press	n/a	n/a	4096	n/a
-184.6970909091	n/a	46174.2727	show_circle	n/a	n/a	0	circle.bmp
-186.3970909091	n/a	46599.2727	show_cross	n/a	n/a	n/a	cross.bmp
-186.9898181818	n/a	46747.4545	show_face	unfamiliar_face	delayed_repeat	15	u134.bmp
-187.8252727273	n/a	46956.3182	show_circle	n/a	n/a	0	circle.bmp
-188.3098181818	n/a	47077.4545	right_press	n/a	n/a	4096	n/a
-189.5252727273	n/a	47381.3182	show_cross	n/a	n/a	n/a	cross.bmp
-190.1134545455	n/a	47528.3636	show_face	unfamiliar_face	first_show	13	u016.bmp
-190.7298181818	n/a	47682.4545	left_press	n/a	n/a	256	n/a
-190.9589090909	n/a	47739.7273	show_circle	n/a	n/a	0	circle.bmp
-192.6589090909	n/a	48164.7273	show_cross	n/a	n/a	n/a	cross.bmp
-193.2370909091	n/a	48309.2727	show_face	unfamiliar_face	immediate_repeat	14	u016.bmp
-193.7789090909	n/a	48444.7273	left_press	n/a	n/a	256	n/a
-194.1825454545	n/a	48545.6364	show_circle	n/a	n/a	0	circle.bmp
-195.8825454545	n/a	48970.6364	show_cross	n/a	n/a	n/a	cross.bmp
-196.4116363636	n/a	49102.9091	show_face	scrambled_face	delayed_repeat	19	s150.bmp
-197.2143636364	n/a	49303.5909	right_press	n/a	n/a	4096	n/a
-197.3770909091	n/a	49344.2727	show_circle	n/a	n/a	0	circle.bmp
-199.0770909091	n/a	49769.2727	show_cross	n/a	n/a	n/a	cross.bmp
-199.5352727273	n/a	49883.8182	show_face	unfamiliar_face	first_show	13	u049.bmp
-200.4980000000	n/a	50124.5	right_press	n/a	n/a	4096	n/a
-200.5452727273	n/a	50136.3182	show_circle	n/a	n/a	0	circle.bmp
-202.2452727273	n/a	50561.3182	show_cross	n/a	n/a	n/a	cross.bmp
-202.7261818182	n/a	50681.5455	show_face	scrambled_face	first_show	17	s129.bmp
-203.3661818182	n/a	50841.5455	left_press	n/a	n/a	256	n/a
-203.5807272727	n/a	50895.1818	show_circle	n/a	n/a	0	circle.bmp
-205.2807272727	n/a	51320.1818	show_cross	n/a	n/a	n/a	cross.bmp
-205.9334545455	n/a	51483.3636	show_face	scrambled_face	immediate_repeat	18	s129.bmp
-206.4834545455	n/a	51620.8636	left_press	n/a	n/a	256	n/a
-206.7680000000	n/a	51692	show_circle	n/a	n/a	0	circle.bmp
-208.4680000000	n/a	52117	show_cross	n/a	n/a	n/a	cross.bmp
-208.9407272727	n/a	52235.1818	show_face	famous_face	first_show	5	f038.bmp
-209.7161818182	n/a	52429.0455	left_press	n/a	n/a	256	n/a
-209.9007272727	n/a	52475.1818	show_circle	n/a	n/a	0	circle.bmp
-211.6007272727	n/a	52900.1818	show_cross	n/a	n/a	n/a	cross.bmp
-212.1980000000	n/a	53049.5	show_face	scrambled_face	first_show	17	s001.bmp
-213.0834545455	n/a	53270.8636	left_press	n/a	n/a	256	n/a
-213.1880000000	n/a	53297	show_circle	n/a	n/a	0	circle.bmp
-214.8880000000	n/a	53722	show_cross	n/a	n/a	n/a	cross.bmp
-215.3716363636	n/a	53842.9091	show_face	scrambled_face	delayed_repeat	19	s101.bmp
-216.1989090909	n/a	54049.7273	left_press	n/a	n/a	256	n/a
-216.3580000000	n/a	54089.5	show_circle	n/a	n/a	0	circle.bmp
-218.0580000000	n/a	54514.5	show_cross	n/a	n/a	n/a	cross.bmp
-218.5461818182	n/a	54636.5455	show_face	unfamiliar_face	first_show	13	u084.bmp
-219.2952727273	n/a	54823.8182	left_press	n/a	n/a	256	n/a
-219.4034545455	n/a	54850.8636	show_circle	n/a	n/a	0	circle.bmp
-221.1034545455	n/a	55275.8636	show_cross	n/a	n/a	n/a	cross.bmp
-221.5698181818	n/a	55392.4545	show_face	unfamiliar_face	immediate_repeat	14	u084.bmp
-222.2616363636	n/a	55565.4091	left_press	n/a	n/a	256	n/a
-222.4634545455	n/a	55615.8636	show_circle	n/a	n/a	0	circle.bmp
-224.1634545455	n/a	56040.8636	show_cross	n/a	n/a	n/a	cross.bmp
-224.7770909091	n/a	56194.2727	show_face	scrambled_face	first_show	17	s029.bmp
-225.5380000000	n/a	56384.5	right_press	n/a	n/a	4096	n/a
-225.7343636364	n/a	56433.5909	show_circle	n/a	n/a	0	circle.bmp
-227.4343636364	n/a	56858.5909	show_cross	n/a	n/a	n/a	cross.bmp
-227.9343636364	n/a	56983.5909	show_face	scrambled_face	immediate_repeat	18	s029.bmp
-228.7789090909	n/a	57194.7273	show_circle	n/a	n/a	0	circle.bmp
-228.8561818182	n/a	57214.0455	left_press	n/a	n/a	256	n/a
-230.4789090909	n/a	57619.7273	show_cross	n/a	n/a	n/a	cross.bmp
-231.0916363636	n/a	57772.9091	show_face	unfamiliar_face	delayed_repeat	15	u049.bmp
-231.9552727273	n/a	57988.8182	right_press	n/a	n/a	4096	n/a
-232.0652727273	n/a	58016.3182	show_circle	n/a	n/a	0	circle.bmp
-233.7652727273	n/a	58441.3182	show_cross	n/a	n/a	n/a	cross.bmp
-234.3825454545	n/a	58595.6364	show_face	unfamiliar_face	first_show	13	u145.bmp
-235.3070909091	n/a	58826.7727	show_circle	n/a	n/a	0	circle.bmp
-236.1898181818	n/a	59047.4545	right_press	n/a	n/a	4096	n/a
-237.0070909091	n/a	59251.7727	show_cross	n/a	n/a	n/a	cross.bmp
-237.4725454545	n/a	59368.1364	show_face	scrambled_face	first_show	17	s030.bmp
-238.1034545455	n/a	59525.8636	left_press	n/a	n/a	256	n/a
-238.3925454545	n/a	59598.1364	show_circle	n/a	n/a	0	circle.bmp
-240.0925454545	n/a	60023.1364	show_cross	n/a	n/a	n/a	cross.bmp
-240.5961818182	n/a	60149.0455	show_face	famous_face	delayed_repeat	7	f038.bmp
-241.2116363636	n/a	60302.9091	left_press	n/a	n/a	256	n/a
-241.5489090909	n/a	60387.2273	show_circle	n/a	n/a	0	circle.bmp
-243.2489090909	n/a	60812.2273	show_cross	n/a	n/a	n/a	cross.bmp
-243.7370909091	n/a	60934.2727	show_face	scrambled_face	first_show	17	s060.bmp
-244.5634545455	n/a	61140.8636	right_press	n/a	n/a	4096	n/a
-244.7552727273	n/a	61188.8182	show_circle	n/a	n/a	0	circle.bmp
-246.4552727273	n/a	61613.8182	show_cross	n/a	n/a	n/a	cross.bmp
-247.0952727273	n/a	61773.8182	show_face	scrambled_face	delayed_repeat	19	s001.bmp
-247.8970909091	n/a	61974.2727	left_press	n/a	n/a	256	n/a
-247.9507272727	n/a	61987.6818	show_circle	n/a	n/a	0	circle.bmp
-249.6507272727	n/a	62412.6818	show_cross	n/a	n/a	n/a	cross.bmp
-250.2352727273	n/a	62558.8182	show_face	unfamiliar_face	first_show	13	u050.bmp
-250.9589090909	n/a	62739.7273	left_press	n/a	n/a	256	n/a
-251.0680000000	n/a	62767	show_circle	n/a	n/a	0	circle.bmp
-252.7680000000	n/a	63192	show_cross	n/a	n/a	n/a	cross.bmp
-253.3425454545	n/a	63335.6364	show_face	unfamiliar_face	immediate_repeat	14	u050.bmp
-253.8343636364	n/a	63458.5909	left_press	n/a	n/a	256	n/a
-254.3298181818	n/a	63582.4545	show_circle	n/a	n/a	0	circle.bmp
-256.0298181818	n/a	64007.4545	show_cross	n/a	n/a	n/a	cross.bmp
-256.5834545455	n/a	64145.8636	show_face	scrambled_face	first_show	17	s076.bmp
-257.3061818182	n/a	64326.5455	left_press	n/a	n/a	256	n/a
-257.5280000000	n/a	64382	show_circle	n/a	n/a	0	circle.bmp
-259.2280000000	n/a	64807	show_cross	n/a	n/a	n/a	cross.bmp
-259.7070909091	n/a	64926.7727	show_face	scrambled_face	first_show	17	s137.bmp
-260.2498181818	n/a	65062.4545	left_press	n/a	n/a	256	n/a
-260.5998181818	n/a	65149.9545	show_circle	n/a	n/a	0	circle.bmp
-262.2998181818	n/a	65574.9545	show_cross	n/a	n/a	n/a	cross.bmp
-262.8307272727	n/a	65707.6818	show_face	unfamiliar_face	delayed_repeat	15	u145.bmp
-263.6861818182	n/a	65921.5455	left_press	n/a	n/a	256	n/a
-263.7625454545	n/a	65940.6364	show_circle	n/a	n/a	0	circle.bmp
-265.4625454545	n/a	66365.6364	show_cross	n/a	n/a	n/a	cross.bmp
-265.9716363636	n/a	66492.9091	show_face	unfamiliar_face	first_show	13	u020.bmp
-266.5070909091	n/a	66626.7727	right_press	n/a	n/a	4096	n/a
-266.9798181818	n/a	66744.9545	show_circle	n/a	n/a	0	circle.bmp
-268.6798181818	n/a	67169.9545	show_cross	n/a	n/a	n/a	cross.bmp
-269.2798181818	n/a	67319.9545	show_face	unfamiliar_face	immediate_repeat	14	u020.bmp
-269.8452727273	n/a	67461.3182	left_press	n/a	n/a	256	n/a
-270.2316363636	n/a	67557.9091	show_circle	n/a	n/a	0	circle.bmp
-271.9316363636	n/a	67982.9091	show_cross	n/a	n/a	n/a	cross.bmp
-272.3861818182	n/a	68096.5455	show_face	scrambled_face	delayed_repeat	19	s030.bmp
-273.2989090909	n/a	68324.7273	right_press	n/a	n/a	4096	n/a
-273.3707272727	n/a	68342.6818	show_circle	n/a	n/a	0	circle.bmp
-275.0707272727	n/a	68767.6818	show_cross	n/a	n/a	n/a	cross.bmp
-275.6770909091	n/a	68919.2727	show_face	unfamiliar_face	first_show	13	u056.bmp
-276.5016363636	n/a	69125.4091	left_press	n/a	n/a	256	n/a
-276.6289090909	n/a	69157.2273	show_circle	n/a	n/a	0	circle.bmp
-278.3289090909	n/a	69582.2273	show_cross	n/a	n/a	n/a	cross.bmp
-278.9680000000	n/a	69742	show_face	scrambled_face	delayed_repeat	19	s060.bmp
-279.5816363636	n/a	69895.4091	right_press	n/a	n/a	4096	n/a
-279.8416363636	n/a	69960.4091	show_circle	n/a	n/a	0	circle.bmp
-281.5416363636	n/a	70385.4091	show_cross	n/a	n/a	n/a	cross.bmp
-282.1761818182	n/a	70544.0455	show_face	famous_face	first_show	5	f032.bmp
-282.9734545455	n/a	70743.3636	right_press	n/a	n/a	4096	n/a
-282.9952727273	n/a	70748.8182	show_circle	n/a	n/a	0	circle.bmp
-284.6952727273	n/a	71173.8182	show_cross	n/a	n/a	n/a	cross.bmp
-285.2325454545	n/a	71308.1364	show_face	scrambled_face	first_show	17	s077.bmp
-285.8180000000	n/a	71454.5	left_press	n/a	n/a	256	n/a
-286.1061818182	n/a	71526.5455	show_circle	n/a	n/a	0	circle.bmp
-287.8061818182	n/a	71951.5455	show_cross	n/a	n/a	n/a	cross.bmp
-288.3898181818	n/a	72097.4545	show_face	scrambled_face	immediate_repeat	18	s077.bmp
-288.8970909091	n/a	72224.2727	left_press	n/a	n/a	256	n/a
-289.2743636364	n/a	72318.5909	show_circle	n/a	n/a	0	circle.bmp
-290.9743636364	n/a	72743.5909	show_cross	n/a	n/a	n/a	cross.bmp
-291.4970909091	n/a	72874.2727	show_face	scrambled_face	delayed_repeat	19	s076.bmp
-292.3725454545	n/a	73093.1364	show_circle	n/a	n/a	0	circle.bmp
-292.3907272727	n/a	73097.6818	left_press	n/a	n/a	256	n/a
-294.0725454545	n/a	73518.1364	show_cross	n/a	n/a	n/a	cross.bmp
-294.6880000000	n/a	73672	show_face	famous_face	first_show	5	f133.bmp
-295.2989090909	n/a	73824.7273	right_press	n/a	n/a	4096	n/a
-295.6034545455	n/a	73900.8636	show_circle	n/a	n/a	0	circle.bmp
-297.3034545455	n/a	74325.8636	show_cross	n/a	n/a	n/a	cross.bmp
-297.7952727273	n/a	74448.8182	show_face	famous_face	immediate_repeat	6	f133.bmp
-298.6107272727	n/a	74652.6818	right_press	n/a	n/a	4096	n/a
-298.7152727273	n/a	74678.8182	show_circle	n/a	n/a	0	circle.bmp
-300.4152727273	n/a	75103.8182	show_cross	n/a	n/a	n/a	cross.bmp
-300.9689090909	n/a	75242.2273	show_face	scrambled_face	delayed_repeat	19	s137.bmp
-301.5734545455	n/a	75393.3636	left_press	n/a	n/a	256	n/a
-301.8143636364	n/a	75453.5909	show_circle	n/a	n/a	0	circle.bmp
-303.5143636364	n/a	75878.5909	show_cross	n/a	n/a	n/a	cross.bmp
-304.0425454545	n/a	76010.6364	show_face	unfamiliar_face	first_show	13	u064.bmp
-304.6407272727	n/a	76160.1818	right_press	n/a	n/a	4096	n/a
-305.0543636364	n/a	76263.5909	show_circle	n/a	n/a	0	circle.bmp
-306.7543636364	n/a	76688.5909	show_cross	n/a	n/a	n/a	cross.bmp
-307.4007272727	n/a	76850.1818	show_face	unfamiliar_face	immediate_repeat	14	u064.bmp
-307.8980000000	n/a	76974.5	right_press	n/a	n/a	4096	n/a
-308.2507272727	n/a	77062.6818	show_circle	n/a	n/a	0	circle.bmp
-309.9507272727	n/a	77487.6818	show_cross	n/a	n/a	n/a	cross.bmp
-310.4070909091	n/a	77601.7727	show_face	scrambled_face	first_show	17	s113.bmp
-311.2298181818	n/a	77807.4545	show_circle	n/a	n/a	0	circle.bmp
-311.2370909091	n/a	77809.2727	right_press	n/a	n/a	4096	n/a
-312.9298181818	n/a	78232.4545	show_cross	n/a	n/a	n/a	cross.bmp
-313.4316363636	n/a	78357.9091	show_face	unfamiliar_face	delayed_repeat	15	u056.bmp
-314.0770909091	n/a	78519.2727	left_press	n/a	n/a	256	n/a
-314.3489090909	n/a	78587.2273	show_circle	n/a	n/a	0	circle.bmp
-316.0489090909	n/a	79012.2273	show_cross	n/a	n/a	n/a	cross.bmp
-316.5880000000	n/a	79147	show_face	famous_face	first_show	5	f015.bmp
-317.1916363636	n/a	79297.9091	right_press	n/a	n/a	4096	n/a
-317.4234545455	n/a	79355.8636	show_circle	n/a	n/a	0	circle.bmp
-319.1234545455	n/a	79780.8636	show_cross	n/a	n/a	n/a	cross.bmp
-319.5789090909	n/a	79894.7273	show_face	famous_face	immediate_repeat	6	f015.bmp
-320.0925454545	n/a	80023.1364	right_press	n/a	n/a	4096	n/a
-320.5643636364	n/a	80141.0909	show_circle	n/a	n/a	0	circle.bmp
-322.2643636364	n/a	80566.0909	show_cross	n/a	n/a	n/a	cross.bmp
-322.8370909091	n/a	80709.2727	show_face	famous_face	delayed_repeat	7	f032.bmp
-323.4870909091	n/a	80871.7727	right_press	n/a	n/a	4096	n/a
-323.7452727273	n/a	80936.3182	show_circle	n/a	n/a	0	circle.bmp
-325.4452727273	n/a	81361.3182	show_cross	n/a	n/a	n/a	cross.bmp
-325.9770909091	n/a	81494.2727	show_face	famous_face	first_show	5	f005.bmp
-326.6880000000	n/a	81672	right_press	n/a	n/a	4096	n/a
-326.8443636364	n/a	81711.0909	show_circle	n/a	n/a	0	circle.bmp
-328.5443636364	n/a	82136.0909	show_cross	n/a	n/a	n/a	cross.bmp
-329.1670909091	n/a	82291.7727	show_face	famous_face	immediate_repeat	6	f005.bmp
-329.7625454545	n/a	82440.6364	right_press	n/a	n/a	4096	n/a
-330.1343636364	n/a	82533.5909	show_circle	n/a	n/a	0	circle.bmp
-331.8343636364	n/a	82958.5909	show_cross	n/a	n/a	n/a	cross.bmp
-332.4252727273	n/a	83106.3182	show_face	famous_face	first_show	5	f115.bmp
-333.1543636364	n/a	83288.5909	right_press	n/a	n/a	4096	n/a
-333.3143636364	n/a	83328.5909	show_circle	n/a	n/a	0	circle.bmp
-335.0143636364	n/a	83753.5909	show_cross	n/a	n/a	n/a	cross.bmp
-335.5652727273	n/a	83891.3182	show_face	famous_face	first_show	5	f040.bmp
-336.1680000000	n/a	84042	right_press	n/a	n/a	4096	n/a
-336.5089090909	n/a	84127.2273	show_circle	n/a	n/a	0	circle.bmp
-338.2089090909	n/a	84552.2273	show_cross	n/a	n/a	n/a	cross.bmp
-338.8061818182	n/a	84701.5455	show_face	famous_face	immediate_repeat	6	f040.bmp
-339.2852727273	n/a	84821.3182	right_press	n/a	n/a	4096	n/a
-339.7907272727	n/a	84947.6818	show_circle	n/a	n/a	0	circle.bmp
-341.4907272727	n/a	85372.6818	show_cross	n/a	n/a	n/a	cross.bmp
-342.0307272727	n/a	85507.6818	show_face	scrambled_face	first_show	17	s109.bmp
-342.9325454545	n/a	85733.1364	left_press	n/a	n/a	256	n/a
-343.0243636364	n/a	85756.0909	show_circle	n/a	n/a	0	circle.bmp
-344.7243636364	n/a	86181.0909	show_cross	n/a	n/a	n/a	cross.bmp
-345.3216363636	n/a	86330.4091	show_face	scrambled_face	delayed_repeat	19	s113.bmp
-345.9280000000	n/a	86482	left_press	n/a	n/a	256	n/a
-346.2580000000	n/a	86564.5	show_circle	n/a	n/a	0	circle.bmp
-347.9580000000	n/a	86989.5	show_cross	n/a	n/a	n/a	cross.bmp
-348.4961818182	n/a	87124.0455	show_face	scrambled_face	first_show	17	s003.bmp
-349.1970909091	n/a	87299.2727	right_press	n/a	n/a	4096	n/a
-349.5080000000	n/a	87377	show_circle	n/a	n/a	0	circle.bmp
-351.2080000000	n/a	87802	show_cross	n/a	n/a	n/a	cross.bmp
-351.7025454545	n/a	87925.6364	show_face	scrambled_face	immediate_repeat	18	s003.bmp
-352.2316363636	n/a	88057.9091	right_press	n/a	n/a	4096	n/a
-352.7125454545	n/a	88178.1364	show_circle	n/a	n/a	0	circle.bmp
-354.4125454545	n/a	88603.1364	show_cross	n/a	n/a	n/a	cross.bmp
-354.8934545455	n/a	88723.3636	show_face	unfamiliar_face	first_show	13	u141.bmp
-355.7689090909	n/a	88942.2273	show_circle	n/a	n/a	0	circle.bmp
-355.8561818182	n/a	88964.0455	right_press	n/a	n/a	4096	n/a
-357.4689090909	n/a	89367.2273	show_cross	n/a	n/a	n/a	cross.bmp
-358.1170909091	n/a	89529.2727	show_face	scrambled_face	first_show	17	s009.bmp
-359.0325454545	n/a	89758.1364	show_circle	n/a	n/a	0	circle.bmp
-359.0643636364	n/a	89766.0909	right_press	n/a	n/a	4096	n/a
-360.7325454545	n/a	90183.1364	show_cross	n/a	n/a	n/a	cross.bmp
-361.1916363636	n/a	90297.9091	show_face	scrambled_face	immediate_repeat	18	s009.bmp
-361.7834545455	n/a	90445.8636	right_press	n/a	n/a	4096	n/a
-362.1080000000	n/a	90527	show_circle	n/a	n/a	0	circle.bmp
-363.8080000000	n/a	90952	show_cross	n/a	n/a	n/a	cross.bmp
-364.4489090909	n/a	91112.2273	show_face	famous_face	delayed_repeat	7	f115.bmp
-365.0898181818	n/a	91272.4545	right_press	n/a	n/a	4096	n/a
-365.4243636364	n/a	91356.0909	show_circle	n/a	n/a	0	circle.bmp
-367.1243636364	n/a	91781.0909	show_cross	n/a	n/a	n/a	cross.bmp
-367.7398181818	n/a	91934.9545	show_face	scrambled_face	first_show	17	s046.bmp
-368.5198181818	n/a	92129.9545	left_press	n/a	n/a	256	n/a
-368.7161818182	n/a	92179.0455	show_circle	n/a	n/a	0	circle.bmp
-370.4161818182	n/a	92604.0455	show_cross	n/a	n/a	n/a	cross.bmp
-370.9470909091	n/a	92736.7727	show_face	scrambled_face	immediate_repeat	18	s046.bmp
-371.5261818182	n/a	92881.5455	left_press	n/a	n/a	256	n/a
-371.9261818182	n/a	92981.5455	show_circle	n/a	n/a	0	circle.bmp
-373.6261818182	n/a	93406.5455	show_cross	n/a	n/a	n/a	cross.bmp
-374.2716363636	n/a	93567.9091	show_face	unfamiliar_face	first_show	13	u138.bmp
-374.9743636364	n/a	93743.5909	right_press	n/a	n/a	4096	n/a
-375.2761818182	n/a	93819.0455	show_circle	n/a	n/a	0	circle.bmp
-376.9761818182	n/a	94244.0455	show_cross	n/a	n/a	n/a	cross.bmp
-377.4289090909	n/a	94357.2273	show_face	unfamiliar_face	immediate_repeat	14	u138.bmp
-377.9943636364	n/a	94498.5909	right_press	n/a	n/a	4096	n/a
-378.3470909091	n/a	94586.7727	show_circle	n/a	n/a	0	circle.bmp
-380.0470909091	n/a	95011.7727	show_cross	n/a	n/a	n/a	cross.bmp
-380.6361818182	n/a	95159.0455	show_face	scrambled_face	delayed_repeat	19	s109.bmp
-381.2952727273	n/a	95323.8182	left_press	n/a	n/a	256	n/a
-381.5798181818	n/a	95394.9545	show_circle	n/a	n/a	0	circle.bmp
-383.2798181818	n/a	95819.9545	show_cross	n/a	n/a	n/a	cross.bmp
-383.9270909091	n/a	95981.7727	show_face	scrambled_face	first_show	17	s094.bmp
-384.5707272727	n/a	96142.6818	right_press	n/a	n/a	4096	n/a
-384.7934545455	n/a	96198.3636	show_circle	n/a	n/a	0	circle.bmp
-386.4934545455	n/a	96623.3636	show_cross	n/a	n/a	n/a	cross.bmp
-387.0007272727	n/a	96750.1818	show_face	scrambled_face	immediate_repeat	18	s094.bmp
-387.5207272727	n/a	96880.1818	right_press	n/a	n/a	4096	n/a
-387.9416363636	n/a	96985.4091	show_circle	n/a	n/a	0	circle.bmp
-389.6416363636	n/a	97410.4091	show_cross	n/a	n/a	n/a	cross.bmp
-390.2252727273	n/a	97556.3182	show_face	famous_face	first_show	5	f095.bmp
-390.9670909091	n/a	97741.7727	left_press	n/a	n/a	256	n/a
-391.0670909091	n/a	97766.7727	show_circle	n/a	n/a	0	circle.bmp
-392.7670909091	n/a	98191.7727	show_cross	n/a	n/a	n/a	cross.bmp
-393.2816363636	n/a	98320.4091	show_face	famous_face	immediate_repeat	6	f095.bmp
-393.8189090909	n/a	98454.7273	left_press	n/a	n/a	256	n/a
-394.2307272727	n/a	98557.6818	show_circle	n/a	n/a	0	circle.bmp
-395.9307272727	n/a	98982.6818	show_cross	n/a	n/a	n/a	cross.bmp
-396.5398181818	n/a	99134.9545	show_face	unfamiliar_face	delayed_repeat	15	u141.bmp
-397.3143636364	n/a	99328.5909	right_press	n/a	n/a	4096	n/a
-397.4889090909	n/a	99372.2273	show_circle	n/a	n/a	0	circle.bmp
-399.1889090909	n/a	99797.2273	show_cross	n/a	n/a	n/a	cross.bmp
-399.7634545455	n/a	99940.8636	show_face	scrambled_face	first_show	17	s132.bmp
-400.4934545455	n/a	100123.3636	left_press	n/a	n/a	256	n/a
-400.6534545455	n/a	100163.3636	show_circle	n/a	n/a	0	circle.bmp
-402.3534545455	n/a	100588.3636	show_cross	n/a	n/a	n/a	cross.bmp
-403.0043636364	n/a	100751.0909	show_face	scrambled_face	immediate_repeat	18	s132.bmp
-403.6434545455	n/a	100910.8636	left_press	n/a	n/a	256	n/a
-403.8425454545	n/a	100960.6364	show_circle	n/a	n/a	0	circle.bmp
-405.5425454545	n/a	101385.6364	show_cross	n/a	n/a	n/a	cross.bmp
-406.0280000000	n/a	101507	show_face	scrambled_face	first_show	17	s055.bmp
-406.7825454545	n/a	101695.6364	right_press	n/a	n/a	4096	n/a
-406.9634545455	n/a	101740.8636	show_circle	n/a	n/a	0	circle.bmp
-408.6634545455	n/a	102165.8636	show_cross	n/a	n/a	n/a	cross.bmp
-409.2352727273	n/a	102308.8182	show_face	unfamiliar_face	first_show	13	u005.bmp
-410.0343636364	n/a	102508.5909	left_press	n/a	n/a	256	n/a
-410.1880000000	n/a	102547	show_circle	n/a	n/a	0	circle.bmp
-411.8880000000	n/a	102972	show_cross	n/a	n/a	n/a	cross.bmp
-412.4261818182	n/a	103106.5455	show_face	unfamiliar_face	first_show	13	u054.bmp
-413.2834545455	n/a	103320.8636	left_press	n/a	n/a	256	n/a
-413.2861818182	n/a	103321.5455	show_circle	n/a	n/a	0	circle.bmp
-414.9861818182	n/a	103746.5455	show_cross	n/a	n/a	n/a	cross.bmp
-415.5998181818	n/a	103899.9545	show_face	famous_face	first_show	5	f022.bmp
-416.3607272727	n/a	104090.1818	right_press	n/a	n/a	4096	n/a
-416.4770909091	n/a	104119.2727	show_circle	n/a	n/a	0	circle.bmp
-418.1770909091	n/a	104544.2727	show_cross	n/a	n/a	n/a	cross.bmp
-418.7407272727	n/a	104685.1818	show_face	famous_face	immediate_repeat	6	f022.bmp
-419.2898181818	n/a	104822.4545	right_press	n/a	n/a	4096	n/a
-419.7543636364	n/a	104938.5909	show_circle	n/a	n/a	0	circle.bmp
-421.4543636364	n/a	105363.5909	show_cross	n/a	n/a	n/a	cross.bmp
-422.0816363636	n/a	105520.4091	show_face	scrambled_face	first_show	17	s095.bmp
-422.8234545455	n/a	105705.8636	left_press	n/a	n/a	256	n/a
-422.9170909091	n/a	105729.2727	show_circle	n/a	n/a	0	circle.bmp
-424.6170909091	n/a	106154.2727	show_cross	n/a	n/a	n/a	cross.bmp
-425.2552727273	n/a	106313.8182	show_face	scrambled_face	first_show	17	s024.bmp
-426.1261818182	n/a	106531.5455	show_circle	n/a	n/a	0	circle.bmp
-426.1570909091	n/a	106539.2727	left_press	n/a	n/a	256	n/a
-427.8261818182	n/a	106956.5455	show_cross	n/a	n/a	n/a	cross.bmp
-428.2961818182	n/a	107074.0455	show_face	scrambled_face	delayed_repeat	19	s055.bmp
-429.0125454545	n/a	107253.1364	left_press	n/a	n/a	256	n/a
-429.2752727273	n/a	107318.8182	show_circle	n/a	n/a	0	circle.bmp
-430.9752727273	n/a	107743.8182	show_cross	n/a	n/a	n/a	cross.bmp
-431.5034545455	n/a	107875.8636	show_face	famous_face	first_show	5	f025.bmp
-432.2689090909	n/a	108067.2273	left_press	n/a	n/a	256	n/a
-432.3643636364	n/a	108091.0909	show_circle	n/a	n/a	0	circle.bmp
-434.0643636364	n/a	108516.0909	show_cross	n/a	n/a	n/a	cross.bmp
-434.5434545455	n/a	108635.8636	show_face	famous_face	immediate_repeat	6	f025.bmp
-435.2225454545	n/a	108805.6364	left_press	n/a	n/a	256	n/a
-435.4470909091	n/a	108861.7727	show_circle	n/a	n/a	0	circle.bmp
-437.1470909091	n/a	109286.7727	show_cross	n/a	n/a	n/a	cross.bmp
-437.6170909091	n/a	109404.2727	show_face	unfamiliar_face	delayed_repeat	15	u005.bmp
-438.4025454545	n/a	109600.6364	left_press	n/a	n/a	256	n/a
-438.4498181818	n/a	109612.4545	show_circle	n/a	n/a	0	circle.bmp
-440.1498181818	n/a	110037.4545	show_cross	n/a	n/a	n/a	cross.bmp
-440.6743636364	n/a	110168.5909	show_face	famous_face	first_show	5	f137.bmp
-441.5989090909	n/a	110399.7273	show_circle	n/a	n/a	0	circle.bmp
-442.1025454545	n/a	110525.6364	left_press	n/a	n/a	256	n/a
-443.2989090909	n/a	110824.7273	show_cross	n/a	n/a	n/a	cross.bmp
-443.9489090909	n/a	110987.2273	show_face	unfamiliar_face	delayed_repeat	15	u054.bmp
-444.7316363636	n/a	111182.9091	left_press	n/a	n/a	256	n/a
-444.9480000000	n/a	111237	show_circle	n/a	n/a	0	circle.bmp
-446.6480000000	n/a	111662	show_cross	n/a	n/a	n/a	cross.bmp
-447.2734545455	n/a	111818.3636	show_face	unfamiliar_face	first_show	13	u107.bmp
-447.8461818182	n/a	111961.5455	right_press	n/a	n/a	4096	n/a
-448.1470909091	n/a	112036.7727	show_circle	n/a	n/a	0	circle.bmp
-449.8470909091	n/a	112461.7727	show_cross	n/a	n/a	n/a	cross.bmp
-450.4470909091	n/a	112611.7727	show_face	unfamiliar_face	first_show	13	u108.bmp
-451.1125454545	n/a	112778.1364	right_press	n/a	n/a	4096	n/a
-451.3461818182	n/a	112836.5455	show_circle	n/a	n/a	0	circle.bmp
-453.0461818182	n/a	113261.5455	show_cross	n/a	n/a	n/a	cross.bmp
-453.6207272727	n/a	113405.1818	show_face	scrambled_face	delayed_repeat	19	s095.bmp
-454.3298181818	n/a	113582.4545	left_press	n/a	n/a	256	n/a
-454.6116363636	n/a	113652.9091	show_circle	n/a	n/a	0	circle.bmp
-456.3116363636	n/a	114077.9091	show_cross	n/a	n/a	n/a	cross.bmp
-456.8116363636	n/a	114202.9091	show_face	famous_face	first_show	5	f093.bmp
-457.4934545455	n/a	114373.3636	right_press	n/a	n/a	4096	n/a
-457.6916363636	n/a	114422.9091	show_circle	n/a	n/a	0	circle.bmp
-459.3916363636	n/a	114847.9091	show_cross	n/a	n/a	n/a	cross.bmp
-459.9525454545	n/a	114988.1364	show_face	famous_face	immediate_repeat	6	f093.bmp
-460.6780000000	n/a	115169.5	right_press	n/a	n/a	4096	n/a
-460.9125454545	n/a	115228.1364	show_circle	n/a	n/a	0	circle.bmp
-462.6125454545	n/a	115653.1364	show_cross	n/a	n/a	n/a	cross.bmp
-463.2261818182	n/a	115806.5455	show_face	scrambled_face	delayed_repeat	19	s024.bmp
-463.7898181818	n/a	115947.4545	left_press	n/a	n/a	256	n/a
-464.0716363636	n/a	116017.9091	show_circle	n/a	n/a	0	circle.bmp
-465.7716363636	n/a	116442.9091	show_cross	n/a	n/a	n/a	cross.bmp
-466.2498181818	n/a	116562.4545	show_face	unfamiliar_face	first_show	13	u121.bmp
-466.9780000000	n/a	116744.5	right_press	n/a	n/a	4096	n/a
-467.2189090909	n/a	116804.7273	show_circle	n/a	n/a	0	circle.bmp
-468.9189090909	n/a	117229.7273	show_cross	n/a	n/a	n/a	cross.bmp
-469.5407272727	n/a	117385.1818	show_face	famous_face	first_show	5	f048.bmp
-470.2989090909	n/a	117574.7273	right_press	n/a	n/a	4096	n/a
-470.5452727273	n/a	117636.3182	show_circle	n/a	n/a	0	circle.bmp
-472.2452727273	n/a	118061.3182	show_cross	n/a	n/a	n/a	cross.bmp
-472.7325454545	n/a	118183.1364	show_face	famous_face	delayed_repeat	7	f137.bmp
-473.4634545455	n/a	118365.8636	left_press	n/a	n/a	256	n/a
-473.6907272727	n/a	118422.6818	show_circle	n/a	n/a	0	circle.bmp
-475.3907272727	n/a	118847.6818	show_cross	n/a	n/a	n/a	cross.bmp
-475.8889090909	n/a	118972.2273	show_face	famous_face	first_show	5	f131.bmp
-476.5589090909	n/a	119139.7273	right_press	n/a	n/a	4096	n/a
-476.7980000000	n/a	119199.5	show_circle	n/a	n/a	0	circle.bmp
-478.4980000000	n/a	119624.5	show_cross	n/a	n/a	n/a	cross.bmp
-479.0461818182	n/a	119761.5455	show_face	unfamiliar_face	delayed_repeat	15	u107.bmp
-479.6570909091	n/a	119914.2727	right_press	n/a	n/a	4096	n/a
-479.9234545455	n/a	119980.8636	show_circle	n/a	n/a	0	circle.bmp
-481.6234545455	n/a	120405.8636	show_cross	n/a	n/a	n/a	cross.bmp
-482.2370909091	n/a	120559.2727	show_face	famous_face	first_show	5	f078.bmp
-482.8707272727	n/a	120717.6818	right_press	n/a	n/a	4096	n/a
-483.2343636364	n/a	120808.5909	show_circle	n/a	n/a	0	circle.bmp
-484.9343636364	n/a	121233.5909	show_cross	n/a	n/a	n/a	cross.bmp
-485.4280000000	n/a	121357	show_face	famous_face	immediate_repeat	6	f078.bmp
-486.0007272727	n/a	121500.1818	right_press	n/a	n/a	4096	n/a
-486.4361818182	n/a	121609.0455	show_circle	n/a	n/a	0	circle.bmp
-488.1361818182	n/a	122034.0455	show_cross	n/a	n/a	n/a	cross.bmp
-488.7189090909	n/a	122179.7273	show_face	unfamiliar_face	delayed_repeat	15	u108.bmp
-489.3470909091	n/a	122336.7727	right_press	n/a	n/a	4096	n/a
-489.6116363636	n/a	122402.9091	show_circle	n/a	n/a	0	circle.bmp
-491.3116363636	n/a	122827.9091	show_cross	n/a	n/a	n/a	cross.bmp
+onset	duration	sample	event_type	face_type	repetition_type	trial	trial_lag	trigger	stim_file
+0.004	n/a	1.0	setup	n/a	n/a	n/a	n/a	n/a	n/a
+0.004	n/a	1.0	right_sym	n/a	n/a	n/a	n/a	n/a	n/a
+25.1161818182	n/a	6279.0455	show_face	famous_face	first_show	1	n/a	5	f074.bmp
+25.9789090909	n/a	6494.7273	show_circle	n/a	n/a	1	n/a	0	circle.bmp
+26.0261818182	n/a	6506.5455	left_press	n/a	n/a	1	n/a	256	n/a
+27.678909090900003	n/a	6919.7273	show_cross	n/a	n/a	2	n/a	n/a	cross.bmp
+28.1734545455	n/a	7043.3636	show_face	unfamiliar_face	first_show	2	n/a	13	u011.bmp
+29.059818181799997	n/a	7264.9545	show_circle	n/a	n/a	2	n/a	0	circle.bmp
+29.111636363600002	n/a	7277.9091	left_press	n/a	n/a	2	n/a	256	n/a
+30.7598181818	n/a	7689.9545	show_cross	n/a	n/a	3	n/a	n/a	cross.bmp
+31.3307272727	n/a	7832.6818	show_face	scrambled_face	first_show	3	n/a	17	s036.bmp
+32.279818181799996	n/a	8069.9545	show_circle	n/a	n/a	3	n/a	0	circle.bmp
+32.2952727273	n/a	8073.8182	left_press	n/a	n/a	3	n/a	256	n/a
+33.9798181818	n/a	8494.9545	show_cross	n/a	n/a	4	n/a	n/a	cross.bmp
+34.438	n/a	8609.5	show_face	famous_face	first_show	4	n/a	5	f112.bmp
+35.0207272727	n/a	8755.1818	right_press	n/a	n/a	4	n/a	4096	n/a
+35.4343636364	n/a	8858.5909	show_circle	n/a	n/a	4	n/a	0	circle.bmp
+37.134363636399996	n/a	9283.5909	show_cross	n/a	n/a	5	n/a	n/a	cross.bmp
+37.7789090909	n/a	9444.7273	show_face	famous_face	immediate_repeat	5	1	6	f112.bmp
+38.3270909091	n/a	9581.7727	right_press	n/a	n/a	5	n/a	4096	n/a
+38.6825454545	n/a	9670.6364	show_circle	n/a	n/a	5	n/a	0	circle.bmp
+40.3825454545	n/a	10095.6364	show_cross	n/a	n/a	6	n/a	n/a	cross.bmp
+40.9698181818	n/a	10242.4545	show_face	unfamiliar_face	first_show	6	n/a	13	u066.bmp
+41.5543636364	n/a	10388.5909	left_press	n/a	n/a	6	n/a	256	n/a
+41.9298181818	n/a	10482.4545	show_circle	n/a	n/a	6	n/a	0	circle.bmp
+43.629818181800005	n/a	10907.4545	show_cross	n/a	n/a	7	n/a	n/a	cross.bmp
+44.2770909091	n/a	11069.2727	show_face	unfamiliar_face	immediate_repeat	7	1	14	u066.bmp
+44.7452727273	n/a	11186.3182	left_press	n/a	n/a	7	n/a	256	n/a
+45.1461818182	n/a	11286.5455	show_circle	n/a	n/a	7	n/a	0	circle.bmp
+46.846181818199994	n/a	11711.5455	show_cross	n/a	n/a	8	n/a	n/a	cross.bmp
+47.350727272700006	n/a	11837.6818	show_face	unfamiliar_face	first_show	8	n/a	13	u113.bmp
+47.957090909099996	n/a	11989.2727	right_press	n/a	n/a	8	n/a	4096	n/a
+48.2598181818	n/a	12064.9545	show_circle	n/a	n/a	8	n/a	0	circle.bmp
+49.9598181818	n/a	12489.9545	show_cross	n/a	n/a	9	n/a	n/a	cross.bmp
+50.508	n/a	12627.0	show_face	unfamiliar_face	immediate_repeat	9	1	14	u113.bmp
+51.2570909091	n/a	12814.2727	right_press	n/a	n/a	9	n/a	4096	n/a
+51.409818181800006	n/a	12852.4545	show_circle	n/a	n/a	9	n/a	0	circle.bmp
+53.1098181818	n/a	13277.4545	show_cross	n/a	n/a	10	n/a	n/a	cross.bmp
+53.5825454545	n/a	13395.6364	show_face	famous_face	delayed_repeat	10	9	7	f074.bmp
+54.269818181800005	n/a	13567.4545	left_press	n/a	n/a	10	n/a	256	n/a
+54.484363636400005	n/a	13621.0909	show_circle	n/a	n/a	10	n/a	0	circle.bmp
+56.1843636364	n/a	14046.0909	show_cross	n/a	n/a	11	n/a	n/a	cross.bmp
+56.6561818182	n/a	14164.0455	show_face	scrambled_face	first_show	11	n/a	17	s100.bmp
+57.5234545455	n/a	14380.8636	show_circle	n/a	n/a	11	n/a	0	circle.bmp
+57.610727272700004	n/a	14402.6818	right_press	n/a	n/a	11	n/a	4096	n/a
+59.223454545500005	n/a	14805.8636	show_cross	n/a	n/a	12	n/a	n/a	cross.bmp
+59.7798181818	n/a	14944.9545	show_face	scrambled_face	immediate_repeat	12	1	18	s100.bmp
+60.3152727273	n/a	15078.8182	right_press	n/a	n/a	12	n/a	4096	n/a
+60.6907272727	n/a	15172.6818	show_circle	n/a	n/a	12	n/a	0	circle.bmp
+62.390727272700005	n/a	15597.6818	show_cross	n/a	n/a	13	n/a	n/a	cross.bmp
+62.9370909091	n/a	15734.2727	show_face	unfamiliar_face	delayed_repeat	13	11	15	u011.bmp
+63.655272727299995	n/a	15913.8182	left_press	n/a	n/a	13	n/a	256	n/a
+63.8470909091	n/a	15961.7727	show_circle	n/a	n/a	13	n/a	0	circle.bmp
+65.54709090909999	n/a	16386.7727	show_cross	n/a	n/a	14	n/a	n/a	cross.bmp
+66.1607272727	n/a	16540.1818	show_face	unfamiliar_face	first_show	14	n/a	13	u069.bmp
+67.07436363640001	n/a	16768.5909	show_circle	n/a	n/a	14	n/a	0	circle.bmp
+67.228	n/a	16807.0	right_press	n/a	n/a	14	n/a	4096	n/a
+68.7743636364	n/a	17193.5909	show_cross	n/a	n/a	15	n/a	n/a	cross.bmp
+69.3689090909	n/a	17342.2273	show_face	unfamiliar_face	immediate_repeat	15	1	14	u069.bmp
+69.9052727273	n/a	17476.3182	right_press	n/a	n/a	15	n/a	4096	n/a
+70.1970909091	n/a	17549.2727	show_circle	n/a	n/a	15	n/a	0	circle.bmp
+71.8970909091	n/a	17974.2727	show_cross	n/a	n/a	16	n/a	n/a	cross.bmp
+72.3925454545	n/a	18098.1364	show_face	scrambled_face	delayed_repeat	16	13	19	s036.bmp
+73.2898181818	n/a	18322.4545	show_circle	n/a	n/a	16	n/a	0	circle.bmp
+73.46436363640001	n/a	18366.0909	right_press	n/a	n/a	16	n/a	4096	n/a
+74.9898181818	n/a	18747.4545	show_cross	n/a	n/a	17	n/a	n/a	cross.bmp
+75.6325454545	n/a	18908.1364	show_face	famous_face	first_show	17	n/a	5	f039.bmp
+76.368	n/a	19092.0	right_press	n/a	n/a	17	n/a	4096	n/a
+76.63436363640001	n/a	19158.5909	show_circle	n/a	n/a	17	n/a	0	circle.bmp
+78.3343636364	n/a	19583.5909	show_cross	n/a	n/a	18	n/a	n/a	cross.bmp
+78.9570909091	n/a	19739.2727	show_face	famous_face	first_show	18	n/a	5	f020.bmp
+79.6643636364	n/a	19916.0909	right_press	n/a	n/a	18	n/a	4096	n/a
+79.8807272727	n/a	19970.1818	show_circle	n/a	n/a	18	n/a	0	circle.bmp
+81.5807272727	n/a	20395.1818	show_cross	n/a	n/a	19	n/a	n/a	cross.bmp
+82.1643636364	n/a	20541.0909	show_face	famous_face	first_show	19	n/a	5	f101.bmp
+82.7389090909	n/a	20684.7273	right_press	n/a	n/a	19	n/a	4096	n/a
+83.07527272729999	n/a	20768.8182	show_circle	n/a	n/a	19	n/a	0	circle.bmp
+84.77527272729999	n/a	21193.8182	show_cross	n/a	n/a	20	n/a	n/a	cross.bmp
+85.3725454545	n/a	21343.1364	show_face	scrambled_face	first_show	20	n/a	17	s058.bmp
+86.0489090909	n/a	21512.2273	left_press	n/a	n/a	20	n/a	256	n/a
+86.2352727273	n/a	21558.8182	show_circle	n/a	n/a	20	n/a	0	circle.bmp
+87.93527272729999	n/a	21983.8182	show_cross	n/a	n/a	21	n/a	n/a	cross.bmp
+88.4625454545	n/a	22115.6364	show_face	scrambled_face	immediate_repeat	21	1	18	s058.bmp
+89.01254545450001	n/a	22253.1364	left_press	n/a	n/a	21	n/a	256	n/a
+89.478	n/a	22369.5	show_circle	n/a	n/a	21	n/a	0	circle.bmp
+91.178	n/a	22794.5	show_cross	n/a	n/a	22	n/a	n/a	cross.bmp
+91.8370909091	n/a	22959.2727	show_face	unfamiliar_face	first_show	22	n/a	13	u061.bmp
+92.42436363639999	n/a	23106.0909	right_press	n/a	n/a	22	n/a	4096	n/a
+92.7425454545	n/a	23185.6364	show_circle	n/a	n/a	22	n/a	0	circle.bmp
+94.4425454545	n/a	23610.6364	show_cross	n/a	n/a	23	n/a	n/a	cross.bmp
+94.9270909091	n/a	23731.7727	show_face	unfamiliar_face	immediate_repeat	23	1	14	u061.bmp
+95.5016363636	n/a	23875.4091	right_press	n/a	n/a	23	n/a	4096	n/a
+95.8570909091	n/a	23964.2727	show_circle	n/a	n/a	23	n/a	0	circle.bmp
+97.5570909091	n/a	24389.2727	show_cross	n/a	n/a	24	n/a	n/a	cross.bmp
+98.118	n/a	24529.5	show_face	famous_face	first_show	24	n/a	5	f105.bmp
+98.668	n/a	24667.0	right_press	n/a	n/a	24	n/a	4096	n/a
+99.0398181818	n/a	24759.9545	show_circle	n/a	n/a	24	n/a	0	circle.bmp
+100.7398181818	n/a	25184.9545	show_cross	n/a	n/a	25	n/a	n/a	cross.bmp
+101.3589090909	n/a	25339.7273	show_face	famous_face	delayed_repeat	25	8	7	f039.bmp
+102.0052727273	n/a	25501.3182	right_press	n/a	n/a	25	n/a	4096	n/a
+102.29072727270001	n/a	25572.6818	show_circle	n/a	n/a	25	n/a	0	circle.bmp
+103.9907272727	n/a	25997.6818	show_cross	n/a	n/a	26	n/a	n/a	cross.bmp
+104.4661818182	n/a	26116.5455	show_face	famous_face	first_show	26	n/a	5	f138.bmp
+105.178	n/a	26294.5	right_press	n/a	n/a	26	n/a	4096	n/a
+105.2889090909	n/a	26322.2273	show_circle	n/a	n/a	26	n/a	0	circle.bmp
+106.9889090909	n/a	26747.2273	show_cross	n/a	n/a	27	n/a	n/a	cross.bmp
+107.5070909091	n/a	26876.7727	show_face	famous_face	delayed_repeat	27	9	7	f020.bmp
+108.32527272729999	n/a	27081.3182	right_press	n/a	n/a	27	n/a	4096	n/a
+108.43527272729999	n/a	27108.8182	show_circle	n/a	n/a	27	n/a	0	circle.bmp
+110.13527272729999	n/a	27533.8182	show_cross	n/a	n/a	28	n/a	n/a	cross.bmp
+110.79709090909999	n/a	27699.2727	show_face	famous_face	first_show	28	n/a	5	f064.bmp
+111.47345454549999	n/a	27868.3636	right_press	n/a	n/a	28	n/a	4096	n/a
+111.67618181819999	n/a	27919.0455	show_circle	n/a	n/a	28	n/a	0	circle.bmp
+113.3761818182	n/a	28344.0455	show_cross	n/a	n/a	29	n/a	n/a	cross.bmp
+113.8543636364	n/a	28463.5909	show_face	famous_face	immediate_repeat	29	1	6	f064.bmp
+114.4052727273	n/a	28601.3182	right_press	n/a	n/a	29	n/a	4096	n/a
+114.6734545455	n/a	28668.3636	show_circle	n/a	n/a	29	n/a	0	circle.bmp
+116.3734545455	n/a	29093.3636	show_cross	n/a	n/a	30	n/a	n/a	cross.bmp
+116.9289090909	n/a	29232.2273	show_face	famous_face	delayed_repeat	30	11	7	f101.bmp
+117.58163636360001	n/a	29395.4091	right_press	n/a	n/a	30	n/a	4096	n/a
+117.8807272727	n/a	29470.1818	show_circle	n/a	n/a	30	n/a	0	circle.bmp
+119.5807272727	n/a	29895.1818	show_cross	n/a	n/a	31	n/a	n/a	cross.bmp
+120.1025454545	n/a	30025.6364	show_face	unfamiliar_face	first_show	31	n/a	13	u127.bmp
+120.68072727270001	n/a	30170.1818	left_press	n/a	n/a	31	n/a	256	n/a
+120.9898181818	n/a	30247.4545	show_circle	n/a	n/a	31	n/a	0	circle.bmp
+122.6898181818	n/a	30672.4545	show_cross	n/a	n/a	32	n/a	n/a	cross.bmp
+123.2425454545	n/a	30810.6364	show_face	scrambled_face	first_show	32	n/a	17	s103.bmp
+124.128	n/a	31032.0	show_circle	n/a	n/a	32	n/a	0	circle.bmp
+124.2616363636	n/a	31065.4091	left_press	n/a	n/a	32	n/a	256	n/a
+125.828	n/a	31457.0	show_cross	n/a	n/a	33	n/a	n/a	cross.bmp
+126.36618181819999	n/a	31591.5455	show_face	unfamiliar_face	first_show	33	n/a	13	u143.bmp
+126.9743636364	n/a	31743.5909	left_press	n/a	n/a	33	n/a	256	n/a
+127.2743636364	n/a	31818.5909	show_circle	n/a	n/a	33	n/a	0	circle.bmp
+128.9743636364	n/a	32243.5909	show_cross	n/a	n/a	34	n/a	n/a	cross.bmp
+129.5407272727	n/a	32385.1818	show_face	famous_face	delayed_repeat	34	10	7	f105.bmp
+130.1416363636	n/a	32535.4091	right_press	n/a	n/a	34	n/a	4096	n/a
+130.4925454545	n/a	32623.1364	show_circle	n/a	n/a	34	n/a	0	circle.bmp
+132.19254545450002	n/a	33048.1364	show_cross	n/a	n/a	35	n/a	n/a	cross.bmp
+132.7643636364	n/a	33191.0909	show_face	famous_face	first_show	35	n/a	5	f119.bmp
+133.3534545455	n/a	33338.3636	left_press	n/a	n/a	35	n/a	256	n/a
+133.608	n/a	33402.0	show_circle	n/a	n/a	35	n/a	0	circle.bmp
+135.308	n/a	33827.0	show_cross	n/a	n/a	36	n/a	n/a	cross.bmp
+135.9052727273	n/a	33976.3182	show_face	famous_face	immediate_repeat	36	1	6	f119.bmp
+136.4534545455	n/a	34113.3636	left_press	n/a	n/a	36	n/a	256	n/a
+136.92163636360002	n/a	34230.4091	show_circle	n/a	n/a	36	n/a	0	circle.bmp
+138.6216363636	n/a	34655.4091	show_cross	n/a	n/a	37	n/a	n/a	cross.bmp
+139.2461818182	n/a	34811.5455	show_face	famous_face	delayed_repeat	37	11	7	f138.bmp
+139.83072727270002	n/a	34957.6818	right_press	n/a	n/a	37	n/a	4096	n/a
+140.20981818180002	n/a	35052.4545	show_circle	n/a	n/a	37	n/a	0	circle.bmp
+141.9098181818	n/a	35477.4545	show_cross	n/a	n/a	38	n/a	n/a	cross.bmp
+142.55436363639998	n/a	35638.5909	show_face	unfamiliar_face	first_show	38	n/a	13	u074.bmp
+143.0743636364	n/a	35768.5909	left_press	n/a	n/a	38	n/a	256	n/a
+143.448	n/a	35862.0	show_circle	n/a	n/a	38	n/a	0	circle.bmp
+145.148	n/a	36287.0	show_cross	n/a	n/a	39	n/a	n/a	cross.bmp
+145.74436363639998	n/a	36436.0909	show_face	unfamiliar_face	immediate_repeat	39	1	14	u074.bmp
+146.23163636360002	n/a	36557.9091	left_press	n/a	n/a	39	n/a	256	n/a
+146.7252727273	n/a	36681.3182	show_circle	n/a	n/a	39	n/a	0	circle.bmp
+148.42527272729998	n/a	37106.3182	show_cross	n/a	n/a	40	n/a	n/a	cross.bmp
+149.0689090909	n/a	37267.2273	show_face	unfamiliar_face	first_show	40	n/a	13	u134.bmp
+149.73527272729999	n/a	37433.8182	left_press	n/a	n/a	40	n/a	256	n/a
+149.9625454545	n/a	37490.6364	show_circle	n/a	n/a	40	n/a	0	circle.bmp
+151.66254545450002	n/a	37915.6364	show_cross	n/a	n/a	41	n/a	n/a	cross.bmp
+152.1261818182	n/a	38031.5455	show_face	unfamiliar_face	delayed_repeat	41	10	15	u127.bmp
+152.6370909091	n/a	38159.2727	right_press	n/a	n/a	41	n/a	4096	n/a
+153.0498181818	n/a	38262.4545	show_circle	n/a	n/a	41	n/a	0	circle.bmp
+154.7498181818	n/a	38687.4545	show_cross	n/a	n/a	42	n/a	n/a	cross.bmp
+155.3834545455	n/a	38845.8636	show_face	scrambled_face	first_show	42	n/a	17	s150.bmp
+156.3143636364	n/a	39078.5909	show_circle	n/a	n/a	42	n/a	0	circle.bmp
+156.5061818182	n/a	39126.5455	right_press	n/a	n/a	42	n/a	4096	n/a
+158.0143636364	n/a	39503.5909	show_cross	n/a	n/a	43	n/a	n/a	cross.bmp
+158.5752727273	n/a	39643.8182	show_face	scrambled_face	delayed_repeat	43	11	19	s103.bmp
+159.4952727273	n/a	39873.8182	right_press	n/a	n/a	43	n/a	4096	n/a
+159.4961818182	n/a	39874.0455	show_circle	n/a	n/a	43	n/a	0	circle.bmp
+161.1961818182	n/a	40299.0455	show_cross	n/a	n/a	44	n/a	n/a	cross.bmp
+161.8152727273	n/a	40453.8182	show_face	unfamiliar_face	first_show	44	n/a	13	u077.bmp
+162.388	n/a	40597.0	left_press	n/a	n/a	44	n/a	256	n/a
+162.6416363636	n/a	40660.4091	show_circle	n/a	n/a	44	n/a	0	circle.bmp
+164.3416363636	n/a	41085.4091	show_cross	n/a	n/a	45	n/a	n/a	cross.bmp
+164.8552727273	n/a	41213.8182	show_face	unfamiliar_face	immediate_repeat	45	1	14	u077.bmp
+165.4570909091	n/a	41364.2727	left_press	n/a	n/a	45	n/a	256	n/a
+165.8652727273	n/a	41466.3182	show_circle	n/a	n/a	45	n/a	0	circle.bmp
+167.5652727273	n/a	41891.3182	show_cross	n/a	n/a	46	n/a	n/a	cross.bmp
+168.1298181818	n/a	42032.4545	show_face	unfamiliar_face	delayed_repeat	46	13	15	u143.bmp
+168.7543636364	n/a	42188.5909	left_press	n/a	n/a	46	n/a	256	n/a
+168.9934545455	n/a	42248.3636	show_circle	n/a	n/a	46	n/a	0	circle.bmp
+170.6934545455	n/a	42673.3636	show_cross	n/a	n/a	47	n/a	n/a	cross.bmp
+171.3370909091	n/a	42834.2727	show_face	scrambled_face	first_show	47	n/a	17	s026.bmp
+172.1070909091	n/a	43026.7727	right_press	n/a	n/a	47	n/a	4096	n/a
+172.3189090909	n/a	43079.7273	show_circle	n/a	n/a	47	n/a	0	circle.bmp
+174.0189090909	n/a	43504.7273	show_cross	n/a	n/a	48	n/a	n/a	cross.bmp
+174.528	n/a	43632.0	show_face	scrambled_face	immediate_repeat	48	1	18	s026.bmp
+175.1616363636	n/a	43790.4091	right_press	n/a	n/a	48	n/a	4096	n/a
+175.3970909091	n/a	43849.2727	show_circle	n/a	n/a	48	n/a	0	circle.bmp
+177.0970909091	n/a	44274.2727	show_cross	n/a	n/a	49	n/a	n/a	cross.bmp
+177.6016363636	n/a	44400.4091	show_face	famous_face	first_show	49	n/a	5	f036.bmp
+178.2043636364	n/a	44551.0909	left_press	n/a	n/a	49	n/a	256	n/a
+178.54163636360002	n/a	44635.4091	show_circle	n/a	n/a	49	n/a	0	circle.bmp
+180.2416363636	n/a	45060.4091	show_cross	n/a	n/a	50	n/a	n/a	cross.bmp
+180.7089090909	n/a	45177.2273	show_face	famous_face	immediate_repeat	50	1	6	f036.bmp
+181.2907272727	n/a	45322.6818	left_press	n/a	n/a	50	n/a	256	n/a
+181.7089090909	n/a	45427.2273	show_circle	n/a	n/a	50	n/a	0	circle.bmp
+183.4089090909	n/a	45852.2273	show_cross	n/a	n/a	51	n/a	n/a	cross.bmp
+183.8661818182	n/a	45966.5455	show_face	scrambled_face	first_show	51	n/a	17	s101.bmp
+184.668	n/a	46167.0	right_press	n/a	n/a	51	n/a	4096	n/a
+184.6970909091	n/a	46174.2727	show_circle	n/a	n/a	51	n/a	0	circle.bmp
+186.3970909091	n/a	46599.2727	show_cross	n/a	n/a	52	n/a	n/a	cross.bmp
+186.9898181818	n/a	46747.4545	show_face	unfamiliar_face	delayed_repeat	52	12	15	u134.bmp
+187.8252727273	n/a	46956.3182	show_circle	n/a	n/a	52	n/a	0	circle.bmp
+188.3098181818	n/a	47077.4545	right_press	n/a	n/a	52	n/a	4096	n/a
+189.5252727273	n/a	47381.3182	show_cross	n/a	n/a	53	n/a	n/a	cross.bmp
+190.1134545455	n/a	47528.3636	show_face	unfamiliar_face	first_show	53	n/a	13	u016.bmp
+190.7298181818	n/a	47682.4545	left_press	n/a	n/a	53	n/a	256	n/a
+190.9589090909	n/a	47739.7273	show_circle	n/a	n/a	53	n/a	0	circle.bmp
+192.6589090909	n/a	48164.7273	show_cross	n/a	n/a	54	n/a	n/a	cross.bmp
+193.2370909091	n/a	48309.2727	show_face	unfamiliar_face	immediate_repeat	54	1	14	u016.bmp
+193.77890909090002	n/a	48444.7273	left_press	n/a	n/a	54	n/a	256	n/a
+194.1825454545	n/a	48545.6364	show_circle	n/a	n/a	54	n/a	0	circle.bmp
+195.88254545450002	n/a	48970.6364	show_cross	n/a	n/a	55	n/a	n/a	cross.bmp
+196.4116363636	n/a	49102.9091	show_face	scrambled_face	delayed_repeat	55	13	19	s150.bmp
+197.21436363639998	n/a	49303.5909	right_press	n/a	n/a	55	n/a	4096	n/a
+197.3770909091	n/a	49344.2727	show_circle	n/a	n/a	55	n/a	0	circle.bmp
+199.0770909091	n/a	49769.2727	show_cross	n/a	n/a	56	n/a	n/a	cross.bmp
+199.5352727273	n/a	49883.8182	show_face	unfamiliar_face	first_show	56	n/a	13	u049.bmp
+200.498	n/a	50124.5	right_press	n/a	n/a	56	n/a	4096	n/a
+200.5452727273	n/a	50136.3182	show_circle	n/a	n/a	56	n/a	0	circle.bmp
+202.2452727273	n/a	50561.3182	show_cross	n/a	n/a	57	n/a	n/a	cross.bmp
+202.7261818182	n/a	50681.5455	show_face	scrambled_face	first_show	57	n/a	17	s129.bmp
+203.3661818182	n/a	50841.5455	left_press	n/a	n/a	57	n/a	256	n/a
+203.58072727270002	n/a	50895.1818	show_circle	n/a	n/a	57	n/a	0	circle.bmp
+205.2807272727	n/a	51320.1818	show_cross	n/a	n/a	58	n/a	n/a	cross.bmp
+205.93345454549998	n/a	51483.3636	show_face	scrambled_face	immediate_repeat	58	1	18	s129.bmp
+206.4834545455	n/a	51620.8636	left_press	n/a	n/a	58	n/a	256	n/a
+206.768	n/a	51692.0	show_circle	n/a	n/a	58	n/a	0	circle.bmp
+208.468	n/a	52117.0	show_cross	n/a	n/a	59	n/a	n/a	cross.bmp
+208.9407272727	n/a	52235.1818	show_face	famous_face	first_show	59	n/a	5	f038.bmp
+209.7161818182	n/a	52429.0455	left_press	n/a	n/a	59	n/a	256	n/a
+209.9007272727	n/a	52475.1818	show_circle	n/a	n/a	59	n/a	0	circle.bmp
+211.6007272727	n/a	52900.1818	show_cross	n/a	n/a	60	n/a	n/a	cross.bmp
+212.198	n/a	53049.5	show_face	scrambled_face	first_show	60	n/a	17	s001.bmp
+213.0834545455	n/a	53270.8636	left_press	n/a	n/a	60	n/a	256	n/a
+213.188	n/a	53297.0	show_circle	n/a	n/a	60	n/a	0	circle.bmp
+214.888	n/a	53722.0	show_cross	n/a	n/a	61	n/a	n/a	cross.bmp
+215.3716363636	n/a	53842.9091	show_face	scrambled_face	delayed_repeat	61	10	19	s101.bmp
+216.1989090909	n/a	54049.7273	left_press	n/a	n/a	61	n/a	256	n/a
+216.358	n/a	54089.5	show_circle	n/a	n/a	61	n/a	0	circle.bmp
+218.058	n/a	54514.5	show_cross	n/a	n/a	62	n/a	n/a	cross.bmp
+218.54618181819998	n/a	54636.5455	show_face	unfamiliar_face	first_show	62	n/a	13	u084.bmp
+219.2952727273	n/a	54823.8182	left_press	n/a	n/a	62	n/a	256	n/a
+219.40345454549998	n/a	54850.8636	show_circle	n/a	n/a	62	n/a	0	circle.bmp
+221.1034545455	n/a	55275.8636	show_cross	n/a	n/a	63	n/a	n/a	cross.bmp
+221.5698181818	n/a	55392.4545	show_face	unfamiliar_face	immediate_repeat	63	1	14	u084.bmp
+222.26163636360002	n/a	55565.4091	left_press	n/a	n/a	63	n/a	256	n/a
+222.46345454549999	n/a	55615.8636	show_circle	n/a	n/a	63	n/a	0	circle.bmp
+224.1634545455	n/a	56040.8636	show_cross	n/a	n/a	64	n/a	n/a	cross.bmp
+224.7770909091	n/a	56194.2727	show_face	scrambled_face	first_show	64	n/a	17	s029.bmp
+225.538	n/a	56384.5	right_press	n/a	n/a	64	n/a	4096	n/a
+225.7343636364	n/a	56433.5909	show_circle	n/a	n/a	64	n/a	0	circle.bmp
+227.4343636364	n/a	56858.5909	show_cross	n/a	n/a	65	n/a	n/a	cross.bmp
+227.9343636364	n/a	56983.5909	show_face	scrambled_face	immediate_repeat	65	1	18	s029.bmp
+228.77890909090002	n/a	57194.7273	show_circle	n/a	n/a	65	n/a	0	circle.bmp
+228.85618181819999	n/a	57214.0455	left_press	n/a	n/a	65	n/a	256	n/a
+230.4789090909	n/a	57619.7273	show_cross	n/a	n/a	66	n/a	n/a	cross.bmp
+231.0916363636	n/a	57772.9091	show_face	unfamiliar_face	delayed_repeat	66	10	15	u049.bmp
+231.95527272729998	n/a	57988.8182	right_press	n/a	n/a	66	n/a	4096	n/a
+232.0652727273	n/a	58016.3182	show_circle	n/a	n/a	66	n/a	0	circle.bmp
+233.7652727273	n/a	58441.3182	show_cross	n/a	n/a	67	n/a	n/a	cross.bmp
+234.38254545450002	n/a	58595.6364	show_face	unfamiliar_face	first_show	67	n/a	13	u145.bmp
+235.3070909091	n/a	58826.7727	show_circle	n/a	n/a	67	n/a	0	circle.bmp
+236.1898181818	n/a	59047.4545	right_press	n/a	n/a	67	n/a	4096	n/a
+237.0070909091	n/a	59251.7727	show_cross	n/a	n/a	68	n/a	n/a	cross.bmp
+237.47254545450002	n/a	59368.1364	show_face	scrambled_face	first_show	68	n/a	17	s030.bmp
+238.1034545455	n/a	59525.8636	left_press	n/a	n/a	68	n/a	256	n/a
+238.3925454545	n/a	59598.1364	show_circle	n/a	n/a	68	n/a	0	circle.bmp
+240.0925454545	n/a	60023.1364	show_cross	n/a	n/a	69	n/a	n/a	cross.bmp
+240.5961818182	n/a	60149.0455	show_face	famous_face	delayed_repeat	69	10	7	f038.bmp
+241.2116363636	n/a	60302.9091	left_press	n/a	n/a	69	n/a	256	n/a
+241.5489090909	n/a	60387.2273	show_circle	n/a	n/a	69	n/a	0	circle.bmp
+243.2489090909	n/a	60812.2273	show_cross	n/a	n/a	70	n/a	n/a	cross.bmp
+243.7370909091	n/a	60934.2727	show_face	scrambled_face	first_show	70	n/a	17	s060.bmp
+244.56345454549998	n/a	61140.8636	right_press	n/a	n/a	70	n/a	4096	n/a
+244.7552727273	n/a	61188.8182	show_circle	n/a	n/a	70	n/a	0	circle.bmp
+246.45527272729998	n/a	61613.8182	show_cross	n/a	n/a	71	n/a	n/a	cross.bmp
+247.0952727273	n/a	61773.8182	show_face	scrambled_face	delayed_repeat	71	11	19	s001.bmp
+247.8970909091	n/a	61974.2727	left_press	n/a	n/a	71	n/a	256	n/a
+247.9507272727	n/a	61987.6818	show_circle	n/a	n/a	71	n/a	0	circle.bmp
+249.6507272727	n/a	62412.6818	show_cross	n/a	n/a	72	n/a	n/a	cross.bmp
+250.23527272729999	n/a	62558.8182	show_face	unfamiliar_face	first_show	72	n/a	13	u050.bmp
+250.9589090909	n/a	62739.7273	left_press	n/a	n/a	72	n/a	256	n/a
+251.068	n/a	62767.0	show_circle	n/a	n/a	72	n/a	0	circle.bmp
+252.768	n/a	63192.0	show_cross	n/a	n/a	73	n/a	n/a	cross.bmp
+253.3425454545	n/a	63335.6364	show_face	unfamiliar_face	immediate_repeat	73	1	14	u050.bmp
+253.83436363639998	n/a	63458.5909	left_press	n/a	n/a	73	n/a	256	n/a
+254.3298181818	n/a	63582.4545	show_circle	n/a	n/a	73	n/a	0	circle.bmp
+256.0298181818	n/a	64007.4545	show_cross	n/a	n/a	74	n/a	n/a	cross.bmp
+256.5834545455	n/a	64145.8636	show_face	scrambled_face	first_show	74	n/a	17	s076.bmp
+257.3061818182	n/a	64326.5455	left_press	n/a	n/a	74	n/a	256	n/a
+257.528	n/a	64382.0	show_circle	n/a	n/a	74	n/a	0	circle.bmp
+259.228	n/a	64807.0	show_cross	n/a	n/a	75	n/a	n/a	cross.bmp
+259.7070909091	n/a	64926.7727	show_face	scrambled_face	first_show	75	n/a	17	s137.bmp
+260.2498181818	n/a	65062.4545	left_press	n/a	n/a	75	n/a	256	n/a
+260.5998181818	n/a	65149.9545	show_circle	n/a	n/a	75	n/a	0	circle.bmp
+262.2998181818	n/a	65574.9545	show_cross	n/a	n/a	76	n/a	n/a	cross.bmp
+262.8307272727	n/a	65707.6818	show_face	unfamiliar_face	delayed_repeat	76	9	15	u145.bmp
+263.6861818182	n/a	65921.5455	left_press	n/a	n/a	76	n/a	256	n/a
+263.7625454545	n/a	65940.6364	show_circle	n/a	n/a	76	n/a	0	circle.bmp
+265.4625454545	n/a	66365.6364	show_cross	n/a	n/a	77	n/a	n/a	cross.bmp
+265.9716363636	n/a	66492.9091	show_face	unfamiliar_face	first_show	77	n/a	13	u020.bmp
+266.5070909091	n/a	66626.7727	right_press	n/a	n/a	77	n/a	4096	n/a
+266.9798181818	n/a	66744.9545	show_circle	n/a	n/a	77	n/a	0	circle.bmp
+268.6798181818	n/a	67169.9545	show_cross	n/a	n/a	78	n/a	n/a	cross.bmp
+269.2798181818	n/a	67319.9545	show_face	unfamiliar_face	immediate_repeat	78	1	14	u020.bmp
+269.84527272729997	n/a	67461.3182	left_press	n/a	n/a	78	n/a	256	n/a
+270.2316363636	n/a	67557.9091	show_circle	n/a	n/a	78	n/a	0	circle.bmp
+271.9316363636	n/a	67982.9091	show_cross	n/a	n/a	79	n/a	n/a	cross.bmp
+272.3861818182	n/a	68096.5455	show_face	scrambled_face	delayed_repeat	79	11	19	s030.bmp
+273.2989090909	n/a	68324.7273	right_press	n/a	n/a	79	n/a	4096	n/a
+273.3707272727	n/a	68342.6818	show_circle	n/a	n/a	79	n/a	0	circle.bmp
+275.0707272727	n/a	68767.6818	show_cross	n/a	n/a	80	n/a	n/a	cross.bmp
+275.6770909091	n/a	68919.2727	show_face	unfamiliar_face	first_show	80	n/a	13	u056.bmp
+276.5016363636	n/a	69125.4091	left_press	n/a	n/a	80	n/a	256	n/a
+276.6289090909	n/a	69157.2273	show_circle	n/a	n/a	80	n/a	0	circle.bmp
+278.3289090909	n/a	69582.2273	show_cross	n/a	n/a	81	n/a	n/a	cross.bmp
+278.968	n/a	69742.0	show_face	scrambled_face	delayed_repeat	81	11	19	s060.bmp
+279.5816363636	n/a	69895.4091	right_press	n/a	n/a	81	n/a	4096	n/a
+279.8416363636	n/a	69960.4091	show_circle	n/a	n/a	81	n/a	0	circle.bmp
+281.5416363636	n/a	70385.4091	show_cross	n/a	n/a	82	n/a	n/a	cross.bmp
+282.1761818182	n/a	70544.0455	show_face	famous_face	first_show	82	n/a	5	f032.bmp
+282.9734545455	n/a	70743.3636	right_press	n/a	n/a	82	n/a	4096	n/a
+282.9952727273	n/a	70748.8182	show_circle	n/a	n/a	82	n/a	0	circle.bmp
+284.6952727273	n/a	71173.8182	show_cross	n/a	n/a	83	n/a	n/a	cross.bmp
+285.2325454545	n/a	71308.1364	show_face	scrambled_face	first_show	83	n/a	17	s077.bmp
+285.818	n/a	71454.5	left_press	n/a	n/a	83	n/a	256	n/a
+286.1061818182	n/a	71526.5455	show_circle	n/a	n/a	83	n/a	0	circle.bmp
+287.8061818182	n/a	71951.5455	show_cross	n/a	n/a	84	n/a	n/a	cross.bmp
+288.3898181818	n/a	72097.4545	show_face	scrambled_face	immediate_repeat	84	1	18	s077.bmp
+288.8970909091	n/a	72224.2727	left_press	n/a	n/a	84	n/a	256	n/a
+289.2743636364	n/a	72318.5909	show_circle	n/a	n/a	84	n/a	0	circle.bmp
+290.97436363639997	n/a	72743.5909	show_cross	n/a	n/a	85	n/a	n/a	cross.bmp
+291.4970909091	n/a	72874.2727	show_face	scrambled_face	delayed_repeat	85	11	19	s076.bmp
+292.3725454545	n/a	73093.1364	show_circle	n/a	n/a	85	n/a	0	circle.bmp
+292.3907272727	n/a	73097.6818	left_press	n/a	n/a	85	n/a	256	n/a
+294.0725454545	n/a	73518.1364	show_cross	n/a	n/a	86	n/a	n/a	cross.bmp
+294.688	n/a	73672.0	show_face	famous_face	first_show	86	n/a	5	f133.bmp
+295.2989090909	n/a	73824.7273	right_press	n/a	n/a	86	n/a	4096	n/a
+295.60345454549997	n/a	73900.8636	show_circle	n/a	n/a	86	n/a	0	circle.bmp
+297.3034545455	n/a	74325.8636	show_cross	n/a	n/a	87	n/a	n/a	cross.bmp
+297.7952727273	n/a	74448.8182	show_face	famous_face	immediate_repeat	87	1	6	f133.bmp
+298.6107272727	n/a	74652.6818	right_press	n/a	n/a	87	n/a	4096	n/a
+298.7152727273	n/a	74678.8182	show_circle	n/a	n/a	87	n/a	0	circle.bmp
+300.4152727273	n/a	75103.8182	show_cross	n/a	n/a	88	n/a	n/a	cross.bmp
+300.9689090909	n/a	75242.2273	show_face	scrambled_face	delayed_repeat	88	13	19	s137.bmp
+301.5734545455	n/a	75393.3636	left_press	n/a	n/a	88	n/a	256	n/a
+301.8143636364	n/a	75453.5909	show_circle	n/a	n/a	88	n/a	0	circle.bmp
+303.5143636364	n/a	75878.5909	show_cross	n/a	n/a	89	n/a	n/a	cross.bmp
+304.0425454545	n/a	76010.6364	show_face	unfamiliar_face	first_show	89	n/a	13	u064.bmp
+304.6407272727	n/a	76160.1818	right_press	n/a	n/a	89	n/a	4096	n/a
+305.0543636364	n/a	76263.5909	show_circle	n/a	n/a	89	n/a	0	circle.bmp
+306.7543636364	n/a	76688.5909	show_cross	n/a	n/a	90	n/a	n/a	cross.bmp
+307.4007272727	n/a	76850.1818	show_face	unfamiliar_face	immediate_repeat	90	1	14	u064.bmp
+307.898	n/a	76974.5	right_press	n/a	n/a	90	n/a	4096	n/a
+308.25072727270003	n/a	77062.6818	show_circle	n/a	n/a	90	n/a	0	circle.bmp
+309.9507272727	n/a	77487.6818	show_cross	n/a	n/a	91	n/a	n/a	cross.bmp
+310.4070909091	n/a	77601.7727	show_face	scrambled_face	first_show	91	n/a	17	s113.bmp
+311.2298181818	n/a	77807.4545	show_circle	n/a	n/a	91	n/a	0	circle.bmp
+311.2370909091	n/a	77809.2727	right_press	n/a	n/a	91	n/a	4096	n/a
+312.9298181818	n/a	78232.4545	show_cross	n/a	n/a	92	n/a	n/a	cross.bmp
+313.4316363636	n/a	78357.9091	show_face	unfamiliar_face	delayed_repeat	92	12	15	u056.bmp
+314.0770909091	n/a	78519.2727	left_press	n/a	n/a	92	n/a	256	n/a
+314.3489090909	n/a	78587.2273	show_circle	n/a	n/a	92	n/a	0	circle.bmp
+316.0489090909	n/a	79012.2273	show_cross	n/a	n/a	93	n/a	n/a	cross.bmp
+316.588	n/a	79147.0	show_face	famous_face	first_show	93	n/a	5	f015.bmp
+317.1916363636	n/a	79297.9091	right_press	n/a	n/a	93	n/a	4096	n/a
+317.42345454549996	n/a	79355.8636	show_circle	n/a	n/a	93	n/a	0	circle.bmp
+319.1234545455	n/a	79780.8636	show_cross	n/a	n/a	94	n/a	n/a	cross.bmp
+319.5789090909	n/a	79894.7273	show_face	famous_face	immediate_repeat	94	1	6	f015.bmp
+320.0925454545	n/a	80023.1364	right_press	n/a	n/a	94	n/a	4096	n/a
+320.5643636364	n/a	80141.0909	show_circle	n/a	n/a	94	n/a	0	circle.bmp
+322.2643636364	n/a	80566.0909	show_cross	n/a	n/a	95	n/a	n/a	cross.bmp
+322.83709090909997	n/a	80709.2727	show_face	famous_face	delayed_repeat	95	13	7	f032.bmp
+323.4870909091	n/a	80871.7727	right_press	n/a	n/a	95	n/a	4096	n/a
+323.7452727273	n/a	80936.3182	show_circle	n/a	n/a	95	n/a	0	circle.bmp
+325.4452727273	n/a	81361.3182	show_cross	n/a	n/a	96	n/a	n/a	cross.bmp
+325.9770909091	n/a	81494.2727	show_face	famous_face	first_show	96	n/a	5	f005.bmp
+326.688	n/a	81672.0	right_press	n/a	n/a	96	n/a	4096	n/a
+326.8443636364	n/a	81711.0909	show_circle	n/a	n/a	96	n/a	0	circle.bmp
+328.5443636364	n/a	82136.0909	show_cross	n/a	n/a	97	n/a	n/a	cross.bmp
+329.1670909091	n/a	82291.7727	show_face	famous_face	immediate_repeat	97	1	6	f005.bmp
+329.7625454545	n/a	82440.6364	right_press	n/a	n/a	97	n/a	4096	n/a
+330.1343636364	n/a	82533.5909	show_circle	n/a	n/a	97	n/a	0	circle.bmp
+331.8343636364	n/a	82958.5909	show_cross	n/a	n/a	98	n/a	n/a	cross.bmp
+332.4252727273	n/a	83106.3182	show_face	famous_face	first_show	98	n/a	5	f115.bmp
+333.1543636364	n/a	83288.5909	right_press	n/a	n/a	98	n/a	4096	n/a
+333.3143636364	n/a	83328.5909	show_circle	n/a	n/a	98	n/a	0	circle.bmp
+335.0143636364	n/a	83753.5909	show_cross	n/a	n/a	99	n/a	n/a	cross.bmp
+335.5652727273	n/a	83891.3182	show_face	famous_face	first_show	99	n/a	5	f040.bmp
+336.168	n/a	84042.0	right_press	n/a	n/a	99	n/a	4096	n/a
+336.5089090909	n/a	84127.2273	show_circle	n/a	n/a	99	n/a	0	circle.bmp
+338.2089090909	n/a	84552.2273	show_cross	n/a	n/a	100	n/a	n/a	cross.bmp
+338.8061818182	n/a	84701.5455	show_face	famous_face	immediate_repeat	100	1	6	f040.bmp
+339.28527272729997	n/a	84821.3182	right_press	n/a	n/a	100	n/a	4096	n/a
+339.7907272727	n/a	84947.6818	show_circle	n/a	n/a	100	n/a	0	circle.bmp
+341.4907272727	n/a	85372.6818	show_cross	n/a	n/a	101	n/a	n/a	cross.bmp
+342.0307272727	n/a	85507.6818	show_face	scrambled_face	first_show	101	n/a	17	s109.bmp
+342.93254545450003	n/a	85733.1364	left_press	n/a	n/a	101	n/a	256	n/a
+343.0243636364	n/a	85756.0909	show_circle	n/a	n/a	101	n/a	0	circle.bmp
+344.72436363639997	n/a	86181.0909	show_cross	n/a	n/a	102	n/a	n/a	cross.bmp
+345.3216363636	n/a	86330.4091	show_face	scrambled_face	delayed_repeat	102	11	19	s113.bmp
+345.928	n/a	86482.0	left_press	n/a	n/a	102	n/a	256	n/a
+346.258	n/a	86564.5	show_circle	n/a	n/a	102	n/a	0	circle.bmp
+347.958	n/a	86989.5	show_cross	n/a	n/a	103	n/a	n/a	cross.bmp
+348.4961818182	n/a	87124.0455	show_face	scrambled_face	first_show	103	n/a	17	s003.bmp
+349.19709090910004	n/a	87299.2727	right_press	n/a	n/a	103	n/a	4096	n/a
+349.508	n/a	87377.0	show_circle	n/a	n/a	103	n/a	0	circle.bmp
+351.208	n/a	87802.0	show_cross	n/a	n/a	104	n/a	n/a	cross.bmp
+351.70254545449995	n/a	87925.6364	show_face	scrambled_face	immediate_repeat	104	1	18	s003.bmp
+352.2316363636	n/a	88057.9091	right_press	n/a	n/a	104	n/a	4096	n/a
+352.71254545449995	n/a	88178.1364	show_circle	n/a	n/a	104	n/a	0	circle.bmp
+354.4125454545	n/a	88603.1364	show_cross	n/a	n/a	105	n/a	n/a	cross.bmp
+354.89345454550005	n/a	88723.3636	show_face	unfamiliar_face	first_show	105	n/a	13	u141.bmp
+355.76890909089997	n/a	88942.2273	show_circle	n/a	n/a	105	n/a	0	circle.bmp
+355.8561818182	n/a	88964.0455	right_press	n/a	n/a	105	n/a	4096	n/a
+357.46890909089996	n/a	89367.2273	show_cross	n/a	n/a	106	n/a	n/a	cross.bmp
+358.11709090910006	n/a	89529.2727	show_face	scrambled_face	first_show	106	n/a	17	s009.bmp
+359.0325454545	n/a	89758.1364	show_circle	n/a	n/a	106	n/a	0	circle.bmp
+359.0643636364	n/a	89766.0909	right_press	n/a	n/a	106	n/a	4096	n/a
+360.7325454545	n/a	90183.1364	show_cross	n/a	n/a	107	n/a	n/a	cross.bmp
+361.1916363636	n/a	90297.9091	show_face	scrambled_face	immediate_repeat	107	1	18	s009.bmp
+361.78345454550004	n/a	90445.8636	right_press	n/a	n/a	107	n/a	4096	n/a
+362.108	n/a	90527.0	show_circle	n/a	n/a	107	n/a	0	circle.bmp
+363.808	n/a	90952.0	show_cross	n/a	n/a	108	n/a	n/a	cross.bmp
+364.4489090909	n/a	91112.2273	show_face	famous_face	delayed_repeat	108	10	7	f115.bmp
+365.0898181818	n/a	91272.4545	right_press	n/a	n/a	108	n/a	4096	n/a
+365.4243636364	n/a	91356.0909	show_circle	n/a	n/a	108	n/a	0	circle.bmp
+367.1243636364	n/a	91781.0909	show_cross	n/a	n/a	109	n/a	n/a	cross.bmp
+367.7398181818	n/a	91934.9545	show_face	scrambled_face	first_show	109	n/a	17	s046.bmp
+368.5198181818	n/a	92129.9545	left_press	n/a	n/a	109	n/a	256	n/a
+368.71618181819997	n/a	92179.0455	show_circle	n/a	n/a	109	n/a	0	circle.bmp
+370.4161818182	n/a	92604.0455	show_cross	n/a	n/a	110	n/a	n/a	cross.bmp
+370.94709090910004	n/a	92736.7727	show_face	scrambled_face	immediate_repeat	110	1	18	s046.bmp
+371.5261818182	n/a	92881.5455	left_press	n/a	n/a	110	n/a	256	n/a
+371.9261818182	n/a	92981.5455	show_circle	n/a	n/a	110	n/a	0	circle.bmp
+373.6261818182	n/a	93406.5455	show_cross	n/a	n/a	111	n/a	n/a	cross.bmp
+374.2716363636	n/a	93567.9091	show_face	unfamiliar_face	first_show	111	n/a	13	u138.bmp
+374.97436363639997	n/a	93743.5909	right_press	n/a	n/a	111	n/a	4096	n/a
+375.2761818182	n/a	93819.0455	show_circle	n/a	n/a	111	n/a	0	circle.bmp
+376.9761818182	n/a	94244.0455	show_cross	n/a	n/a	112	n/a	n/a	cross.bmp
+377.42890909089994	n/a	94357.2273	show_face	unfamiliar_face	immediate_repeat	112	1	14	u138.bmp
+377.9943636364	n/a	94498.5909	right_press	n/a	n/a	112	n/a	4096	n/a
+378.3470909091	n/a	94586.7727	show_circle	n/a	n/a	112	n/a	0	circle.bmp
+380.04709090910006	n/a	95011.7727	show_cross	n/a	n/a	113	n/a	n/a	cross.bmp
+380.6361818182	n/a	95159.0455	show_face	scrambled_face	delayed_repeat	113	12	19	s109.bmp
+381.2952727273	n/a	95323.8182	left_press	n/a	n/a	113	n/a	256	n/a
+381.5798181818	n/a	95394.9545	show_circle	n/a	n/a	113	n/a	0	circle.bmp
+383.2798181818	n/a	95819.9545	show_cross	n/a	n/a	114	n/a	n/a	cross.bmp
+383.92709090910006	n/a	95981.7727	show_face	scrambled_face	first_show	114	n/a	17	s094.bmp
+384.57072727269997	n/a	96142.6818	right_press	n/a	n/a	114	n/a	4096	n/a
+384.7934545455	n/a	96198.3636	show_circle	n/a	n/a	114	n/a	0	circle.bmp
+386.4934545455	n/a	96623.3636	show_cross	n/a	n/a	115	n/a	n/a	cross.bmp
+387.0007272727	n/a	96750.1818	show_face	scrambled_face	immediate_repeat	115	1	18	s094.bmp
+387.52072727269996	n/a	96880.1818	right_press	n/a	n/a	115	n/a	4096	n/a
+387.9416363636	n/a	96985.4091	show_circle	n/a	n/a	115	n/a	0	circle.bmp
+389.6416363636	n/a	97410.4091	show_cross	n/a	n/a	116	n/a	n/a	cross.bmp
+390.2252727273	n/a	97556.3182	show_face	famous_face	first_show	116	n/a	5	f095.bmp
+390.9670909091	n/a	97741.7727	left_press	n/a	n/a	116	n/a	256	n/a
+391.06709090910005	n/a	97766.7727	show_circle	n/a	n/a	116	n/a	0	circle.bmp
+392.76709090910003	n/a	98191.7727	show_cross	n/a	n/a	117	n/a	n/a	cross.bmp
+393.2816363636	n/a	98320.4091	show_face	famous_face	immediate_repeat	117	1	6	f095.bmp
+393.8189090909	n/a	98454.7273	left_press	n/a	n/a	117	n/a	256	n/a
+394.2307272727	n/a	98557.6818	show_circle	n/a	n/a	117	n/a	0	circle.bmp
+395.9307272727	n/a	98982.6818	show_cross	n/a	n/a	118	n/a	n/a	cross.bmp
+396.5398181818	n/a	99134.9545	show_face	unfamiliar_face	delayed_repeat	118	13	15	u141.bmp
+397.3143636364	n/a	99328.5909	right_press	n/a	n/a	118	n/a	4096	n/a
+397.48890909089994	n/a	99372.2273	show_circle	n/a	n/a	118	n/a	0	circle.bmp
+399.1889090909	n/a	99797.2273	show_cross	n/a	n/a	119	n/a	n/a	cross.bmp
+399.76345454550005	n/a	99940.8636	show_face	scrambled_face	first_show	119	n/a	17	s132.bmp
+400.4934545455	n/a	100123.3636	left_press	n/a	n/a	119	n/a	256	n/a
+400.65345454550004	n/a	100163.3636	show_circle	n/a	n/a	119	n/a	0	circle.bmp
+402.3534545455	n/a	100588.3636	show_cross	n/a	n/a	120	n/a	n/a	cross.bmp
+403.0043636364	n/a	100751.0909	show_face	scrambled_face	immediate_repeat	120	1	18	s132.bmp
+403.64345454550005	n/a	100910.8636	left_press	n/a	n/a	120	n/a	256	n/a
+403.84254545449994	n/a	100960.6364	show_circle	n/a	n/a	120	n/a	0	circle.bmp
+405.5425454545	n/a	101385.6364	show_cross	n/a	n/a	121	n/a	n/a	cross.bmp
+406.028	n/a	101507.0	show_face	scrambled_face	first_show	121	n/a	17	s055.bmp
+406.7825454545	n/a	101695.6364	right_press	n/a	n/a	121	n/a	4096	n/a
+406.96345454550004	n/a	101740.8636	show_circle	n/a	n/a	121	n/a	0	circle.bmp
+408.66345454550003	n/a	102165.8636	show_cross	n/a	n/a	122	n/a	n/a	cross.bmp
+409.2352727273	n/a	102308.8182	show_face	unfamiliar_face	first_show	122	n/a	13	u005.bmp
+410.0343636364	n/a	102508.5909	left_press	n/a	n/a	122	n/a	256	n/a
+410.188	n/a	102547.0	show_circle	n/a	n/a	122	n/a	0	circle.bmp
+411.888	n/a	102972.0	show_cross	n/a	n/a	123	n/a	n/a	cross.bmp
+412.4261818182	n/a	103106.5455	show_face	unfamiliar_face	first_show	123	n/a	13	u054.bmp
+413.28345454550004	n/a	103320.8636	left_press	n/a	n/a	123	n/a	256	n/a
+413.2861818182	n/a	103321.5455	show_circle	n/a	n/a	123	n/a	0	circle.bmp
+414.9861818182	n/a	103746.5455	show_cross	n/a	n/a	124	n/a	n/a	cross.bmp
+415.5998181818	n/a	103899.9545	show_face	famous_face	first_show	124	n/a	5	f022.bmp
+416.3607272727	n/a	104090.1818	right_press	n/a	n/a	124	n/a	4096	n/a
+416.4770909091	n/a	104119.2727	show_circle	n/a	n/a	124	n/a	0	circle.bmp
+418.17709090910006	n/a	104544.2727	show_cross	n/a	n/a	125	n/a	n/a	cross.bmp
+418.7407272727	n/a	104685.1818	show_face	famous_face	immediate_repeat	125	1	6	f022.bmp
+419.2898181818	n/a	104822.4545	right_press	n/a	n/a	125	n/a	4096	n/a
+419.7543636364	n/a	104938.5909	show_circle	n/a	n/a	125	n/a	0	circle.bmp
+421.4543636364	n/a	105363.5909	show_cross	n/a	n/a	126	n/a	n/a	cross.bmp
+422.0816363636	n/a	105520.4091	show_face	scrambled_face	first_show	126	n/a	17	s095.bmp
+422.82345454550006	n/a	105705.8636	left_press	n/a	n/a	126	n/a	256	n/a
+422.9170909091	n/a	105729.2727	show_circle	n/a	n/a	126	n/a	0	circle.bmp
+424.61709090910006	n/a	106154.2727	show_cross	n/a	n/a	127	n/a	n/a	cross.bmp
+425.25527272730005	n/a	106313.8182	show_face	scrambled_face	first_show	127	n/a	17	s024.bmp
+426.1261818182	n/a	106531.5455	show_circle	n/a	n/a	127	n/a	0	circle.bmp
+426.1570909091	n/a	106539.2727	left_press	n/a	n/a	127	n/a	256	n/a
+427.8261818182	n/a	106956.5455	show_cross	n/a	n/a	128	n/a	n/a	cross.bmp
+428.2961818182	n/a	107074.0455	show_face	scrambled_face	delayed_repeat	128	7	19	s055.bmp
+429.01254545449996	n/a	107253.1364	left_press	n/a	n/a	128	n/a	256	n/a
+429.27527272730003	n/a	107318.8182	show_circle	n/a	n/a	128	n/a	0	circle.bmp
+430.9752727273	n/a	107743.8182	show_cross	n/a	n/a	129	n/a	n/a	cross.bmp
+431.5034545455	n/a	107875.8636	show_face	famous_face	first_show	129	n/a	5	f025.bmp
+432.26890909089997	n/a	108067.2273	left_press	n/a	n/a	129	n/a	256	n/a
+432.3643636364	n/a	108091.0909	show_circle	n/a	n/a	129	n/a	0	circle.bmp
+434.0643636364	n/a	108516.0909	show_cross	n/a	n/a	130	n/a	n/a	cross.bmp
+434.5434545455	n/a	108635.8636	show_face	famous_face	immediate_repeat	130	1	6	f025.bmp
+435.2225454545	n/a	108805.6364	left_press	n/a	n/a	130	n/a	256	n/a
+435.44709090910004	n/a	108861.7727	show_circle	n/a	n/a	130	n/a	0	circle.bmp
+437.14709090910003	n/a	109286.7727	show_cross	n/a	n/a	131	n/a	n/a	cross.bmp
+437.61709090910006	n/a	109404.2727	show_face	unfamiliar_face	delayed_repeat	131	9	15	u005.bmp
+438.40254545449994	n/a	109600.6364	left_press	n/a	n/a	131	n/a	256	n/a
+438.4498181818	n/a	109612.4545	show_circle	n/a	n/a	131	n/a	0	circle.bmp
+440.1498181818	n/a	110037.4545	show_cross	n/a	n/a	132	n/a	n/a	cross.bmp
+440.6743636364	n/a	110168.5909	show_face	famous_face	first_show	132	n/a	5	f137.bmp
+441.59890909089995	n/a	110399.7273	show_circle	n/a	n/a	132	n/a	0	circle.bmp
+442.1025454545	n/a	110525.6364	left_press	n/a	n/a	132	n/a	256	n/a
+443.29890909089994	n/a	110824.7273	show_cross	n/a	n/a	133	n/a	n/a	cross.bmp
+443.9489090909	n/a	110987.2273	show_face	unfamiliar_face	delayed_repeat	133	10	15	u054.bmp
+444.7316363636	n/a	111182.9091	left_press	n/a	n/a	133	n/a	256	n/a
+444.948	n/a	111237.0	show_circle	n/a	n/a	133	n/a	0	circle.bmp
+446.648	n/a	111662.0	show_cross	n/a	n/a	134	n/a	n/a	cross.bmp
+447.27345454550004	n/a	111818.3636	show_face	unfamiliar_face	first_show	134	n/a	13	u107.bmp
+447.8461818182	n/a	111961.5455	right_press	n/a	n/a	134	n/a	4096	n/a
+448.14709090910003	n/a	112036.7727	show_circle	n/a	n/a	134	n/a	0	circle.bmp
+449.8470909091	n/a	112461.7727	show_cross	n/a	n/a	135	n/a	n/a	cross.bmp
+450.44709090910004	n/a	112611.7727	show_face	unfamiliar_face	first_show	135	n/a	13	u108.bmp
+451.1125454545	n/a	112778.1364	right_press	n/a	n/a	135	n/a	4096	n/a
+451.3461818182	n/a	112836.5455	show_circle	n/a	n/a	135	n/a	0	circle.bmp
+453.0461818182	n/a	113261.5455	show_cross	n/a	n/a	136	n/a	n/a	cross.bmp
+453.6207272727	n/a	113405.1818	show_face	scrambled_face	delayed_repeat	136	10	19	s095.bmp
+454.3298181818	n/a	113582.4545	left_press	n/a	n/a	136	n/a	256	n/a
+454.6116363636	n/a	113652.9091	show_circle	n/a	n/a	136	n/a	0	circle.bmp
+456.31163636360003	n/a	114077.9091	show_cross	n/a	n/a	137	n/a	n/a	cross.bmp
+456.81163636360003	n/a	114202.9091	show_face	famous_face	first_show	137	n/a	5	f093.bmp
+457.4934545455	n/a	114373.3636	right_press	n/a	n/a	137	n/a	4096	n/a
+457.6916363636	n/a	114422.9091	show_circle	n/a	n/a	137	n/a	0	circle.bmp
+459.3916363636	n/a	114847.9091	show_cross	n/a	n/a	138	n/a	n/a	cross.bmp
+459.95254545449995	n/a	114988.1364	show_face	famous_face	immediate_repeat	138	1	6	f093.bmp
+460.678	n/a	115169.5	right_press	n/a	n/a	138	n/a	4096	n/a
+460.9125454545	n/a	115228.1364	show_circle	n/a	n/a	138	n/a	0	circle.bmp
+462.6125454545	n/a	115653.1364	show_cross	n/a	n/a	139	n/a	n/a	cross.bmp
+463.2261818182	n/a	115806.5455	show_face	scrambled_face	delayed_repeat	139	12	19	s024.bmp
+463.7898181818	n/a	115947.4545	left_press	n/a	n/a	139	n/a	256	n/a
+464.0716363636	n/a	116017.9091	show_circle	n/a	n/a	139	n/a	0	circle.bmp
+465.7716363636	n/a	116442.9091	show_cross	n/a	n/a	140	n/a	n/a	cross.bmp
+466.2498181818	n/a	116562.4545	show_face	unfamiliar_face	first_show	140	n/a	13	u121.bmp
+466.978	n/a	116744.5	right_press	n/a	n/a	140	n/a	4096	n/a
+467.21890909089996	n/a	116804.7273	show_circle	n/a	n/a	140	n/a	0	circle.bmp
+468.91890909089994	n/a	117229.7273	show_cross	n/a	n/a	141	n/a	n/a	cross.bmp
+469.54072727269994	n/a	117385.1818	show_face	famous_face	first_show	141	n/a	5	f048.bmp
+470.29890909089994	n/a	117574.7273	right_press	n/a	n/a	141	n/a	4096	n/a
+470.5452727273	n/a	117636.3182	show_circle	n/a	n/a	141	n/a	0	circle.bmp
+472.24527272730006	n/a	118061.3182	show_cross	n/a	n/a	142	n/a	n/a	cross.bmp
+472.7325454545	n/a	118183.1364	show_face	famous_face	delayed_repeat	142	10	7	f137.bmp
+473.46345454550004	n/a	118365.8636	left_press	n/a	n/a	142	n/a	256	n/a
+473.6907272727	n/a	118422.6818	show_circle	n/a	n/a	142	n/a	0	circle.bmp
+475.39072727269996	n/a	118847.6818	show_cross	n/a	n/a	143	n/a	n/a	cross.bmp
+475.8889090909	n/a	118972.2273	show_face	famous_face	first_show	143	n/a	5	f131.bmp
+476.5589090909	n/a	119139.7273	right_press	n/a	n/a	143	n/a	4096	n/a
+476.798	n/a	119199.5	show_circle	n/a	n/a	143	n/a	0	circle.bmp
+478.498	n/a	119624.5	show_cross	n/a	n/a	144	n/a	n/a	cross.bmp
+479.0461818182	n/a	119761.5455	show_face	unfamiliar_face	delayed_repeat	144	10	15	u107.bmp
+479.6570909091	n/a	119914.2727	right_press	n/a	n/a	144	n/a	4096	n/a
+479.9234545455	n/a	119980.8636	show_circle	n/a	n/a	144	n/a	0	circle.bmp
+481.6234545455	n/a	120405.8636	show_cross	n/a	n/a	145	n/a	n/a	cross.bmp
+482.23709090910006	n/a	120559.2727	show_face	famous_face	first_show	145	n/a	5	f078.bmp
+482.8707272727	n/a	120717.6818	right_press	n/a	n/a	145	n/a	4096	n/a
+483.2343636364	n/a	120808.5909	show_circle	n/a	n/a	145	n/a	0	circle.bmp
+484.9343636364	n/a	121233.5909	show_cross	n/a	n/a	146	n/a	n/a	cross.bmp
+485.428	n/a	121357.0	show_face	famous_face	immediate_repeat	146	1	6	f078.bmp
+486.0007272727	n/a	121500.1818	right_press	n/a	n/a	146	n/a	4096	n/a
+486.4361818182	n/a	121609.0455	show_circle	n/a	n/a	146	n/a	0	circle.bmp
+488.1361818182	n/a	122034.0455	show_cross	n/a	n/a	147	n/a	n/a	cross.bmp
+488.71890909089996	n/a	122179.7273	show_face	unfamiliar_face	delayed_repeat	147	12	15	u108.bmp
+489.3470909091	n/a	122336.7727	right_press	n/a	n/a	147	n/a	4096	n/a
+489.6116363636	n/a	122402.9091	show_circle	n/a	n/a	147	n/a	0	circle.bmp
+491.31163636360003	n/a	122827.9091	show_cross	n/a	n/a	148	n/a	n/a	cross.bmp

--- a/eeg_hed_small/sub-003/eeg/sub-003_task-FacePerception_run-2_events.tsv
+++ b/eeg_hed_small/sub-003/eeg/sub-003_task-FacePerception_run-2_events.tsv
@@ -1,593 +1,593 @@
-onset	duration	sample	event_type	face_type	repetition_type	trigger	stim_file
-0.0040000000	n/a	1	setup	n/a	n/a	n/a	n/a
-0.0040000000	n/a	1	right_sym	n/a	n/a	n/a	n/a
-25.0143636364	n/a	6253.5909	show_face	famous_face	first_show	5	f108.bmp
-25.8598181818	n/a	6464.9545	right_press	n/a	n/a	4096	n/a
-25.9516363636	n/a	6487.9091	show_circle	n/a	n/a	0	circle.bmp
-27.6516363636	n/a	6912.9091	show_cross	n/a	n/a	n/a	cross.bmp
-28.2552727273	n/a	7063.8182	show_face	scrambled_face	first_show	17	s141.bmp
-28.9170909091	n/a	7229.2727	left_press	n/a	n/a	256	n/a
-29.2725454545	n/a	7318.1364	show_circle	n/a	n/a	0	circle.bmp
-30.9725454545	n/a	7743.1364	show_cross	n/a	n/a	n/a	cross.bmp
-31.4452727273	n/a	7861.3182	show_face	scrambled_face	immediate_repeat	18	s141.bmp
-32.1234545455	n/a	8030.8636	left_press	n/a	n/a	256	n/a
-32.3816363636	n/a	8095.4091	show_circle	n/a	n/a	0	circle.bmp
-34.0816363636	n/a	8520.4091	show_cross	n/a	n/a	n/a	cross.bmp
-34.5698181818	n/a	8642.4545	show_face	unfamiliar_face	first_show	13	u132.bmp
-35.3943636364	n/a	8848.5909	right_press	n/a	n/a	4096	n/a
-35.4189090909	n/a	8854.7273	show_circle	n/a	n/a	0	circle.bmp
-37.1189090909	n/a	9279.7273	show_cross	n/a	n/a	n/a	cross.bmp
-37.7434545455	n/a	9435.8636	show_face	unfamiliar_face	immediate_repeat	14	u132.bmp
-38.1970909091	n/a	9549.2727	right_press	n/a	n/a	4096	n/a
-38.5725454545	n/a	9643.1364	show_circle	n/a	n/a	0	circle.bmp
-40.2725454545	n/a	10068.1364	show_cross	n/a	n/a	n/a	cross.bmp
-40.7834545455	n/a	10195.8636	show_face	scrambled_face	first_show	17	s033.bmp
-41.6189090909	n/a	10404.7273	right_press	n/a	n/a	4096	n/a
-41.7589090909	n/a	10439.7273	show_circle	n/a	n/a	0	circle.bmp
-43.4589090909	n/a	10864.7273	show_cross	n/a	n/a	n/a	cross.bmp
-44.0743636364	n/a	11018.5909	show_face	scrambled_face	immediate_repeat	18	s033.bmp
-44.5670909091	n/a	11141.7727	right_press	n/a	n/a	4096	n/a
-45.0161818182	n/a	11254.0455	show_circle	n/a	n/a	0	circle.bmp
-46.7161818182	n/a	11679.0455	show_cross	n/a	n/a	n/a	cross.bmp
-47.2489090909	n/a	11812.2273	show_face	scrambled_face	first_show	17	s062.bmp
-47.8234545455	n/a	11955.8636	left_press	n/a	n/a	256	n/a
-48.2470909091	n/a	12061.7727	show_circle	n/a	n/a	0	circle.bmp
-49.9470909091	n/a	12486.7727	show_cross	n/a	n/a	n/a	cross.bmp
-50.4389090909	n/a	12609.7273	show_face	famous_face	first_show	5	f102.bmp
-51.1325454545	n/a	12783.1364	right_press	n/a	n/a	4096	n/a
-51.2798181818	n/a	12819.9545	show_circle	n/a	n/a	0	circle.bmp
-52.9798181818	n/a	13244.9545	show_cross	n/a	n/a	n/a	cross.bmp
-53.5298181818	n/a	13382.4545	show_face	famous_face	immediate_repeat	6	f102.bmp
-54.0234545455	n/a	13505.8636	right_press	n/a	n/a	4096	n/a
-54.3998181818	n/a	13599.9545	show_circle	n/a	n/a	0	circle.bmp
-56.0998181818	n/a	14024.9545	show_cross	n/a	n/a	n/a	cross.bmp
-56.6034545455	n/a	14150.8636	show_face	famous_face	delayed_repeat	7	f108.bmp
-57.2434545455	n/a	14310.8636	right_press	n/a	n/a	4096	n/a
-57.4443636364	n/a	14361.0909	show_circle	n/a	n/a	0	circle.bmp
-59.1443636364	n/a	14786.0909	show_cross	n/a	n/a	n/a	cross.bmp
-59.7789090909	n/a	14944.7273	show_face	unfamiliar_face	first_show	13	u106.bmp
-60.4034545455	n/a	15100.8636	right_press	n/a	n/a	4096	n/a
-60.7607272727	n/a	15190.1818	show_circle	n/a	n/a	0	circle.bmp
-62.4607272727	n/a	15615.1818	show_cross	n/a	n/a	n/a	cross.bmp
-63.1189090909	n/a	15779.7273	show_face	scrambled_face	first_show	17	s017.bmp
-63.9698181818	n/a	15992.4545	left_press	n/a	n/a	256	n/a
-64.0725454545	n/a	16018.1364	show_circle	n/a	n/a	0	circle.bmp
-65.7725454545	n/a	16443.1364	show_cross	n/a	n/a	n/a	cross.bmp
-66.3589090909	n/a	16589.7273	show_face	unfamiliar_face	first_show	13	u024.bmp
-67.2180000000	n/a	16804.5	left_press	n/a	n/a	256	n/a
-67.2261818182	n/a	16806.5455	show_circle	n/a	n/a	0	circle.bmp
-68.9261818182	n/a	17231.5455	show_cross	n/a	n/a	n/a	cross.bmp
-69.5670909091	n/a	17391.7727	show_face	famous_face	first_show	5	f051.bmp
-70.1725454545	n/a	17543.1364	right_press	n/a	n/a	4096	n/a
-70.5616363636	n/a	17640.4091	show_circle	n/a	n/a	0	circle.bmp
-72.2616363636	n/a	18065.4091	show_cross	n/a	n/a	n/a	cross.bmp
-72.9080000000	n/a	18227	show_face	scrambled_face	delayed_repeat	19	s062.bmp
-73.7225454545	n/a	18430.6364	left_press	n/a	n/a	256	n/a
-73.8216363636	n/a	18455.4091	show_circle	n/a	n/a	0	circle.bmp
-75.5216363636	n/a	18880.4091	show_cross	n/a	n/a	n/a	cross.bmp
-76.0652727273	n/a	19016.3182	show_face	scrambled_face	first_show	17	s025.bmp
-76.8516363636	n/a	19212.9091	left_press	n/a	n/a	256	n/a
-77.0380000000	n/a	19259.5	show_circle	n/a	n/a	0	circle.bmp
-78.7380000000	n/a	19684.5	show_cross	n/a	n/a	n/a	cross.bmp
-79.2561818182	n/a	19814.0455	show_face	unfamiliar_face	first_show	13	u097.bmp
-79.8752727273	n/a	19968.8182	right_press	n/a	n/a	4096	n/a
-80.1680000000	n/a	20042	show_circle	n/a	n/a	0	circle.bmp
-81.8680000000	n/a	20467	show_cross	n/a	n/a	n/a	cross.bmp
-82.5134545455	n/a	20628.3636	show_face	unfamiliar_face	delayed_repeat	15	u106.bmp
-83.2434545455	n/a	20810.8636	right_press	n/a	n/a	4096	n/a
-83.4852727273	n/a	20871.3182	show_circle	n/a	n/a	0	circle.bmp
-85.1852727273	n/a	21296.3182	show_cross	n/a	n/a	n/a	cross.bmp
-85.7870909091	n/a	21446.7727	show_face	famous_face	first_show	5	f147.bmp
-86.5116363636	n/a	21627.9091	right_press	n/a	n/a	4096	n/a
-86.7452727273	n/a	21686.3182	show_circle	n/a	n/a	0	circle.bmp
-88.4452727273	n/a	22111.3182	show_cross	n/a	n/a	n/a	cross.bmp
-89.0452727273	n/a	22261.3182	show_face	scrambled_face	delayed_repeat	19	s017.bmp
-89.6243636364	n/a	22406.0909	left_press	n/a	n/a	256	n/a
-89.9643636364	n/a	22491.0909	show_circle	n/a	n/a	0	circle.bmp
-91.6643636364	n/a	22916.0909	show_cross	n/a	n/a	n/a	cross.bmp
-92.1852727273	n/a	23046.3182	show_face	scrambled_face	first_show	17	s080.bmp
-92.9625454545	n/a	23240.6364	left_press	n/a	n/a	256	n/a
-93.1170909091	n/a	23279.2727	show_circle	n/a	n/a	0	circle.bmp
-94.8170909091	n/a	23704.2727	show_cross	n/a	n/a	n/a	cross.bmp
-95.3261818182	n/a	23831.5455	show_face	scrambled_face	immediate_repeat	18	s080.bmp
-95.9489090909	n/a	23987.2273	left_press	n/a	n/a	256	n/a
-96.2061818182	n/a	24051.5455	show_circle	n/a	n/a	0	circle.bmp
-97.9061818182	n/a	24476.5455	show_cross	n/a	n/a	n/a	cross.bmp
-98.4161818182	n/a	24604.0455	show_face	unfamiliar_face	delayed_repeat	15	u024.bmp
-99.1952727273	n/a	24798.8182	left_press	n/a	n/a	256	n/a
-99.2743636364	n/a	24818.5909	show_circle	n/a	n/a	0	circle.bmp
-100.9743636364	n/a	25243.5909	show_cross	n/a	n/a	n/a	cross.bmp
-101.5570909091	n/a	25389.2727	show_face	unfamiliar_face	first_show	13	u098.bmp
-102.1661818182	n/a	25541.5455	right_press	n/a	n/a	4096	n/a
-102.5016363636	n/a	25625.4091	show_circle	n/a	n/a	0	circle.bmp
-104.2016363636	n/a	26050.4091	show_cross	n/a	n/a	n/a	cross.bmp
-104.8316363636	n/a	26207.9091	show_face	unfamiliar_face	immediate_repeat	14	u098.bmp
-105.3980000000	n/a	26349.5	right_press	n/a	n/a	4096	n/a
-105.8080000000	n/a	26452	show_circle	n/a	n/a	0	circle.bmp
-107.5080000000	n/a	26877	show_cross	n/a	n/a	n/a	cross.bmp
-107.9889090909	n/a	26997.2273	show_face	famous_face	delayed_repeat	7	f051.bmp
-108.6689090909	n/a	27167.2273	right_press	n/a	n/a	4096	n/a
-108.9852727273	n/a	27246.3182	show_circle	n/a	n/a	0	circle.bmp
-110.6852727273	n/a	27671.3182	show_cross	n/a	n/a	n/a	cross.bmp
-111.3298181818	n/a	27832.4545	show_face	unfamiliar_face	first_show	13	u100.bmp
-111.9307272727	n/a	27982.6818	left_press	n/a	n/a	256	n/a
-112.2098181818	n/a	28052.4545	show_circle	n/a	n/a	0	circle.bmp
-113.9098181818	n/a	28477.4545	show_cross	n/a	n/a	n/a	cross.bmp
-114.4870909091	n/a	28621.7727	show_face	scrambled_face	delayed_repeat	19	s025.bmp
-115.1225454545	n/a	28780.6364	left_press	n/a	n/a	256	n/a
-115.3643636364	n/a	28841.0909	show_circle	n/a	n/a	0	circle.bmp
-117.0643636364	n/a	29266.0909	show_cross	n/a	n/a	n/a	cross.bmp
-117.6107272727	n/a	29402.6818	show_face	famous_face	first_show	5	f099.bmp
-118.3225454545	n/a	29580.6364	right_press	n/a	n/a	4096	n/a
-118.4961818182	n/a	29624.0455	show_circle	n/a	n/a	0	circle.bmp
-120.1961818182	n/a	30049.0455	show_cross	n/a	n/a	n/a	cross.bmp
-120.7016363636	n/a	30175.4091	show_face	famous_face	immediate_repeat	6	f099.bmp
-121.2916363636	n/a	30322.9091	right_press	n/a	n/a	4096	n/a
-121.5316363636	n/a	30382.9091	show_circle	n/a	n/a	0	circle.bmp
-123.2316363636	n/a	30807.9091	show_cross	n/a	n/a	n/a	cross.bmp
-123.7080000000	n/a	30927	show_face	unfamiliar_face	delayed_repeat	15	u097.bmp
-124.3725454545	n/a	31093.1364	right_press	n/a	n/a	4096	n/a
-124.7080000000	n/a	31177	show_circle	n/a	n/a	0	circle.bmp
-126.4080000000	n/a	31602	show_cross	n/a	n/a	n/a	cross.bmp
-127.0161818182	n/a	31754.0455	show_face	scrambled_face	first_show	17	s071.bmp
-127.7516363636	n/a	31937.9091	right_press	n/a	n/a	4096	n/a
-127.8416363636	n/a	31960.4091	show_circle	n/a	n/a	0	circle.bmp
-129.5416363636	n/a	32385.4091	show_cross	n/a	n/a	n/a	cross.bmp
-130.1734545455	n/a	32543.3636	show_face	scrambled_face	immediate_repeat	18	s071.bmp
-131.0525454545	n/a	32763.1364	right_press	n/a	n/a	4096	n/a
-131.1007272727	n/a	32775.1818	show_circle	n/a	n/a	0	circle.bmp
-132.8007272727	n/a	33200.1818	show_cross	n/a	n/a	n/a	cross.bmp
-133.4307272727	n/a	33357.6818	show_face	famous_face	delayed_repeat	7	f147.bmp
-134.0570909091	n/a	33514.2727	right_press	n/a	n/a	4096	n/a
-134.3970909091	n/a	33599.2727	show_circle	n/a	n/a	0	circle.bmp
-136.0970909091	n/a	34024.2727	show_cross	n/a	n/a	n/a	cross.bmp
-136.7216363636	n/a	34180.4091	show_face	unfamiliar_face	first_show	13	u091.bmp
-137.4443636364	n/a	34361.0909	right_press	n/a	n/a	4096	n/a
-137.6298181818	n/a	34407.4545	show_circle	n/a	n/a	0	circle.bmp
-139.3298181818	n/a	34832.4545	show_cross	n/a	n/a	n/a	cross.bmp
-139.8452727273	n/a	34961.3182	show_face	unfamiliar_face	immediate_repeat	14	u091.bmp
-140.3534545455	n/a	35088.3636	right_press	n/a	n/a	4096	n/a
-140.7798181818	n/a	35194.9545	show_circle	n/a	n/a	0	circle.bmp
-142.4798181818	n/a	35619.9545	show_cross	n/a	n/a	n/a	cross.bmp
-143.0861818182	n/a	35771.5455	show_face	scrambled_face	first_show	17	s106.bmp
-143.7398181818	n/a	35934.9545	left_press	n/a	n/a	256	n/a
-144.0098181818	n/a	36002.4545	show_circle	n/a	n/a	0	circle.bmp
-145.7098181818	n/a	36427.4545	show_cross	n/a	n/a	n/a	cross.bmp
-146.3107272727	n/a	36577.6818	show_face	scrambled_face	immediate_repeat	18	s106.bmp
-146.8798181818	n/a	36719.9545	left_press	n/a	n/a	256	n/a
-147.2116363636	n/a	36802.9091	show_circle	n/a	n/a	0	circle.bmp
-148.9116363636	n/a	37227.9091	show_cross	n/a	n/a	n/a	cross.bmp
-149.4170909091	n/a	37354.2727	show_face	famous_face	first_show	5	f034.bmp
-150.0307272727	n/a	37507.6818	right_press	n/a	n/a	4096	n/a
-150.3380000000	n/a	37584.5	show_circle	n/a	n/a	0	circle.bmp
-152.0380000000	n/a	38009.5	show_cross	n/a	n/a	n/a	cross.bmp
-152.6416363636	n/a	38160.4091	show_face	unfamiliar_face	delayed_repeat	15	u100.bmp
-153.3152727273	n/a	38328.8182	left_press	n/a	n/a	256	n/a
-153.6043636364	n/a	38401.0909	show_circle	n/a	n/a	0	circle.bmp
-155.3043636364	n/a	38826.0909	show_cross	n/a	n/a	n/a	cross.bmp
-155.8152727273	n/a	38953.8182	show_face	scrambled_face	first_show	17	s006.bmp
-156.6525454545	n/a	39163.1364	show_circle	n/a	n/a	0	circle.bmp
-156.8070909091	n/a	39201.7727	right_press	n/a	n/a	4096	n/a
-158.3525454545	n/a	39588.1364	show_cross	n/a	n/a	n/a	cross.bmp
-158.9561818182	n/a	39739.0455	show_face	scrambled_face	immediate_repeat	18	s006.bmp
-159.7261818182	n/a	39931.5455	right_press	n/a	n/a	4096	n/a
-159.7970909091	n/a	39949.2727	show_circle	n/a	n/a	0	circle.bmp
-161.4970909091	n/a	40374.2727	show_cross	n/a	n/a	n/a	cross.bmp
-162.1298181818	n/a	40532.4545	show_face	unfamiliar_face	first_show	13	u083.bmp
-162.7570909091	n/a	40689.2727	right_press	n/a	n/a	4096	n/a
-163.1070909091	n/a	40776.7727	show_circle	n/a	n/a	0	circle.bmp
-164.8070909091	n/a	41201.7727	show_cross	n/a	n/a	n/a	cross.bmp
-165.3380000000	n/a	41334.5	show_face	scrambled_face	first_show	17	s015.bmp
-165.9843636364	n/a	41496.0909	left_press	n/a	n/a	256	n/a
-166.3016363636	n/a	41575.4091	show_circle	n/a	n/a	0	circle.bmp
-168.0016363636	n/a	42000.4091	show_cross	n/a	n/a	n/a	cross.bmp
-168.6289090909	n/a	42157.2273	show_face	scrambled_face	first_show	17	s142.bmp
-169.3461818182	n/a	42336.5455	right_press	n/a	n/a	4096	n/a
-169.5016363636	n/a	42375.4091	show_circle	n/a	n/a	0	circle.bmp
-171.2016363636	n/a	42800.4091	show_cross	n/a	n/a	n/a	cross.bmp
-171.8525454545	n/a	42963.1364	show_face	scrambled_face	immediate_repeat	18	s142.bmp
-172.3698181818	n/a	43092.4545	right_press	n/a	n/a	4096	n/a
-172.8543636364	n/a	43213.5909	show_circle	n/a	n/a	0	circle.bmp
-174.5543636364	n/a	43638.5909	show_cross	n/a	n/a	n/a	cross.bmp
-175.1270909091	n/a	43781.7727	show_face	famous_face	first_show	5	f075.bmp
-175.7525454545	n/a	43938.1364	right_press	n/a	n/a	4096	n/a
-176.0925454545	n/a	44023.1364	show_circle	n/a	n/a	0	circle.bmp
-177.7925454545	n/a	44448.1364	show_cross	n/a	n/a	n/a	cross.bmp
-178.2670909091	n/a	44566.7727	show_face	famous_face	delayed_repeat	7	f034.bmp
-179.0834545455	n/a	44770.8636	right_press	n/a	n/a	4096	n/a
-179.1725454545	n/a	44793.1364	show_circle	n/a	n/a	0	circle.bmp
-180.8725454545	n/a	45218.1364	show_cross	n/a	n/a	n/a	cross.bmp
-181.4916363636	n/a	45372.9091	show_face	unfamiliar_face	first_show	13	u103.bmp
-182.2689090909	n/a	45567.2273	right_press	n/a	n/a	4096	n/a
-182.3580000000	n/a	45589.5	show_circle	n/a	n/a	0	circle.bmp
-184.0580000000	n/a	46014.5	show_cross	n/a	n/a	n/a	cross.bmp
-184.5652727273	n/a	46141.3182	show_face	unfamiliar_face	first_show	13	u071.bmp
-185.2070909091	n/a	46301.7727	right_press	n/a	n/a	4096	n/a
-185.5316363636	n/a	46382.9091	show_circle	n/a	n/a	0	circle.bmp
-187.2316363636	n/a	46807.9091	show_cross	n/a	n/a	n/a	cross.bmp
-187.7061818182	n/a	46926.5455	show_face	unfamiliar_face	immediate_repeat	14	u071.bmp
-188.2307272727	n/a	47057.6818	right_press	n/a	n/a	4096	n/a
-188.5952727273	n/a	47148.8182	show_circle	n/a	n/a	0	circle.bmp
-190.2952727273	n/a	47573.8182	show_cross	n/a	n/a	n/a	cross.bmp
-190.8461818182	n/a	47711.5455	show_face	unfamiliar_face	delayed_repeat	15	u083.bmp
-191.7616363636	n/a	47940.4091	left_press	n/a	n/a	256	n/a
-191.8298181818	n/a	47957.4545	show_circle	n/a	n/a	0	circle.bmp
-193.5298181818	n/a	48382.4545	show_cross	n/a	n/a	n/a	cross.bmp
-194.0534545455	n/a	48513.3636	show_face	scrambled_face	first_show	17	s043.bmp
-194.7634545455	n/a	48690.8636	left_press	n/a	n/a	256	n/a
-195.0325454545	n/a	48758.1364	show_circle	n/a	n/a	0	circle.bmp
-196.7325454545	n/a	49183.1364	show_cross	n/a	n/a	n/a	cross.bmp
-197.1943636364	n/a	49298.5909	show_face	scrambled_face	delayed_repeat	19	s015.bmp
-197.8189090909	n/a	49454.7273	left_press	n/a	n/a	256	n/a
-198.0816363636	n/a	49520.4091	show_circle	n/a	n/a	0	circle.bmp
-199.7816363636	n/a	49945.4091	show_cross	n/a	n/a	n/a	cross.bmp
-200.2680000000	n/a	50067	show_face	unfamiliar_face	first_show	13	u122.bmp
-201.2507272727	n/a	50312.6818	show_circle	n/a	n/a	0	circle.bmp
-201.2552727273	n/a	50313.8182	left_press	n/a	n/a	256	n/a
-202.9507272727	n/a	50737.6818	show_cross	n/a	n/a	n/a	cross.bmp
-203.5752727273	n/a	50893.8182	show_face	unfamiliar_face	first_show	13	u028.bmp
-204.5943636364	n/a	51148.5909	show_circle	n/a	n/a	0	circle.bmp
-204.5961818182	n/a	51149.0455	left_press	n/a	n/a	256	n/a
-206.2943636364	n/a	51573.5909	show_cross	n/a	n/a	n/a	cross.bmp
-206.8998181818	n/a	51724.9545	show_face	unfamiliar_face	immediate_repeat	14	u028.bmp
-207.5416363636	n/a	51885.4091	left_press	n/a	n/a	256	n/a
-207.8461818182	n/a	51961.5455	show_circle	n/a	n/a	0	circle.bmp
-209.5461818182	n/a	52386.5455	show_cross	n/a	n/a	n/a	cross.bmp
-210.0070909091	n/a	52501.7727	show_face	famous_face	delayed_repeat	7	f075.bmp
-210.6498181818	n/a	52662.4545	right_press	n/a	n/a	4096	n/a
-210.8280000000	n/a	52707	show_circle	n/a	n/a	0	circle.bmp
-212.5280000000	n/a	53132	show_cross	n/a	n/a	n/a	cross.bmp
-213.0470909091	n/a	53261.7727	show_face	unfamiliar_face	first_show	13	u105.bmp
-213.7798181818	n/a	53444.9545	right_press	n/a	n/a	4096	n/a
-214.0334545455	n/a	53508.3636	show_circle	n/a	n/a	0	circle.bmp
-215.7334545455	n/a	53933.3636	show_cross	n/a	n/a	n/a	cross.bmp
-216.2380000000	n/a	54059.5	show_face	unfamiliar_face	delayed_repeat	15	u103.bmp
-216.9998181818	n/a	54249.9545	right_press	n/a	n/a	4096	n/a
-217.0825454545	n/a	54270.6364	show_circle	n/a	n/a	0	circle.bmp
-218.7825454545	n/a	54695.6364	show_cross	n/a	n/a	n/a	cross.bmp
-219.3452727273	n/a	54836.3182	show_face	famous_face	first_show	5	f041.bmp
-220.2470909091	n/a	55061.7727	right_press	n/a	n/a	4096	n/a
-220.3452727273	n/a	55086.3182	show_circle	n/a	n/a	0	circle.bmp
-222.0452727273	n/a	55511.3182	show_cross	n/a	n/a	n/a	cross.bmp
-222.7034545455	n/a	55675.8636	show_face	unfamiliar_face	first_show	13	u022.bmp
-223.5443636364	n/a	55886.0909	show_circle	n/a	n/a	0	circle.bmp
-223.6607272727	n/a	55915.1818	right_press	n/a	n/a	4096	n/a
-225.2443636364	n/a	56311.0909	show_cross	n/a	n/a	n/a	cross.bmp
-225.7934545455	n/a	56448.3636	show_face	unfamiliar_face	immediate_repeat	14	u022.bmp
-226.4525454545	n/a	56613.1364	right_press	n/a	n/a	4096	n/a
-226.6125454545	n/a	56653.1364	show_circle	n/a	n/a	0	circle.bmp
-228.3125454545	n/a	57078.1364	show_cross	n/a	n/a	n/a	cross.bmp
-228.9343636364	n/a	57233.5909	show_face	scrambled_face	delayed_repeat	19	s043.bmp
-229.7789090909	n/a	57444.7273	left_press	n/a	n/a	256	n/a
-229.8970909091	n/a	57474.2727	show_circle	n/a	n/a	0	circle.bmp
-231.5970909091	n/a	57899.2727	show_cross	n/a	n/a	n/a	cross.bmp
-232.1252727273	n/a	58031.3182	show_face	unfamiliar_face	first_show	13	u023.bmp
-232.9507272727	n/a	58237.6818	show_circle	n/a	n/a	0	circle.bmp
-233.0643636364	n/a	58266.0909	left_press	n/a	n/a	256	n/a
-234.6507272727	n/a	58662.6818	show_cross	n/a	n/a	n/a	cross.bmp
-235.1989090909	n/a	58799.7273	show_face	unfamiliar_face	delayed_repeat	15	u122.bmp
-236.0189090909	n/a	59004.7273	left_press	n/a	n/a	256	n/a
-236.1980000000	n/a	59049.5	show_circle	n/a	n/a	0	circle.bmp
-237.8980000000	n/a	59474.5	show_cross	n/a	n/a	n/a	cross.bmp
-238.4070909091	n/a	59601.7727	show_face	famous_face	first_show	5	f028.bmp
-239.0198181818	n/a	59754.9545	right_press	n/a	n/a	4096	n/a
-239.2852727273	n/a	59821.3182	show_circle	n/a	n/a	0	circle.bmp
-240.9852727273	n/a	60246.3182	show_cross	n/a	n/a	n/a	cross.bmp
-241.5798181818	n/a	60394.9545	show_face	famous_face	immediate_repeat	6	f028.bmp
-242.1334545455	n/a	60533.3636	right_press	n/a	n/a	4096	n/a
-242.5652727273	n/a	60641.3182	show_circle	n/a	n/a	0	circle.bmp
-244.2652727273	n/a	61066.3182	show_cross	n/a	n/a	n/a	cross.bmp
-244.7543636364	n/a	61188.5909	show_face	unfamiliar_face	first_show	13	u052.bmp
-245.3725454545	n/a	61343.1364	right_press	n/a	n/a	4096	n/a
-245.6470909091	n/a	61411.7727	show_circle	n/a	n/a	0	circle.bmp
-247.3470909091	n/a	61836.7727	show_cross	n/a	n/a	n/a	cross.bmp
-247.9443636364	n/a	61986.0909	show_face	unfamiliar_face	immediate_repeat	14	u052.bmp
-248.4589090909	n/a	62114.7273	right_press	n/a	n/a	4096	n/a
-248.9234545455	n/a	62230.8636	show_circle	n/a	n/a	0	circle.bmp
-250.6234545455	n/a	62655.8636	show_cross	n/a	n/a	n/a	cross.bmp
-251.1689090909	n/a	62792.2273	show_face	unfamiliar_face	delayed_repeat	15	u105.bmp
-251.8752727273	n/a	62968.8182	right_press	n/a	n/a	4096	n/a
-252.0998181818	n/a	63024.9545	show_circle	n/a	n/a	0	circle.bmp
-253.7998181818	n/a	63449.9545	show_cross	n/a	n/a	n/a	cross.bmp
-254.2761818182	n/a	63569.0455	show_face	unfamiliar_face	first_show	13	u017.bmp
-255.0225454545	n/a	63755.6364	right_press	n/a	n/a	4096	n/a
-255.1725454545	n/a	63793.1364	show_circle	n/a	n/a	0	circle.bmp
-256.8725454545	n/a	64218.1364	show_cross	n/a	n/a	n/a	cross.bmp
-257.4670909091	n/a	64366.7727	show_face	famous_face	delayed_repeat	7	f041.bmp
-258.1770909091	n/a	64544.2727	left_press	n/a	n/a	256	n/a
-258.3934545455	n/a	64598.3636	show_circle	n/a	n/a	0	circle.bmp
-260.0934545455	n/a	65023.3636	show_cross	n/a	n/a	n/a	cross.bmp
-260.7070909091	n/a	65176.7727	show_face	famous_face	first_show	5	f089.bmp
-261.3870909091	n/a	65346.7727	left_press	n/a	n/a	256	n/a
-261.5452727273	n/a	65386.3182	show_circle	n/a	n/a	0	circle.bmp
-263.2452727273	n/a	65811.3182	show_cross	n/a	n/a	n/a	cross.bmp
-263.8316363636	n/a	65957.9091	show_face	famous_face	immediate_repeat	6	f089.bmp
-264.4334545455	n/a	66108.3636	left_press	n/a	n/a	256	n/a
-264.7616363636	n/a	66190.4091	show_circle	n/a	n/a	0	circle.bmp
-266.4616363636	n/a	66615.4091	show_cross	n/a	n/a	n/a	cross.bmp
-266.9889090909	n/a	66747.2273	show_face	unfamiliar_face	first_show	13	u104.bmp
-267.8707272727	n/a	66967.6818	show_circle	n/a	n/a	0	circle.bmp
-267.9125454545	n/a	66978.1364	right_press	n/a	n/a	4096	n/a
-269.5707272727	n/a	67392.6818	show_cross	n/a	n/a	n/a	cross.bmp
-270.0452727273	n/a	67511.3182	show_face	unfamiliar_face	delayed_repeat	15	u023.bmp
-270.6407272727	n/a	67660.1818	left_press	n/a	n/a	256	n/a
-270.9998181818	n/a	67749.9545	show_circle	n/a	n/a	0	circle.bmp
-272.6998181818	n/a	68174.9545	show_cross	n/a	n/a	n/a	cross.bmp
-273.3361818182	n/a	68334.0455	show_face	famous_face	first_show	5	f149.bmp
-274.1061818182	n/a	68526.5455	right_press	n/a	n/a	4096	n/a
-274.2016363636	n/a	68550.4091	show_circle	n/a	n/a	0	circle.bmp
-275.9016363636	n/a	68975.4091	show_cross	n/a	n/a	n/a	cross.bmp
-276.4934545455	n/a	69123.3636	show_face	famous_face	first_show	5	f120.bmp
-277.3361818182	n/a	69334.0455	right_press	n/a	n/a	4096	n/a
-277.3598181818	n/a	69339.9545	show_circle	n/a	n/a	0	circle.bmp
-279.0598181818	n/a	69764.9545	show_cross	n/a	n/a	n/a	cross.bmp
-279.5670909091	n/a	69891.7727	show_face	famous_face	immediate_repeat	6	f120.bmp
-280.2098181818	n/a	70052.4545	right_press	n/a	n/a	4096	n/a
-280.4807272727	n/a	70120.1818	show_circle	n/a	n/a	0	circle.bmp
-282.1807272727	n/a	70545.1818	show_cross	n/a	n/a	n/a	cross.bmp
-282.6916363636	n/a	70672.9091	show_face	scrambled_face	first_show	17	s072.bmp
-283.5243636364	n/a	70881.0909	show_circle	n/a	n/a	0	circle.bmp
-284.0170909091	n/a	71004.2727	right_press	n/a	n/a	4096	n/a
-285.2243636364	n/a	71306.0909	show_cross	n/a	n/a	n/a	cross.bmp
-285.8316363636	n/a	71457.9091	show_face	scrambled_face	immediate_repeat	18	s072.bmp
-286.4134545455	n/a	71603.3636	left_press	n/a	n/a	256	n/a
-286.7761818182	n/a	71694.0455	show_circle	n/a	n/a	0	circle.bmp
-288.4761818182	n/a	72119.0455	show_cross	n/a	n/a	n/a	cross.bmp
-289.0225454545	n/a	72255.6364	show_face	unfamiliar_face	delayed_repeat	15	u017.bmp
-289.6461818182	n/a	72411.5455	right_press	n/a	n/a	4096	n/a
-290.0107272727	n/a	72502.6818	show_circle	n/a	n/a	0	circle.bmp
-291.7107272727	n/a	72927.6818	show_cross	n/a	n/a	n/a	cross.bmp
-292.3470909091	n/a	73086.7727	show_face	famous_face	first_show	5	f013.bmp
-292.9707272727	n/a	73242.6818	right_press	n/a	n/a	4096	n/a
-293.2452727273	n/a	73311.3182	show_circle	n/a	n/a	0	circle.bmp
-294.9452727273	n/a	73736.3182	show_cross	n/a	n/a	n/a	cross.bmp
-295.4880000000	n/a	73872	show_face	famous_face	immediate_repeat	6	f013.bmp
-295.9961818182	n/a	73999.0455	right_press	n/a	n/a	4096	n/a
-296.4670909091	n/a	74116.7727	show_circle	n/a	n/a	0	circle.bmp
-298.1670909091	n/a	74541.7727	show_cross	n/a	n/a	n/a	cross.bmp
-298.6616363636	n/a	74665.4091	show_face	famous_face	first_show	5	f004.bmp
-299.3370909091	n/a	74834.2727	left_press	n/a	n/a	256	n/a
-299.4870909091	n/a	74871.7727	show_circle	n/a	n/a	0	circle.bmp
-301.1870909091	n/a	75296.7727	show_cross	n/a	n/a	n/a	cross.bmp
-301.7852727273	n/a	75446.3182	show_face	famous_face	immediate_repeat	6	f004.bmp
-302.2634545455	n/a	75565.8636	left_press	n/a	n/a	256	n/a
-302.7870909091	n/a	75696.7727	show_circle	n/a	n/a	0	circle.bmp
-304.4870909091	n/a	76121.7727	show_cross	n/a	n/a	n/a	cross.bmp
-304.9761818182	n/a	76244.0455	show_face	unfamiliar_face	delayed_repeat	15	u104.bmp
-305.6161818182	n/a	76404.0455	right_press	n/a	n/a	4096	n/a
-305.9780000000	n/a	76494.5	show_circle	n/a	n/a	0	circle.bmp
-307.6780000000	n/a	76919.5	show_cross	n/a	n/a	n/a	cross.bmp
-308.2680000000	n/a	77067	show_face	famous_face	first_show	5	f109.bmp
-308.9052727273	n/a	77226.3182	left_press	n/a	n/a	256	n/a
-309.2680000000	n/a	77317	show_circle	n/a	n/a	0	circle.bmp
-310.9680000000	n/a	77742	show_cross	n/a	n/a	n/a	cross.bmp
-311.4416363636	n/a	77860.4091	show_face	famous_face	delayed_repeat	7	f149.bmp
-312.4307272727	n/a	78107.6818	show_circle	n/a	n/a	0	circle.bmp
-312.4780000000	n/a	78119.5	right_press	n/a	n/a	4096	n/a
-314.1307272727	n/a	78532.6818	show_cross	n/a	n/a	n/a	cross.bmp
-314.7816363636	n/a	78695.4091	show_face	famous_face	first_show	5	f136.bmp
-315.6525454545	n/a	78913.1364	show_circle	n/a	n/a	0	circle.bmp
-315.7152727273	n/a	78928.8182	left_press	n/a	n/a	256	n/a
-317.3525454545	n/a	79338.1364	show_cross	n/a	n/a	n/a	cross.bmp
-317.9061818182	n/a	79476.5455	show_face	scrambled_face	first_show	17	s048.bmp
-318.5216363636	n/a	79630.4091	left_press	n/a	n/a	256	n/a
-318.8316363636	n/a	79707.9091	show_circle	n/a	n/a	0	circle.bmp
-320.5316363636	n/a	80132.9091	show_cross	n/a	n/a	n/a	cross.bmp
-321.1634545455	n/a	80290.8636	show_face	scrambled_face	immediate_repeat	18	s048.bmp
-321.7798181818	n/a	80444.9545	left_press	n/a	n/a	256	n/a
-322.1570909091	n/a	80539.2727	show_circle	n/a	n/a	0	circle.bmp
-323.8570909091	n/a	80964.2727	show_cross	n/a	n/a	n/a	cross.bmp
-324.5043636364	n/a	81126.0909	show_face	scrambled_face	first_show	17	s067.bmp
-325.4280000000	n/a	81357	show_circle	n/a	n/a	0	circle.bmp
-325.5861818182	n/a	81396.5455	right_press	n/a	n/a	4096	n/a
-327.1280000000	n/a	81782	show_cross	n/a	n/a	n/a	cross.bmp
-327.6789090909	n/a	81919.7273	show_face	scrambled_face	first_show	17	s126.bmp
-328.3116363636	n/a	82077.9091	left_press	n/a	n/a	256	n/a
-328.5543636364	n/a	82138.5909	show_circle	n/a	n/a	0	circle.bmp
-330.2543636364	n/a	82563.5909	show_cross	n/a	n/a	n/a	cross.bmp
-330.7852727273	n/a	82696.3182	show_face	scrambled_face	immediate_repeat	18	s126.bmp
-331.3570909091	n/a	82839.2727	left_press	n/a	n/a	256	n/a
-331.6452727273	n/a	82911.3182	show_circle	n/a	n/a	0	circle.bmp
-333.3452727273	n/a	83336.3182	show_cross	n/a	n/a	n/a	cross.bmp
-333.9761818182	n/a	83494.0455	show_face	unfamiliar_face	first_show	13	u150.bmp
-334.6789090909	n/a	83669.7273	right_press	n/a	n/a	4096	n/a
-334.9207272727	n/a	83730.1818	show_circle	n/a	n/a	0	circle.bmp
-336.6207272727	n/a	84155.1818	show_cross	n/a	n/a	n/a	cross.bmp
-337.1507272727	n/a	84287.6818	show_face	unfamiliar_face	immediate_repeat	14	u150.bmp
-337.7380000000	n/a	84434.5	right_press	n/a	n/a	4096	n/a
-338.1352727273	n/a	84533.8182	show_circle	n/a	n/a	0	circle.bmp
-339.8352727273	n/a	84958.8182	show_cross	n/a	n/a	n/a	cross.bmp
-340.2907272727	n/a	85072.6818	show_face	famous_face	delayed_repeat	7	f109.bmp
-341.2580000000	n/a	85314.5	show_circle	n/a	n/a	0	circle.bmp
-341.3198181818	n/a	85329.9545	right_press	n/a	n/a	4096	n/a
-342.9580000000	n/a	85739.5	show_cross	n/a	n/a	n/a	cross.bmp
-343.5316363636	n/a	85882.9091	show_face	famous_face	first_show	5	f080.bmp
-344.1652727273	n/a	86041.3182	right_press	n/a	n/a	4096	n/a
-344.3552727273	n/a	86088.8182	show_circle	n/a	n/a	0	circle.bmp
-346.0552727273	n/a	86513.8182	show_cross	n/a	n/a	n/a	cross.bmp
-346.6725454545	n/a	86668.1364	show_face	famous_face	immediate_repeat	6	f080.bmp
-347.2298181818	n/a	86807.4545	right_press	n/a	n/a	4096	n/a
-347.5052727273	n/a	86876.3182	show_circle	n/a	n/a	0	circle.bmp
-349.2052727273	n/a	87301.3182	show_cross	n/a	n/a	n/a	cross.bmp
-349.8461818182	n/a	87461.5455	show_face	famous_face	delayed_repeat	7	f136.bmp
-350.6252727273	n/a	87656.3182	right_press	n/a	n/a	4096	n/a
-350.7170909091	n/a	87679.2727	show_circle	n/a	n/a	0	circle.bmp
-352.4170909091	n/a	88104.2727	show_cross	n/a	n/a	n/a	cross.bmp
-353.0198181818	n/a	88254.9545	show_face	famous_face	first_show	5	f073.bmp
-353.6880000000	n/a	88422	left_press	n/a	n/a	256	n/a
-354.0098181818	n/a	88502.4545	show_circle	n/a	n/a	0	circle.bmp
-355.7098181818	n/a	88927.4545	show_cross	n/a	n/a	n/a	cross.bmp
-356.3280000000	n/a	89082	show_face	famous_face	first_show	5	f065.bmp
-357.0943636364	n/a	89273.5909	left_press	n/a	n/a	256	n/a
-357.2243636364	n/a	89306.0909	show_circle	n/a	n/a	0	circle.bmp
-358.9243636364	n/a	89731.0909	show_cross	n/a	n/a	n/a	cross.bmp
-359.5689090909	n/a	89892.2273	show_face	scrambled_face	delayed_repeat	19	s067.bmp
-360.2225454545	n/a	90055.6364	right_press	n/a	n/a	4096	n/a
-360.4161818182	n/a	90104.0455	show_circle	n/a	n/a	0	circle.bmp
-362.1161818182	n/a	90529.0455	show_cross	n/a	n/a	n/a	cross.bmp
-362.6589090909	n/a	90664.7273	show_face	scrambled_face	first_show	17	s131.bmp
-363.4698181818	n/a	90867.4545	left_press	n/a	n/a	256	n/a
-363.4934545455	n/a	90873.3636	show_circle	n/a	n/a	0	circle.bmp
-365.1934545455	n/a	91298.3636	show_cross	n/a	n/a	n/a	cross.bmp
-365.6661818182	n/a	91416.5455	show_face	famous_face	first_show	5	f046.bmp
-366.5325454545	n/a	91633.1364	left_press	n/a	n/a	256	n/a
-366.6780000000	n/a	91669.5	show_circle	n/a	n/a	0	circle.bmp
-368.3780000000	n/a	92094.5	show_cross	n/a	n/a	n/a	cross.bmp
-368.8407272727	n/a	92210.1818	show_face	famous_face	immediate_repeat	6	f046.bmp
-369.4843636364	n/a	92371.0909	left_press	n/a	n/a	256	n/a
-369.6734545455	n/a	92418.3636	show_circle	n/a	n/a	0	circle.bmp
-371.3734545455	n/a	92843.3636	show_cross	n/a	n/a	n/a	cross.bmp
-372.0143636364	n/a	93003.5909	show_face	famous_face	first_show	5	f087.bmp
-372.6970909091	n/a	93174.2727	right_press	n/a	n/a	4096	n/a
-372.9252727273	n/a	93231.3182	show_circle	n/a	n/a	0	circle.bmp
-374.6252727273	n/a	93656.3182	show_cross	n/a	n/a	n/a	cross.bmp
-375.2380000000	n/a	93809.5	show_face	scrambled_face	first_show	17	s144.bmp
-376.0725454545	n/a	94018.1364	right_press	n/a	n/a	4096	n/a
-376.2434545455	n/a	94060.8636	show_circle	n/a	n/a	0	circle.bmp
-377.9434545455	n/a	94485.8636	show_cross	n/a	n/a	n/a	cross.bmp
-378.5625454545	n/a	94640.6364	show_face	famous_face	delayed_repeat	7	f073.bmp
-379.2816363636	n/a	94820.4091	left_press	n/a	n/a	256	n/a
-379.4589090909	n/a	94864.7273	show_circle	n/a	n/a	0	circle.bmp
-381.1589090909	n/a	95289.7273	show_cross	n/a	n/a	n/a	cross.bmp
-381.6861818182	n/a	95421.5455	show_face	scrambled_face	first_show	17	s085.bmp
-382.5570909091	n/a	95639.2727	right_press	n/a	n/a	4096	n/a
-382.6216363636	n/a	95655.4091	show_circle	n/a	n/a	0	circle.bmp
-384.3216363636	n/a	96080.4091	show_cross	n/a	n/a	n/a	cross.bmp
-384.7934545455	n/a	96198.3636	show_face	scrambled_face	immediate_repeat	18	s085.bmp
-385.2852727273	n/a	96321.3182	right_press	n/a	n/a	4096	n/a
-385.6925454545	n/a	96423.1364	show_circle	n/a	n/a	0	circle.bmp
-387.3925454545	n/a	96848.1364	show_cross	n/a	n/a	n/a	cross.bmp
-387.9670909091	n/a	96991.7727	show_face	famous_face	delayed_repeat	7	f065.bmp
-388.7716363636	n/a	97192.9091	left_press	n/a	n/a	256	n/a
-388.8980000000	n/a	97224.5	show_circle	n/a	n/a	0	circle.bmp
-390.5980000000	n/a	97649.5	show_cross	n/a	n/a	n/a	cross.bmp
-391.1580000000	n/a	97789.5	show_face	unfamiliar_face	first_show	13	u003.bmp
-392.0907272727	n/a	98022.6818	show_circle	n/a	n/a	0	circle.bmp
-392.2643636364	n/a	98066.0909	left_press	n/a	n/a	256	n/a
-393.7907272727	n/a	98447.6818	show_cross	n/a	n/a	n/a	cross.bmp
-394.3489090909	n/a	98587.2273	show_face	scrambled_face	delayed_repeat	19	s131.bmp
-395.0125454545	n/a	98753.1364	right_press	n/a	n/a	4096	n/a
-395.1980000000	n/a	98799.5	show_circle	n/a	n/a	0	circle.bmp
-396.8980000000	n/a	99224.5	show_cross	n/a	n/a	n/a	cross.bmp
-397.4561818182	n/a	99364.0455	show_face	scrambled_face	first_show	17	s093.bmp
-398.2880000000	n/a	99572	show_circle	n/a	n/a	0	circle.bmp
-398.3061818182	n/a	99576.5455	right_press	n/a	n/a	4096	n/a
-399.9880000000	n/a	99997	show_cross	n/a	n/a	n/a	cross.bmp
-400.5961818182	n/a	100149.0455	show_face	famous_face	first_show	5	f132.bmp
-401.4343636364	n/a	100358.5909	show_circle	n/a	n/a	0	circle.bmp
-401.8398181818	n/a	100459.9545	left_press	n/a	n/a	256	n/a
-403.1343636364	n/a	100783.5909	show_cross	n/a	n/a	n/a	cross.bmp
-403.6198181818	n/a	100904.9545	show_face	famous_face	immediate_repeat	6	f132.bmp
-404.1834545455	n/a	101045.8636	left_press	n/a	n/a	256	n/a
-404.6325454545	n/a	101158.1364	show_circle	n/a	n/a	0	circle.bmp
-406.3325454545	n/a	101583.1364	show_cross	n/a	n/a	n/a	cross.bmp
-406.8943636364	n/a	101723.5909	show_face	famous_face	delayed_repeat	7	f087.bmp
-407.5025454545	n/a	101875.6364	right_press	n/a	n/a	4096	n/a
-407.7707272727	n/a	101942.6818	show_circle	n/a	n/a	0	circle.bmp
-409.4707272727	n/a	102367.6818	show_cross	n/a	n/a	n/a	cross.bmp
-409.9516363636	n/a	102487.9091	show_face	famous_face	first_show	5	f117.bmp
-410.6798181818	n/a	102669.9545	left_press	n/a	n/a	256	n/a
-410.8443636364	n/a	102711.0909	show_circle	n/a	n/a	0	circle.bmp
-412.5443636364	n/a	103136.0909	show_cross	n/a	n/a	n/a	cross.bmp
-413.1925454545	n/a	103298.1364	show_face	famous_face	immediate_repeat	6	f117.bmp
-413.7789090909	n/a	103444.7273	left_press	n/a	n/a	256	n/a
-414.1070909091	n/a	103526.7727	show_circle	n/a	n/a	0	circle.bmp
-415.8070909091	n/a	103951.7727	show_cross	n/a	n/a	n/a	cross.bmp
-416.2825454545	n/a	104070.6364	show_face	scrambled_face	delayed_repeat	19	s144.bmp
-417.2334545455	n/a	104308.3636	show_circle	n/a	n/a	0	circle.bmp
-417.4225454545	n/a	104355.6364	left_press	n/a	n/a	256	n/a
-418.9334545455	n/a	104733.3636	show_cross	n/a	n/a	n/a	cross.bmp
-419.4234545455	n/a	104855.8636	show_face	unfamiliar_face	first_show	13	u070.bmp
-420.1589090909	n/a	105039.7273	left_press	n/a	n/a	256	n/a
-420.4370909091	n/a	105109.2727	show_circle	n/a	n/a	0	circle.bmp
-422.1370909091	n/a	105534.2727	show_cross	n/a	n/a	n/a	cross.bmp
-422.6470909091	n/a	105661.7727	show_face	scrambled_face	first_show	17	s002.bmp
-423.4552727273	n/a	105863.8182	right_press	n/a	n/a	4096	n/a
-423.5343636364	n/a	105883.5909	show_circle	n/a	n/a	0	circle.bmp
-425.2343636364	n/a	106308.5909	show_cross	n/a	n/a	n/a	cross.bmp
-425.7043636364	n/a	106426.0909	show_face	unfamiliar_face	delayed_repeat	15	u003.bmp
-426.5907272727	n/a	106647.6818	show_circle	n/a	n/a	0	circle.bmp
-426.6143636364	n/a	106653.5909	right_press	n/a	n/a	4096	n/a
-428.2907272727	n/a	107072.6818	show_cross	n/a	n/a	n/a	cross.bmp
-428.8780000000	n/a	107219.5	show_face	unfamiliar_face	first_show	13	u007.bmp
-429.5816363636	n/a	107395.4091	left_press	n/a	n/a	256	n/a
-429.8116363636	n/a	107452.9091	show_circle	n/a	n/a	0	circle.bmp
-431.5116363636	n/a	107877.9091	show_cross	n/a	n/a	n/a	cross.bmp
-432.0025454545	n/a	108000.6364	show_face	scrambled_face	delayed_repeat	19	s093.bmp
-432.8480000000	n/a	108212	show_circle	n/a	n/a	0	circle.bmp
-432.9570909091	n/a	108239.2727	left_press	n/a	n/a	256	n/a
-434.5480000000	n/a	108637	show_cross	n/a	n/a	n/a	cross.bmp
-435.1925454545	n/a	108798.1364	show_face	scrambled_face	first_show	17	s123.bmp
-435.8407272727	n/a	108960.1818	left_press	n/a	n/a	256	n/a
-436.0643636364	n/a	109016.0909	show_circle	n/a	n/a	0	circle.bmp
-437.7643636364	n/a	109441.0909	show_cross	n/a	n/a	n/a	cross.bmp
-438.2998181818	n/a	109574.9545	show_face	scrambled_face	immediate_repeat	18	s123.bmp
-439.0470909091	n/a	109761.7727	left_press	n/a	n/a	256	n/a
-439.1289090909	n/a	109782.2273	show_circle	n/a	n/a	0	circle.bmp
-439.1298181818	n/a	109782.4545	show_circle	n/a	n/a	0	circle.bmp
-440.8289090909	n/a	110207.2273	show_cross	n/a	n/a	n/a	cross.bmp
-440.8298181818	n/a	110207.4545	show_cross	n/a	n/a	n/a	cross.bmp
-441.3070909091	n/a	110326.7727	show_face	scrambled_face	first_show	17	s011.bmp
-441.9352727273	n/a	110483.8182	right_press	n/a	n/a	4096	n/a
-442.1516363636	n/a	110537.9091	show_circle	n/a	n/a	0	circle.bmp
-443.8516363636	n/a	110962.9091	show_cross	n/a	n/a	n/a	cross.bmp
-444.4807272727	n/a	111120.1818	show_face	scrambled_face	immediate_repeat	18	s011.bmp
-444.9089090909	n/a	111227.2273	right_press	n/a	n/a	4096	n/a
-445.3670909091	n/a	111341.7727	show_circle	n/a	n/a	0	circle.bmp
-447.0670909091	n/a	111766.7727	show_cross	n/a	n/a	n/a	cross.bmp
-447.7216363636	n/a	111930.4091	show_face	unfamiliar_face	first_show	13	u029.bmp
-448.3434545455	n/a	112085.8636	right_press	n/a	n/a	4096	n/a
-448.5507272727	n/a	112137.6818	show_circle	n/a	n/a	0	circle.bmp
-450.2507272727	n/a	112562.6818	show_cross	n/a	n/a	n/a	cross.bmp
-450.7952727273	n/a	112698.8182	show_face	unfamiliar_face	immediate_repeat	14	u029.bmp
-451.2643636364	n/a	112816.0909	right_press	n/a	n/a	4096	n/a
-451.6407272727	n/a	112910.1818	show_circle	n/a	n/a	0	circle.bmp
-453.3407272727	n/a	113335.1818	show_cross	n/a	n/a	n/a	cross.bmp
-453.8361818182	n/a	113459.0455	show_face	unfamiliar_face	delayed_repeat	15	u070.bmp
-454.6098181818	n/a	113652.4545	right_press	n/a	n/a	4096	n/a
-454.7507272727	n/a	113687.6818	show_circle	n/a	n/a	0	circle.bmp
-456.4507272727	n/a	114112.6818	show_cross	n/a	n/a	n/a	cross.bmp
-457.0934545455	n/a	114273.3636	show_face	scrambled_face	first_show	17	s010.bmp
-457.9716363636	n/a	114492.9091	right_press	n/a	n/a	4096	n/a
-458.0307272727	n/a	114507.6818	show_circle	n/a	n/a	0	circle.bmp
-459.7307272727	n/a	114932.6818	show_cross	n/a	n/a	n/a	cross.bmp
-460.3007272727	n/a	115075.1818	show_face	scrambled_face	immediate_repeat	18	s010.bmp
-461.2680000000	n/a	115317	show_circle	n/a	n/a	0	circle.bmp
-461.4198181818	n/a	115354.9545	right_press	n/a	n/a	4096	n/a
-462.9680000000	n/a	115742	show_cross	n/a	n/a	n/a	cross.bmp
-463.5416363636	n/a	115885.4091	show_face	scrambled_face	delayed_repeat	19	s002.bmp
-464.3007272727	n/a	116075.1818	left_press	n/a	n/a	256	n/a
-464.5443636364	n/a	116136.0909	show_circle	n/a	n/a	0	circle.bmp
-466.2443636364	n/a	116561.0909	show_cross	n/a	n/a	n/a	cross.bmp
-466.7661818182	n/a	116691.5455	show_face	famous_face	first_show	5	f012.bmp
-467.3989090909	n/a	116849.7273	right_press	n/a	n/a	4096	n/a
-467.7116363636	n/a	116927.9091	show_circle	n/a	n/a	0	circle.bmp
-469.4116363636	n/a	117352.9091	show_cross	n/a	n/a	n/a	cross.bmp
-470.0398181818	n/a	117509.9545	show_face	unfamiliar_face	delayed_repeat	15	u007.bmp
-470.6516363636	n/a	117662.9091	right_press	n/a	n/a	4096	n/a
-470.9098181818	n/a	117727.4545	show_circle	n/a	n/a	0	circle.bmp
-472.6098181818	n/a	118152.4545	show_cross	n/a	n/a	n/a	cross.bmp
-473.2470909091	n/a	118311.7727	show_face	unfamiliar_face	first_show	13	u009.bmp
-474.0516363636	n/a	118512.9091	left_press	n/a	n/a	256	n/a
-474.1307272727	n/a	118532.6818	show_circle	n/a	n/a	0	circle.bmp
-475.8307272727	n/a	118957.6818	show_cross	n/a	n/a	n/a	cross.bmp
-476.4552727273	n/a	119113.8182	show_face	unfamiliar_face	immediate_repeat	14	u009.bmp
-476.9634545455	n/a	119240.8636	left_press	n/a	n/a	256	n/a
-477.3334545455	n/a	119333.3636	show_circle	n/a	n/a	0	circle.bmp
-479.0334545455	n/a	119758.3636	show_cross	n/a	n/a	n/a	cross.bmp
-479.5452727273	n/a	119886.3182	show_face	unfamiliar_face	first_show	13	u068.bmp
-480.2261818182	n/a	120056.5455	right_press	n/a	n/a	4096	n/a
-480.5543636364	n/a	120138.5909	show_circle	n/a	n/a	0	circle.bmp
-482.2543636364	n/a	120563.5909	show_cross	n/a	n/a	n/a	cross.bmp
-482.7689090909	n/a	120692.2273	show_face	famous_face	first_show	5	f054.bmp
-483.4189090909	n/a	120854.7273	left_press	n/a	n/a	256	n/a
-483.5998181818	n/a	120899.9545	show_circle	n/a	n/a	0	circle.bmp
-485.2998181818	n/a	121324.9545	show_cross	n/a	n/a	n/a	cross.bmp
-485.9434545455	n/a	121485.8636	show_face	scrambled_face	first_show	17	s049.bmp
-486.5880000000	n/a	121647	left_press	n/a	n/a	256	n/a
-486.8161818182	n/a	121704.0455	show_circle	n/a	n/a	0	circle.bmp
-488.5161818182	n/a	122129.0455	show_cross	n/a	n/a	n/a	cross.bmp
-489.1170909091	n/a	122279.2727	show_face	scrambled_face	immediate_repeat	18	s049.bmp
-489.5952727273	n/a	122398.8182	left_press	n/a	n/a	256	n/a
-490.0361818182	n/a	122509.0455	show_circle	n/a	n/a	0	circle.bmp
-491.7361818182	n/a	122934.0455	show_cross	n/a	n/a	n/a	cross.bmp
+onset	duration	sample	event_type	face_type	repetition_type	trial	trial_lag	trigger	stim_file
+0.004	n/a	1.0	setup	n/a	n/a	n/a	n/a	n/a	n/a
+0.004	n/a	1.0	right_sym	n/a	n/a	n/a	n/a	n/a	n/a
+25.0143636364	n/a	6253.5909	show_face	famous_face	first_show	1	n/a	5	f108.bmp
+25.859818181799998	n/a	6464.9545	right_press	n/a	n/a	1	n/a	4096	n/a
+25.951636363600002	n/a	6487.9091	show_circle	n/a	n/a	1	n/a	0	circle.bmp
+27.6516363636	n/a	6912.9091	show_cross	n/a	n/a	2	n/a	n/a	cross.bmp
+28.2552727273	n/a	7063.8182	show_face	scrambled_face	first_show	2	n/a	17	s141.bmp
+28.917090909099997	n/a	7229.2727	left_press	n/a	n/a	2	n/a	256	n/a
+29.272545454499998	n/a	7318.1364	show_circle	n/a	n/a	2	n/a	0	circle.bmp
+30.972545454499997	n/a	7743.1364	show_cross	n/a	n/a	3	n/a	n/a	cross.bmp
+31.4452727273	n/a	7861.3182	show_face	scrambled_face	immediate_repeat	3	1	18	s141.bmp
+32.1234545455	n/a	8030.8636	left_press	n/a	n/a	3	n/a	256	n/a
+32.3816363636	n/a	8095.4091	show_circle	n/a	n/a	3	n/a	0	circle.bmp
+34.081636363600005	n/a	8520.4091	show_cross	n/a	n/a	4	n/a	n/a	cross.bmp
+34.569818181799995	n/a	8642.4545	show_face	unfamiliar_face	first_show	4	n/a	13	u132.bmp
+35.3943636364	n/a	8848.5909	right_press	n/a	n/a	4	n/a	4096	n/a
+35.4189090909	n/a	8854.7273	show_circle	n/a	n/a	4	n/a	0	circle.bmp
+37.118909090900004	n/a	9279.7273	show_cross	n/a	n/a	5	n/a	n/a	cross.bmp
+37.7434545455	n/a	9435.8636	show_face	unfamiliar_face	immediate_repeat	5	1	14	u132.bmp
+38.1970909091	n/a	9549.2727	right_press	n/a	n/a	5	n/a	4096	n/a
+38.572545454499995	n/a	9643.1364	show_circle	n/a	n/a	5	n/a	0	circle.bmp
+40.2725454545	n/a	10068.1364	show_cross	n/a	n/a	6	n/a	n/a	cross.bmp
+40.7834545455	n/a	10195.8636	show_face	scrambled_face	first_show	6	n/a	17	s033.bmp
+41.618909090900004	n/a	10404.7273	right_press	n/a	n/a	6	n/a	4096	n/a
+41.758909090900005	n/a	10439.7273	show_circle	n/a	n/a	6	n/a	0	circle.bmp
+43.4589090909	n/a	10864.7273	show_cross	n/a	n/a	7	n/a	n/a	cross.bmp
+44.0743636364	n/a	11018.5909	show_face	scrambled_face	immediate_repeat	7	1	18	s033.bmp
+44.567090909099996	n/a	11141.7727	right_press	n/a	n/a	7	n/a	4096	n/a
+45.016181818199996	n/a	11254.0455	show_circle	n/a	n/a	7	n/a	0	circle.bmp
+46.7161818182	n/a	11679.0455	show_cross	n/a	n/a	8	n/a	n/a	cross.bmp
+47.2489090909	n/a	11812.2273	show_face	scrambled_face	first_show	8	n/a	17	s062.bmp
+47.8234545455	n/a	11955.8636	left_press	n/a	n/a	8	n/a	256	n/a
+48.247090909099995	n/a	12061.7727	show_circle	n/a	n/a	8	n/a	0	circle.bmp
+49.9470909091	n/a	12486.7727	show_cross	n/a	n/a	9	n/a	n/a	cross.bmp
+50.438909090900005	n/a	12609.7273	show_face	famous_face	first_show	9	n/a	5	f102.bmp
+51.1325454545	n/a	12783.1364	right_press	n/a	n/a	9	n/a	4096	n/a
+51.2798181818	n/a	12819.9545	show_circle	n/a	n/a	9	n/a	0	circle.bmp
+52.979818181800006	n/a	13244.9545	show_cross	n/a	n/a	10	n/a	n/a	cross.bmp
+53.5298181818	n/a	13382.4545	show_face	famous_face	immediate_repeat	10	1	6	f102.bmp
+54.0234545455	n/a	13505.8636	right_press	n/a	n/a	10	n/a	4096	n/a
+54.3998181818	n/a	13599.9545	show_circle	n/a	n/a	10	n/a	0	circle.bmp
+56.0998181818	n/a	14024.9545	show_cross	n/a	n/a	11	n/a	n/a	cross.bmp
+56.6034545455	n/a	14150.8636	show_face	famous_face	delayed_repeat	11	10	7	f108.bmp
+57.2434545455	n/a	14310.8636	right_press	n/a	n/a	11	n/a	4096	n/a
+57.444363636400006	n/a	14361.0909	show_circle	n/a	n/a	11	n/a	0	circle.bmp
+59.1443636364	n/a	14786.0909	show_cross	n/a	n/a	12	n/a	n/a	cross.bmp
+59.7789090909	n/a	14944.7273	show_face	unfamiliar_face	first_show	12	n/a	13	u106.bmp
+60.403454545500004	n/a	15100.8636	right_press	n/a	n/a	12	n/a	4096	n/a
+60.7607272727	n/a	15190.1818	show_circle	n/a	n/a	12	n/a	0	circle.bmp
+62.460727272700005	n/a	15615.1818	show_cross	n/a	n/a	13	n/a	n/a	cross.bmp
+63.118909090900004	n/a	15779.7273	show_face	scrambled_face	first_show	13	n/a	17	s017.bmp
+63.9698181818	n/a	15992.4545	left_press	n/a	n/a	13	n/a	256	n/a
+64.0725454545	n/a	16018.1364	show_circle	n/a	n/a	13	n/a	0	circle.bmp
+65.7725454545	n/a	16443.1364	show_cross	n/a	n/a	14	n/a	n/a	cross.bmp
+66.3589090909	n/a	16589.7273	show_face	unfamiliar_face	first_show	14	n/a	13	u024.bmp
+67.218	n/a	16804.5	left_press	n/a	n/a	14	n/a	256	n/a
+67.22618181819999	n/a	16806.5455	show_circle	n/a	n/a	14	n/a	0	circle.bmp
+68.92618181819999	n/a	17231.5455	show_cross	n/a	n/a	15	n/a	n/a	cross.bmp
+69.5670909091	n/a	17391.7727	show_face	famous_face	first_show	15	n/a	5	f051.bmp
+70.1725454545	n/a	17543.1364	right_press	n/a	n/a	15	n/a	4096	n/a
+70.5616363636	n/a	17640.4091	show_circle	n/a	n/a	15	n/a	0	circle.bmp
+72.26163636359999	n/a	18065.4091	show_cross	n/a	n/a	16	n/a	n/a	cross.bmp
+72.908	n/a	18227.0	show_face	scrambled_face	delayed_repeat	16	8	19	s062.bmp
+73.7225454545	n/a	18430.6364	left_press	n/a	n/a	16	n/a	256	n/a
+73.82163636359999	n/a	18455.4091	show_circle	n/a	n/a	16	n/a	0	circle.bmp
+75.5216363636	n/a	18880.4091	show_cross	n/a	n/a	17	n/a	n/a	cross.bmp
+76.0652727273	n/a	19016.3182	show_face	scrambled_face	first_show	17	n/a	17	s025.bmp
+76.8516363636	n/a	19212.9091	left_press	n/a	n/a	17	n/a	256	n/a
+77.038	n/a	19259.5	show_circle	n/a	n/a	17	n/a	0	circle.bmp
+78.738	n/a	19684.5	show_cross	n/a	n/a	18	n/a	n/a	cross.bmp
+79.25618181819999	n/a	19814.0455	show_face	unfamiliar_face	first_show	18	n/a	13	u097.bmp
+79.8752727273	n/a	19968.8182	right_press	n/a	n/a	18	n/a	4096	n/a
+80.168	n/a	20042.0	show_circle	n/a	n/a	18	n/a	0	circle.bmp
+81.868	n/a	20467.0	show_cross	n/a	n/a	19	n/a	n/a	cross.bmp
+82.5134545455	n/a	20628.3636	show_face	unfamiliar_face	delayed_repeat	19	7	15	u106.bmp
+83.2434545455	n/a	20810.8636	right_press	n/a	n/a	19	n/a	4096	n/a
+83.4852727273	n/a	20871.3182	show_circle	n/a	n/a	19	n/a	0	circle.bmp
+85.18527272729999	n/a	21296.3182	show_cross	n/a	n/a	20	n/a	n/a	cross.bmp
+85.7870909091	n/a	21446.7727	show_face	famous_face	first_show	20	n/a	5	f147.bmp
+86.5116363636	n/a	21627.9091	right_press	n/a	n/a	20	n/a	4096	n/a
+86.74527272729999	n/a	21686.3182	show_circle	n/a	n/a	20	n/a	0	circle.bmp
+88.4452727273	n/a	22111.3182	show_cross	n/a	n/a	21	n/a	n/a	cross.bmp
+89.0452727273	n/a	22261.3182	show_face	scrambled_face	delayed_repeat	21	8	19	s017.bmp
+89.62436363639999	n/a	22406.0909	left_press	n/a	n/a	21	n/a	256	n/a
+89.9643636364	n/a	22491.0909	show_circle	n/a	n/a	21	n/a	0	circle.bmp
+91.6643636364	n/a	22916.0909	show_cross	n/a	n/a	22	n/a	n/a	cross.bmp
+92.18527272729999	n/a	23046.3182	show_face	scrambled_face	first_show	22	n/a	17	s080.bmp
+92.9625454545	n/a	23240.6364	left_press	n/a	n/a	22	n/a	256	n/a
+93.1170909091	n/a	23279.2727	show_circle	n/a	n/a	22	n/a	0	circle.bmp
+94.8170909091	n/a	23704.2727	show_cross	n/a	n/a	23	n/a	n/a	cross.bmp
+95.3261818182	n/a	23831.5455	show_face	scrambled_face	immediate_repeat	23	1	18	s080.bmp
+95.9489090909	n/a	23987.2273	left_press	n/a	n/a	23	n/a	256	n/a
+96.2061818182	n/a	24051.5455	show_circle	n/a	n/a	23	n/a	0	circle.bmp
+97.9061818182	n/a	24476.5455	show_cross	n/a	n/a	24	n/a	n/a	cross.bmp
+98.4161818182	n/a	24604.0455	show_face	unfamiliar_face	delayed_repeat	24	10	15	u024.bmp
+99.1952727273	n/a	24798.8182	left_press	n/a	n/a	24	n/a	256	n/a
+99.2743636364	n/a	24818.5909	show_circle	n/a	n/a	24	n/a	0	circle.bmp
+100.9743636364	n/a	25243.5909	show_cross	n/a	n/a	25	n/a	n/a	cross.bmp
+101.5570909091	n/a	25389.2727	show_face	unfamiliar_face	first_show	25	n/a	13	u098.bmp
+102.1661818182	n/a	25541.5455	right_press	n/a	n/a	25	n/a	4096	n/a
+102.5016363636	n/a	25625.4091	show_circle	n/a	n/a	25	n/a	0	circle.bmp
+104.2016363636	n/a	26050.4091	show_cross	n/a	n/a	26	n/a	n/a	cross.bmp
+104.83163636360001	n/a	26207.9091	show_face	unfamiliar_face	immediate_repeat	26	1	14	u098.bmp
+105.398	n/a	26349.5	right_press	n/a	n/a	26	n/a	4096	n/a
+105.808	n/a	26452.0	show_circle	n/a	n/a	26	n/a	0	circle.bmp
+107.508	n/a	26877.0	show_cross	n/a	n/a	27	n/a	n/a	cross.bmp
+107.9889090909	n/a	26997.2273	show_face	famous_face	delayed_repeat	27	12	7	f051.bmp
+108.6689090909	n/a	27167.2273	right_press	n/a	n/a	27	n/a	4096	n/a
+108.9852727273	n/a	27246.3182	show_circle	n/a	n/a	27	n/a	0	circle.bmp
+110.68527272729999	n/a	27671.3182	show_cross	n/a	n/a	28	n/a	n/a	cross.bmp
+111.32981818180001	n/a	27832.4545	show_face	unfamiliar_face	first_show	28	n/a	13	u100.bmp
+111.93072727270001	n/a	27982.6818	left_press	n/a	n/a	28	n/a	256	n/a
+112.2098181818	n/a	28052.4545	show_circle	n/a	n/a	28	n/a	0	circle.bmp
+113.9098181818	n/a	28477.4545	show_cross	n/a	n/a	29	n/a	n/a	cross.bmp
+114.4870909091	n/a	28621.7727	show_face	scrambled_face	delayed_repeat	29	12	19	s025.bmp
+115.12254545450001	n/a	28780.6364	left_press	n/a	n/a	29	n/a	256	n/a
+115.3643636364	n/a	28841.0909	show_circle	n/a	n/a	29	n/a	0	circle.bmp
+117.06436363639999	n/a	29266.0909	show_cross	n/a	n/a	30	n/a	n/a	cross.bmp
+117.6107272727	n/a	29402.6818	show_face	famous_face	first_show	30	n/a	5	f099.bmp
+118.3225454545	n/a	29580.6364	right_press	n/a	n/a	30	n/a	4096	n/a
+118.4961818182	n/a	29624.0455	show_circle	n/a	n/a	30	n/a	0	circle.bmp
+120.1961818182	n/a	30049.0455	show_cross	n/a	n/a	31	n/a	n/a	cross.bmp
+120.7016363636	n/a	30175.4091	show_face	famous_face	immediate_repeat	31	1	6	f099.bmp
+121.2916363636	n/a	30322.9091	right_press	n/a	n/a	31	n/a	4096	n/a
+121.5316363636	n/a	30382.9091	show_circle	n/a	n/a	31	n/a	0	circle.bmp
+123.2316363636	n/a	30807.9091	show_cross	n/a	n/a	32	n/a	n/a	cross.bmp
+123.708	n/a	30927.0	show_face	unfamiliar_face	delayed_repeat	32	14	15	u097.bmp
+124.37254545450001	n/a	31093.1364	right_press	n/a	n/a	32	n/a	4096	n/a
+124.708	n/a	31177.0	show_circle	n/a	n/a	32	n/a	0	circle.bmp
+126.408	n/a	31602.0	show_cross	n/a	n/a	33	n/a	n/a	cross.bmp
+127.0161818182	n/a	31754.0455	show_face	scrambled_face	first_show	33	n/a	17	s071.bmp
+127.7516363636	n/a	31937.9091	right_press	n/a	n/a	33	n/a	4096	n/a
+127.8416363636	n/a	31960.4091	show_circle	n/a	n/a	33	n/a	0	circle.bmp
+129.54163636360002	n/a	32385.4091	show_cross	n/a	n/a	34	n/a	n/a	cross.bmp
+130.1734545455	n/a	32543.3636	show_face	scrambled_face	immediate_repeat	34	1	18	s071.bmp
+131.0525454545	n/a	32763.1364	right_press	n/a	n/a	34	n/a	4096	n/a
+131.1007272727	n/a	32775.1818	show_circle	n/a	n/a	34	n/a	0	circle.bmp
+132.80072727270002	n/a	33200.1818	show_cross	n/a	n/a	35	n/a	n/a	cross.bmp
+133.4307272727	n/a	33357.6818	show_face	famous_face	delayed_repeat	35	15	7	f147.bmp
+134.0570909091	n/a	33514.2727	right_press	n/a	n/a	35	n/a	4096	n/a
+134.3970909091	n/a	33599.2727	show_circle	n/a	n/a	35	n/a	0	circle.bmp
+136.0970909091	n/a	34024.2727	show_cross	n/a	n/a	36	n/a	n/a	cross.bmp
+136.7216363636	n/a	34180.4091	show_face	unfamiliar_face	first_show	36	n/a	13	u091.bmp
+137.4443636364	n/a	34361.0909	right_press	n/a	n/a	36	n/a	4096	n/a
+137.6298181818	n/a	34407.4545	show_circle	n/a	n/a	36	n/a	0	circle.bmp
+139.3298181818	n/a	34832.4545	show_cross	n/a	n/a	37	n/a	n/a	cross.bmp
+139.8452727273	n/a	34961.3182	show_face	unfamiliar_face	immediate_repeat	37	1	14	u091.bmp
+140.3534545455	n/a	35088.3636	right_press	n/a	n/a	37	n/a	4096	n/a
+140.7798181818	n/a	35194.9545	show_circle	n/a	n/a	37	n/a	0	circle.bmp
+142.4798181818	n/a	35619.9545	show_cross	n/a	n/a	38	n/a	n/a	cross.bmp
+143.0861818182	n/a	35771.5455	show_face	scrambled_face	first_show	38	n/a	17	s106.bmp
+143.7398181818	n/a	35934.9545	left_press	n/a	n/a	38	n/a	256	n/a
+144.0098181818	n/a	36002.4545	show_circle	n/a	n/a	38	n/a	0	circle.bmp
+145.70981818180002	n/a	36427.4545	show_cross	n/a	n/a	39	n/a	n/a	cross.bmp
+146.3107272727	n/a	36577.6818	show_face	scrambled_face	immediate_repeat	39	1	18	s106.bmp
+146.8798181818	n/a	36719.9545	left_press	n/a	n/a	39	n/a	256	n/a
+147.2116363636	n/a	36802.9091	show_circle	n/a	n/a	39	n/a	0	circle.bmp
+148.9116363636	n/a	37227.9091	show_cross	n/a	n/a	40	n/a	n/a	cross.bmp
+149.4170909091	n/a	37354.2727	show_face	famous_face	first_show	40	n/a	5	f034.bmp
+150.0307272727	n/a	37507.6818	right_press	n/a	n/a	40	n/a	4096	n/a
+150.338	n/a	37584.5	show_circle	n/a	n/a	40	n/a	0	circle.bmp
+152.038	n/a	38009.5	show_cross	n/a	n/a	41	n/a	n/a	cross.bmp
+152.6416363636	n/a	38160.4091	show_face	unfamiliar_face	delayed_repeat	41	13	15	u100.bmp
+153.3152727273	n/a	38328.8182	left_press	n/a	n/a	41	n/a	256	n/a
+153.6043636364	n/a	38401.0909	show_circle	n/a	n/a	41	n/a	0	circle.bmp
+155.30436363639998	n/a	38826.0909	show_cross	n/a	n/a	42	n/a	n/a	cross.bmp
+155.8152727273	n/a	38953.8182	show_face	scrambled_face	first_show	42	n/a	17	s006.bmp
+156.6525454545	n/a	39163.1364	show_circle	n/a	n/a	42	n/a	0	circle.bmp
+156.8070909091	n/a	39201.7727	right_press	n/a	n/a	42	n/a	4096	n/a
+158.35254545450002	n/a	39588.1364	show_cross	n/a	n/a	43	n/a	n/a	cross.bmp
+158.9561818182	n/a	39739.0455	show_face	scrambled_face	immediate_repeat	43	1	18	s006.bmp
+159.7261818182	n/a	39931.5455	right_press	n/a	n/a	43	n/a	4096	n/a
+159.7970909091	n/a	39949.2727	show_circle	n/a	n/a	43	n/a	0	circle.bmp
+161.4970909091	n/a	40374.2727	show_cross	n/a	n/a	44	n/a	n/a	cross.bmp
+162.1298181818	n/a	40532.4545	show_face	unfamiliar_face	first_show	44	n/a	13	u083.bmp
+162.7570909091	n/a	40689.2727	right_press	n/a	n/a	44	n/a	4096	n/a
+163.1070909091	n/a	40776.7727	show_circle	n/a	n/a	44	n/a	0	circle.bmp
+164.8070909091	n/a	41201.7727	show_cross	n/a	n/a	45	n/a	n/a	cross.bmp
+165.338	n/a	41334.5	show_face	scrambled_face	first_show	45	n/a	17	s015.bmp
+165.9843636364	n/a	41496.0909	left_press	n/a	n/a	45	n/a	256	n/a
+166.3016363636	n/a	41575.4091	show_circle	n/a	n/a	45	n/a	0	circle.bmp
+168.0016363636	n/a	42000.4091	show_cross	n/a	n/a	46	n/a	n/a	cross.bmp
+168.6289090909	n/a	42157.2273	show_face	scrambled_face	first_show	46	n/a	17	s142.bmp
+169.3461818182	n/a	42336.5455	right_press	n/a	n/a	46	n/a	4096	n/a
+169.5016363636	n/a	42375.4091	show_circle	n/a	n/a	46	n/a	0	circle.bmp
+171.20163636360002	n/a	42800.4091	show_cross	n/a	n/a	47	n/a	n/a	cross.bmp
+171.85254545450002	n/a	42963.1364	show_face	scrambled_face	immediate_repeat	47	1	18	s142.bmp
+172.3698181818	n/a	43092.4545	right_press	n/a	n/a	47	n/a	4096	n/a
+172.8543636364	n/a	43213.5909	show_circle	n/a	n/a	47	n/a	0	circle.bmp
+174.55436363639998	n/a	43638.5909	show_cross	n/a	n/a	48	n/a	n/a	cross.bmp
+175.1270909091	n/a	43781.7727	show_face	famous_face	first_show	48	n/a	5	f075.bmp
+175.7525454545	n/a	43938.1364	right_press	n/a	n/a	48	n/a	4096	n/a
+176.0925454545	n/a	44023.1364	show_circle	n/a	n/a	48	n/a	0	circle.bmp
+177.79254545450002	n/a	44448.1364	show_cross	n/a	n/a	49	n/a	n/a	cross.bmp
+178.2670909091	n/a	44566.7727	show_face	famous_face	delayed_repeat	49	9	7	f034.bmp
+179.0834545455	n/a	44770.8636	right_press	n/a	n/a	49	n/a	4096	n/a
+179.1725454545	n/a	44793.1364	show_circle	n/a	n/a	49	n/a	0	circle.bmp
+180.8725454545	n/a	45218.1364	show_cross	n/a	n/a	50	n/a	n/a	cross.bmp
+181.4916363636	n/a	45372.9091	show_face	unfamiliar_face	first_show	50	n/a	13	u103.bmp
+182.2689090909	n/a	45567.2273	right_press	n/a	n/a	50	n/a	4096	n/a
+182.358	n/a	45589.5	show_circle	n/a	n/a	50	n/a	0	circle.bmp
+184.058	n/a	46014.5	show_cross	n/a	n/a	51	n/a	n/a	cross.bmp
+184.5652727273	n/a	46141.3182	show_face	unfamiliar_face	first_show	51	n/a	13	u071.bmp
+185.2070909091	n/a	46301.7727	right_press	n/a	n/a	51	n/a	4096	n/a
+185.5316363636	n/a	46382.9091	show_circle	n/a	n/a	51	n/a	0	circle.bmp
+187.23163636360002	n/a	46807.9091	show_cross	n/a	n/a	52	n/a	n/a	cross.bmp
+187.7061818182	n/a	46926.5455	show_face	unfamiliar_face	immediate_repeat	52	1	14	u071.bmp
+188.2307272727	n/a	47057.6818	right_press	n/a	n/a	52	n/a	4096	n/a
+188.5952727273	n/a	47148.8182	show_circle	n/a	n/a	52	n/a	0	circle.bmp
+190.2952727273	n/a	47573.8182	show_cross	n/a	n/a	53	n/a	n/a	cross.bmp
+190.8461818182	n/a	47711.5455	show_face	unfamiliar_face	delayed_repeat	53	9	15	u083.bmp
+191.76163636360002	n/a	47940.4091	left_press	n/a	n/a	53	n/a	256	n/a
+191.8298181818	n/a	47957.4545	show_circle	n/a	n/a	53	n/a	0	circle.bmp
+193.5298181818	n/a	48382.4545	show_cross	n/a	n/a	54	n/a	n/a	cross.bmp
+194.0534545455	n/a	48513.3636	show_face	scrambled_face	first_show	54	n/a	17	s043.bmp
+194.7634545455	n/a	48690.8636	left_press	n/a	n/a	54	n/a	256	n/a
+195.0325454545	n/a	48758.1364	show_circle	n/a	n/a	54	n/a	0	circle.bmp
+196.7325454545	n/a	49183.1364	show_cross	n/a	n/a	55	n/a	n/a	cross.bmp
+197.1943636364	n/a	49298.5909	show_face	scrambled_face	delayed_repeat	55	10	19	s015.bmp
+197.8189090909	n/a	49454.7273	left_press	n/a	n/a	55	n/a	256	n/a
+198.0816363636	n/a	49520.4091	show_circle	n/a	n/a	55	n/a	0	circle.bmp
+199.7816363636	n/a	49945.4091	show_cross	n/a	n/a	56	n/a	n/a	cross.bmp
+200.268	n/a	50067.0	show_face	unfamiliar_face	first_show	56	n/a	13	u122.bmp
+201.2507272727	n/a	50312.6818	show_circle	n/a	n/a	56	n/a	0	circle.bmp
+201.2552727273	n/a	50313.8182	left_press	n/a	n/a	56	n/a	256	n/a
+202.9507272727	n/a	50737.6818	show_cross	n/a	n/a	57	n/a	n/a	cross.bmp
+203.5752727273	n/a	50893.8182	show_face	unfamiliar_face	first_show	57	n/a	13	u028.bmp
+204.5943636364	n/a	51148.5909	show_circle	n/a	n/a	57	n/a	0	circle.bmp
+204.5961818182	n/a	51149.0455	left_press	n/a	n/a	57	n/a	256	n/a
+206.2943636364	n/a	51573.5909	show_cross	n/a	n/a	58	n/a	n/a	cross.bmp
+206.89981818180001	n/a	51724.9545	show_face	unfamiliar_face	immediate_repeat	58	1	14	u028.bmp
+207.54163636360002	n/a	51885.4091	left_press	n/a	n/a	58	n/a	256	n/a
+207.8461818182	n/a	51961.5455	show_circle	n/a	n/a	58	n/a	0	circle.bmp
+209.54618181819998	n/a	52386.5455	show_cross	n/a	n/a	59	n/a	n/a	cross.bmp
+210.0070909091	n/a	52501.7727	show_face	famous_face	delayed_repeat	59	11	7	f075.bmp
+210.64981818180001	n/a	52662.4545	right_press	n/a	n/a	59	n/a	4096	n/a
+210.828	n/a	52707.0	show_circle	n/a	n/a	59	n/a	0	circle.bmp
+212.528	n/a	53132.0	show_cross	n/a	n/a	60	n/a	n/a	cross.bmp
+213.0470909091	n/a	53261.7727	show_face	unfamiliar_face	first_show	60	n/a	13	u105.bmp
+213.7798181818	n/a	53444.9545	right_press	n/a	n/a	60	n/a	4096	n/a
+214.03345454549998	n/a	53508.3636	show_circle	n/a	n/a	60	n/a	0	circle.bmp
+215.7334545455	n/a	53933.3636	show_cross	n/a	n/a	61	n/a	n/a	cross.bmp
+216.238	n/a	54059.5	show_face	unfamiliar_face	delayed_repeat	61	11	15	u103.bmp
+216.9998181818	n/a	54249.9545	right_press	n/a	n/a	61	n/a	4096	n/a
+217.0825454545	n/a	54270.6364	show_circle	n/a	n/a	61	n/a	0	circle.bmp
+218.7825454545	n/a	54695.6364	show_cross	n/a	n/a	62	n/a	n/a	cross.bmp
+219.3452727273	n/a	54836.3182	show_face	famous_face	first_show	62	n/a	5	f041.bmp
+220.2470909091	n/a	55061.7727	right_press	n/a	n/a	62	n/a	4096	n/a
+220.3452727273	n/a	55086.3182	show_circle	n/a	n/a	62	n/a	0	circle.bmp
+222.0452727273	n/a	55511.3182	show_cross	n/a	n/a	63	n/a	n/a	cross.bmp
+222.7034545455	n/a	55675.8636	show_face	unfamiliar_face	first_show	63	n/a	13	u022.bmp
+223.5443636364	n/a	55886.0909	show_circle	n/a	n/a	63	n/a	0	circle.bmp
+223.6607272727	n/a	55915.1818	right_press	n/a	n/a	63	n/a	4096	n/a
+225.24436363639998	n/a	56311.0909	show_cross	n/a	n/a	64	n/a	n/a	cross.bmp
+225.7934545455	n/a	56448.3636	show_face	unfamiliar_face	immediate_repeat	64	1	14	u022.bmp
+226.4525454545	n/a	56613.1364	right_press	n/a	n/a	64	n/a	4096	n/a
+226.6125454545	n/a	56653.1364	show_circle	n/a	n/a	64	n/a	0	circle.bmp
+228.3125454545	n/a	57078.1364	show_cross	n/a	n/a	65	n/a	n/a	cross.bmp
+228.9343636364	n/a	57233.5909	show_face	scrambled_face	delayed_repeat	65	11	19	s043.bmp
+229.77890909090002	n/a	57444.7273	left_press	n/a	n/a	65	n/a	256	n/a
+229.8970909091	n/a	57474.2727	show_circle	n/a	n/a	65	n/a	0	circle.bmp
+231.5970909091	n/a	57899.2727	show_cross	n/a	n/a	66	n/a	n/a	cross.bmp
+232.1252727273	n/a	58031.3182	show_face	unfamiliar_face	first_show	66	n/a	13	u023.bmp
+232.9507272727	n/a	58237.6818	show_circle	n/a	n/a	66	n/a	0	circle.bmp
+233.0643636364	n/a	58266.0909	left_press	n/a	n/a	66	n/a	256	n/a
+234.6507272727	n/a	58662.6818	show_cross	n/a	n/a	67	n/a	n/a	cross.bmp
+235.1989090909	n/a	58799.7273	show_face	unfamiliar_face	delayed_repeat	67	11	15	u122.bmp
+236.0189090909	n/a	59004.7273	left_press	n/a	n/a	67	n/a	256	n/a
+236.198	n/a	59049.5	show_circle	n/a	n/a	67	n/a	0	circle.bmp
+237.898	n/a	59474.5	show_cross	n/a	n/a	68	n/a	n/a	cross.bmp
+238.4070909091	n/a	59601.7727	show_face	famous_face	first_show	68	n/a	5	f028.bmp
+239.0198181818	n/a	59754.9545	right_press	n/a	n/a	68	n/a	4096	n/a
+239.2852727273	n/a	59821.3182	show_circle	n/a	n/a	68	n/a	0	circle.bmp
+240.98527272729999	n/a	60246.3182	show_cross	n/a	n/a	69	n/a	n/a	cross.bmp
+241.5798181818	n/a	60394.9545	show_face	famous_face	immediate_repeat	69	1	6	f028.bmp
+242.1334545455	n/a	60533.3636	right_press	n/a	n/a	69	n/a	4096	n/a
+242.5652727273	n/a	60641.3182	show_circle	n/a	n/a	69	n/a	0	circle.bmp
+244.2652727273	n/a	61066.3182	show_cross	n/a	n/a	70	n/a	n/a	cross.bmp
+244.7543636364	n/a	61188.5909	show_face	unfamiliar_face	first_show	70	n/a	13	u052.bmp
+245.3725454545	n/a	61343.1364	right_press	n/a	n/a	70	n/a	4096	n/a
+245.6470909091	n/a	61411.7727	show_circle	n/a	n/a	70	n/a	0	circle.bmp
+247.3470909091	n/a	61836.7727	show_cross	n/a	n/a	71	n/a	n/a	cross.bmp
+247.9443636364	n/a	61986.0909	show_face	unfamiliar_face	immediate_repeat	71	1	14	u052.bmp
+248.4589090909	n/a	62114.7273	right_press	n/a	n/a	71	n/a	4096	n/a
+248.9234545455	n/a	62230.8636	show_circle	n/a	n/a	71	n/a	0	circle.bmp
+250.62345454549998	n/a	62655.8636	show_cross	n/a	n/a	72	n/a	n/a	cross.bmp
+251.1689090909	n/a	62792.2273	show_face	unfamiliar_face	delayed_repeat	72	12	15	u105.bmp
+251.8752727273	n/a	62968.8182	right_press	n/a	n/a	72	n/a	4096	n/a
+252.0998181818	n/a	63024.9545	show_circle	n/a	n/a	72	n/a	0	circle.bmp
+253.7998181818	n/a	63449.9545	show_cross	n/a	n/a	73	n/a	n/a	cross.bmp
+254.2761818182	n/a	63569.0455	show_face	unfamiliar_face	first_show	73	n/a	13	u017.bmp
+255.0225454545	n/a	63755.6364	right_press	n/a	n/a	73	n/a	4096	n/a
+255.1725454545	n/a	63793.1364	show_circle	n/a	n/a	73	n/a	0	circle.bmp
+256.8725454545	n/a	64218.1364	show_cross	n/a	n/a	74	n/a	n/a	cross.bmp
+257.4670909091	n/a	64366.7727	show_face	famous_face	delayed_repeat	74	12	7	f041.bmp
+258.1770909091	n/a	64544.2727	left_press	n/a	n/a	74	n/a	256	n/a
+258.3934545455	n/a	64598.3636	show_circle	n/a	n/a	74	n/a	0	circle.bmp
+260.0934545455	n/a	65023.3636	show_cross	n/a	n/a	75	n/a	n/a	cross.bmp
+260.7070909091	n/a	65176.7727	show_face	famous_face	first_show	75	n/a	5	f089.bmp
+261.3870909091	n/a	65346.7727	left_press	n/a	n/a	75	n/a	256	n/a
+261.5452727273	n/a	65386.3182	show_circle	n/a	n/a	75	n/a	0	circle.bmp
+263.2452727273	n/a	65811.3182	show_cross	n/a	n/a	76	n/a	n/a	cross.bmp
+263.8316363636	n/a	65957.9091	show_face	famous_face	immediate_repeat	76	1	6	f089.bmp
+264.4334545455	n/a	66108.3636	left_press	n/a	n/a	76	n/a	256	n/a
+264.7616363636	n/a	66190.4091	show_circle	n/a	n/a	76	n/a	0	circle.bmp
+266.4616363636	n/a	66615.4091	show_cross	n/a	n/a	77	n/a	n/a	cross.bmp
+266.9889090909	n/a	66747.2273	show_face	unfamiliar_face	first_show	77	n/a	13	u104.bmp
+267.8707272727	n/a	66967.6818	show_circle	n/a	n/a	77	n/a	0	circle.bmp
+267.9125454545	n/a	66978.1364	right_press	n/a	n/a	77	n/a	4096	n/a
+269.5707272727	n/a	67392.6818	show_cross	n/a	n/a	78	n/a	n/a	cross.bmp
+270.0452727273	n/a	67511.3182	show_face	unfamiliar_face	delayed_repeat	78	12	15	u023.bmp
+270.6407272727	n/a	67660.1818	left_press	n/a	n/a	78	n/a	256	n/a
+270.9998181818	n/a	67749.9545	show_circle	n/a	n/a	78	n/a	0	circle.bmp
+272.6998181818	n/a	68174.9545	show_cross	n/a	n/a	79	n/a	n/a	cross.bmp
+273.3361818182	n/a	68334.0455	show_face	famous_face	first_show	79	n/a	5	f149.bmp
+274.1061818182	n/a	68526.5455	right_press	n/a	n/a	79	n/a	4096	n/a
+274.2016363636	n/a	68550.4091	show_circle	n/a	n/a	79	n/a	0	circle.bmp
+275.9016363636	n/a	68975.4091	show_cross	n/a	n/a	80	n/a	n/a	cross.bmp
+276.4934545455	n/a	69123.3636	show_face	famous_face	first_show	80	n/a	5	f120.bmp
+277.3361818182	n/a	69334.0455	right_press	n/a	n/a	80	n/a	4096	n/a
+277.3598181818	n/a	69339.9545	show_circle	n/a	n/a	80	n/a	0	circle.bmp
+279.0598181818	n/a	69764.9545	show_cross	n/a	n/a	81	n/a	n/a	cross.bmp
+279.5670909091	n/a	69891.7727	show_face	famous_face	immediate_repeat	81	1	6	f120.bmp
+280.2098181818	n/a	70052.4545	right_press	n/a	n/a	81	n/a	4096	n/a
+280.4807272727	n/a	70120.1818	show_circle	n/a	n/a	81	n/a	0	circle.bmp
+282.1807272727	n/a	70545.1818	show_cross	n/a	n/a	82	n/a	n/a	cross.bmp
+282.6916363636	n/a	70672.9091	show_face	scrambled_face	first_show	82	n/a	17	s072.bmp
+283.5243636364	n/a	70881.0909	show_circle	n/a	n/a	82	n/a	0	circle.bmp
+284.0170909091	n/a	71004.2727	right_press	n/a	n/a	82	n/a	4096	n/a
+285.22436363639997	n/a	71306.0909	show_cross	n/a	n/a	83	n/a	n/a	cross.bmp
+285.8316363636	n/a	71457.9091	show_face	scrambled_face	immediate_repeat	83	1	18	s072.bmp
+286.4134545455	n/a	71603.3636	left_press	n/a	n/a	83	n/a	256	n/a
+286.7761818182	n/a	71694.0455	show_circle	n/a	n/a	83	n/a	0	circle.bmp
+288.4761818182	n/a	72119.0455	show_cross	n/a	n/a	84	n/a	n/a	cross.bmp
+289.0225454545	n/a	72255.6364	show_face	unfamiliar_face	delayed_repeat	84	11	15	u017.bmp
+289.6461818182	n/a	72411.5455	right_press	n/a	n/a	84	n/a	4096	n/a
+290.0107272727	n/a	72502.6818	show_circle	n/a	n/a	84	n/a	0	circle.bmp
+291.7107272727	n/a	72927.6818	show_cross	n/a	n/a	85	n/a	n/a	cross.bmp
+292.3470909091	n/a	73086.7727	show_face	famous_face	first_show	85	n/a	5	f013.bmp
+292.9707272727	n/a	73242.6818	right_press	n/a	n/a	85	n/a	4096	n/a
+293.2452727273	n/a	73311.3182	show_circle	n/a	n/a	85	n/a	0	circle.bmp
+294.9452727273	n/a	73736.3182	show_cross	n/a	n/a	86	n/a	n/a	cross.bmp
+295.488	n/a	73872.0	show_face	famous_face	immediate_repeat	86	1	6	f013.bmp
+295.9961818182	n/a	73999.0455	right_press	n/a	n/a	86	n/a	4096	n/a
+296.4670909091	n/a	74116.7727	show_circle	n/a	n/a	86	n/a	0	circle.bmp
+298.1670909091	n/a	74541.7727	show_cross	n/a	n/a	87	n/a	n/a	cross.bmp
+298.6616363636	n/a	74665.4091	show_face	famous_face	first_show	87	n/a	5	f004.bmp
+299.33709090909997	n/a	74834.2727	left_press	n/a	n/a	87	n/a	256	n/a
+299.4870909091	n/a	74871.7727	show_circle	n/a	n/a	87	n/a	0	circle.bmp
+301.1870909091	n/a	75296.7727	show_cross	n/a	n/a	88	n/a	n/a	cross.bmp
+301.78527272729997	n/a	75446.3182	show_face	famous_face	immediate_repeat	88	1	6	f004.bmp
+302.2634545455	n/a	75565.8636	left_press	n/a	n/a	88	n/a	256	n/a
+302.7870909091	n/a	75696.7727	show_circle	n/a	n/a	88	n/a	0	circle.bmp
+304.4870909091	n/a	76121.7727	show_cross	n/a	n/a	89	n/a	n/a	cross.bmp
+304.9761818182	n/a	76244.0455	show_face	unfamiliar_face	delayed_repeat	89	12	15	u104.bmp
+305.6161818182	n/a	76404.0455	right_press	n/a	n/a	89	n/a	4096	n/a
+305.978	n/a	76494.5	show_circle	n/a	n/a	89	n/a	0	circle.bmp
+307.678	n/a	76919.5	show_cross	n/a	n/a	90	n/a	n/a	cross.bmp
+308.268	n/a	77067.0	show_face	famous_face	first_show	90	n/a	5	f109.bmp
+308.9052727273	n/a	77226.3182	left_press	n/a	n/a	90	n/a	256	n/a
+309.268	n/a	77317.0	show_circle	n/a	n/a	90	n/a	0	circle.bmp
+310.968	n/a	77742.0	show_cross	n/a	n/a	91	n/a	n/a	cross.bmp
+311.4416363636	n/a	77860.4091	show_face	famous_face	delayed_repeat	91	12	7	f149.bmp
+312.4307272727	n/a	78107.6818	show_circle	n/a	n/a	91	n/a	0	circle.bmp
+312.478	n/a	78119.5	right_press	n/a	n/a	91	n/a	4096	n/a
+314.1307272727	n/a	78532.6818	show_cross	n/a	n/a	92	n/a	n/a	cross.bmp
+314.7816363636	n/a	78695.4091	show_face	famous_face	first_show	92	n/a	5	f136.bmp
+315.6525454545	n/a	78913.1364	show_circle	n/a	n/a	92	n/a	0	circle.bmp
+315.7152727273	n/a	78928.8182	left_press	n/a	n/a	92	n/a	256	n/a
+317.3525454545	n/a	79338.1364	show_cross	n/a	n/a	93	n/a	n/a	cross.bmp
+317.9061818182	n/a	79476.5455	show_face	scrambled_face	first_show	93	n/a	17	s048.bmp
+318.5216363636	n/a	79630.4091	left_press	n/a	n/a	93	n/a	256	n/a
+318.8316363636	n/a	79707.9091	show_circle	n/a	n/a	93	n/a	0	circle.bmp
+320.5316363636	n/a	80132.9091	show_cross	n/a	n/a	94	n/a	n/a	cross.bmp
+321.1634545455	n/a	80290.8636	show_face	scrambled_face	immediate_repeat	94	1	18	s048.bmp
+321.7798181818	n/a	80444.9545	left_press	n/a	n/a	94	n/a	256	n/a
+322.1570909091	n/a	80539.2727	show_circle	n/a	n/a	94	n/a	0	circle.bmp
+323.8570909091	n/a	80964.2727	show_cross	n/a	n/a	95	n/a	n/a	cross.bmp
+324.5043636364	n/a	81126.0909	show_face	scrambled_face	first_show	95	n/a	17	s067.bmp
+325.428	n/a	81357.0	show_circle	n/a	n/a	95	n/a	0	circle.bmp
+325.5861818182	n/a	81396.5455	right_press	n/a	n/a	95	n/a	4096	n/a
+327.128	n/a	81782.0	show_cross	n/a	n/a	96	n/a	n/a	cross.bmp
+327.6789090909	n/a	81919.7273	show_face	scrambled_face	first_show	96	n/a	17	s126.bmp
+328.31163636360003	n/a	82077.9091	left_press	n/a	n/a	96	n/a	256	n/a
+328.5543636364	n/a	82138.5909	show_circle	n/a	n/a	96	n/a	0	circle.bmp
+330.2543636364	n/a	82563.5909	show_cross	n/a	n/a	97	n/a	n/a	cross.bmp
+330.78527272729997	n/a	82696.3182	show_face	scrambled_face	immediate_repeat	97	1	18	s126.bmp
+331.3570909091	n/a	82839.2727	left_press	n/a	n/a	97	n/a	256	n/a
+331.6452727273	n/a	82911.3182	show_circle	n/a	n/a	97	n/a	0	circle.bmp
+333.34527272729997	n/a	83336.3182	show_cross	n/a	n/a	98	n/a	n/a	cross.bmp
+333.9761818182	n/a	83494.0455	show_face	unfamiliar_face	first_show	98	n/a	13	u150.bmp
+334.6789090909	n/a	83669.7273	right_press	n/a	n/a	98	n/a	4096	n/a
+334.9207272727	n/a	83730.1818	show_circle	n/a	n/a	98	n/a	0	circle.bmp
+336.6207272727	n/a	84155.1818	show_cross	n/a	n/a	99	n/a	n/a	cross.bmp
+337.1507272727	n/a	84287.6818	show_face	unfamiliar_face	immediate_repeat	99	1	14	u150.bmp
+337.738	n/a	84434.5	right_press	n/a	n/a	99	n/a	4096	n/a
+338.1352727273	n/a	84533.8182	show_circle	n/a	n/a	99	n/a	0	circle.bmp
+339.8352727273	n/a	84958.8182	show_cross	n/a	n/a	100	n/a	n/a	cross.bmp
+340.2907272727	n/a	85072.6818	show_face	famous_face	delayed_repeat	100	10	7	f109.bmp
+341.258	n/a	85314.5	show_circle	n/a	n/a	100	n/a	0	circle.bmp
+341.31981818180003	n/a	85329.9545	right_press	n/a	n/a	100	n/a	4096	n/a
+342.958	n/a	85739.5	show_cross	n/a	n/a	101	n/a	n/a	cross.bmp
+343.5316363636	n/a	85882.9091	show_face	famous_face	first_show	101	n/a	5	f080.bmp
+344.1652727273	n/a	86041.3182	right_press	n/a	n/a	101	n/a	4096	n/a
+344.3552727273	n/a	86088.8182	show_circle	n/a	n/a	101	n/a	0	circle.bmp
+346.0552727273	n/a	86513.8182	show_cross	n/a	n/a	102	n/a	n/a	cross.bmp
+346.6725454545	n/a	86668.1364	show_face	famous_face	immediate_repeat	102	1	6	f080.bmp
+347.2298181818	n/a	86807.4545	right_press	n/a	n/a	102	n/a	4096	n/a
+347.50527272730005	n/a	86876.3182	show_circle	n/a	n/a	102	n/a	0	circle.bmp
+349.20527272730004	n/a	87301.3182	show_cross	n/a	n/a	103	n/a	n/a	cross.bmp
+349.8461818182	n/a	87461.5455	show_face	famous_face	delayed_repeat	103	11	7	f136.bmp
+350.62527272730006	n/a	87656.3182	right_press	n/a	n/a	103	n/a	4096	n/a
+350.7170909091	n/a	87679.2727	show_circle	n/a	n/a	103	n/a	0	circle.bmp
+352.4170909091	n/a	88104.2727	show_cross	n/a	n/a	104	n/a	n/a	cross.bmp
+353.0198181818	n/a	88254.9545	show_face	famous_face	first_show	104	n/a	5	f073.bmp
+353.688	n/a	88422.0	left_press	n/a	n/a	104	n/a	256	n/a
+354.00981818180003	n/a	88502.4545	show_circle	n/a	n/a	104	n/a	0	circle.bmp
+355.7098181818	n/a	88927.4545	show_cross	n/a	n/a	105	n/a	n/a	cross.bmp
+356.328	n/a	89082.0	show_face	famous_face	first_show	105	n/a	5	f065.bmp
+357.0943636364	n/a	89273.5909	left_press	n/a	n/a	105	n/a	256	n/a
+357.22436363639997	n/a	89306.0909	show_circle	n/a	n/a	105	n/a	0	circle.bmp
+358.9243636364	n/a	89731.0909	show_cross	n/a	n/a	106	n/a	n/a	cross.bmp
+359.5689090909	n/a	89892.2273	show_face	scrambled_face	delayed_repeat	106	11	19	s067.bmp
+360.2225454545	n/a	90055.6364	right_press	n/a	n/a	106	n/a	4096	n/a
+360.4161818182	n/a	90104.0455	show_circle	n/a	n/a	106	n/a	0	circle.bmp
+362.1161818182	n/a	90529.0455	show_cross	n/a	n/a	107	n/a	n/a	cross.bmp
+362.65890909089995	n/a	90664.7273	show_face	scrambled_face	first_show	107	n/a	17	s131.bmp
+363.4698181818	n/a	90867.4545	left_press	n/a	n/a	107	n/a	256	n/a
+363.4934545455	n/a	90873.3636	show_circle	n/a	n/a	107	n/a	0	circle.bmp
+365.1934545455	n/a	91298.3636	show_cross	n/a	n/a	108	n/a	n/a	cross.bmp
+365.6661818182	n/a	91416.5455	show_face	famous_face	first_show	108	n/a	5	f046.bmp
+366.5325454545	n/a	91633.1364	left_press	n/a	n/a	108	n/a	256	n/a
+366.678	n/a	91669.5	show_circle	n/a	n/a	108	n/a	0	circle.bmp
+368.378	n/a	92094.5	show_cross	n/a	n/a	109	n/a	n/a	cross.bmp
+368.84072727269995	n/a	92210.1818	show_face	famous_face	immediate_repeat	109	1	6	f046.bmp
+369.4843636364	n/a	92371.0909	left_press	n/a	n/a	109	n/a	256	n/a
+369.6734545455	n/a	92418.3636	show_circle	n/a	n/a	109	n/a	0	circle.bmp
+371.3734545455	n/a	92843.3636	show_cross	n/a	n/a	110	n/a	n/a	cross.bmp
+372.0143636364	n/a	93003.5909	show_face	famous_face	first_show	110	n/a	5	f087.bmp
+372.69709090910004	n/a	93174.2727	right_press	n/a	n/a	110	n/a	4096	n/a
+372.9252727273	n/a	93231.3182	show_circle	n/a	n/a	110	n/a	0	circle.bmp
+374.62527272730006	n/a	93656.3182	show_cross	n/a	n/a	111	n/a	n/a	cross.bmp
+375.238	n/a	93809.5	show_face	scrambled_face	first_show	111	n/a	17	s144.bmp
+376.07254545449996	n/a	94018.1364	right_press	n/a	n/a	111	n/a	4096	n/a
+376.2434545455	n/a	94060.8636	show_circle	n/a	n/a	111	n/a	0	circle.bmp
+377.9434545455	n/a	94485.8636	show_cross	n/a	n/a	112	n/a	n/a	cross.bmp
+378.56254545449997	n/a	94640.6364	show_face	famous_face	delayed_repeat	112	8	7	f073.bmp
+379.2816363636	n/a	94820.4091	left_press	n/a	n/a	112	n/a	256	n/a
+379.45890909089997	n/a	94864.7273	show_circle	n/a	n/a	112	n/a	0	circle.bmp
+381.15890909089995	n/a	95289.7273	show_cross	n/a	n/a	113	n/a	n/a	cross.bmp
+381.6861818182	n/a	95421.5455	show_face	scrambled_face	first_show	113	n/a	17	s085.bmp
+382.55709090910005	n/a	95639.2727	right_press	n/a	n/a	113	n/a	4096	n/a
+382.62163636360003	n/a	95655.4091	show_circle	n/a	n/a	113	n/a	0	circle.bmp
+384.3216363636	n/a	96080.4091	show_cross	n/a	n/a	114	n/a	n/a	cross.bmp
+384.7934545455	n/a	96198.3636	show_face	scrambled_face	immediate_repeat	114	1	18	s085.bmp
+385.2852727273	n/a	96321.3182	right_press	n/a	n/a	114	n/a	4096	n/a
+385.69254545449996	n/a	96423.1364	show_circle	n/a	n/a	114	n/a	0	circle.bmp
+387.39254545449995	n/a	96848.1364	show_cross	n/a	n/a	115	n/a	n/a	cross.bmp
+387.9670909091	n/a	96991.7727	show_face	famous_face	delayed_repeat	115	10	7	f065.bmp
+388.7716363636	n/a	97192.9091	left_press	n/a	n/a	115	n/a	256	n/a
+388.898	n/a	97224.5	show_circle	n/a	n/a	115	n/a	0	circle.bmp
+390.598	n/a	97649.5	show_cross	n/a	n/a	116	n/a	n/a	cross.bmp
+391.158	n/a	97789.5	show_face	unfamiliar_face	first_show	116	n/a	13	u003.bmp
+392.09072727269995	n/a	98022.6818	show_circle	n/a	n/a	116	n/a	0	circle.bmp
+392.2643636364	n/a	98066.0909	left_press	n/a	n/a	116	n/a	256	n/a
+393.79072727269994	n/a	98447.6818	show_cross	n/a	n/a	117	n/a	n/a	cross.bmp
+394.34890909089995	n/a	98587.2273	show_face	scrambled_face	delayed_repeat	117	10	19	s131.bmp
+395.01254545449996	n/a	98753.1364	right_press	n/a	n/a	117	n/a	4096	n/a
+395.198	n/a	98799.5	show_circle	n/a	n/a	117	n/a	0	circle.bmp
+396.898	n/a	99224.5	show_cross	n/a	n/a	118	n/a	n/a	cross.bmp
+397.4561818182	n/a	99364.0455	show_face	scrambled_face	first_show	118	n/a	17	s093.bmp
+398.288	n/a	99572.0	show_circle	n/a	n/a	118	n/a	0	circle.bmp
+398.3061818182	n/a	99576.5455	right_press	n/a	n/a	118	n/a	4096	n/a
+399.988	n/a	99997.0	show_cross	n/a	n/a	119	n/a	n/a	cross.bmp
+400.5961818182	n/a	100149.0455	show_face	famous_face	first_show	119	n/a	5	f132.bmp
+401.4343636364	n/a	100358.5909	show_circle	n/a	n/a	119	n/a	0	circle.bmp
+401.8398181818	n/a	100459.9545	left_press	n/a	n/a	119	n/a	256	n/a
+403.1343636364	n/a	100783.5909	show_cross	n/a	n/a	120	n/a	n/a	cross.bmp
+403.6198181818	n/a	100904.9545	show_face	famous_face	immediate_repeat	120	1	6	f132.bmp
+404.1834545455	n/a	101045.8636	left_press	n/a	n/a	120	n/a	256	n/a
+404.63254545449996	n/a	101158.1364	show_circle	n/a	n/a	120	n/a	0	circle.bmp
+406.33254545449995	n/a	101583.1364	show_cross	n/a	n/a	121	n/a	n/a	cross.bmp
+406.8943636364	n/a	101723.5909	show_face	famous_face	delayed_repeat	121	11	7	f087.bmp
+407.50254545449997	n/a	101875.6364	right_press	n/a	n/a	121	n/a	4096	n/a
+407.77072727269996	n/a	101942.6818	show_circle	n/a	n/a	121	n/a	0	circle.bmp
+409.47072727269995	n/a	102367.6818	show_cross	n/a	n/a	122	n/a	n/a	cross.bmp
+409.9516363636	n/a	102487.9091	show_face	famous_face	first_show	122	n/a	5	f117.bmp
+410.6798181818	n/a	102669.9545	left_press	n/a	n/a	122	n/a	256	n/a
+410.8443636364	n/a	102711.0909	show_circle	n/a	n/a	122	n/a	0	circle.bmp
+412.5443636364	n/a	103136.0909	show_cross	n/a	n/a	123	n/a	n/a	cross.bmp
+413.19254545449996	n/a	103298.1364	show_face	famous_face	immediate_repeat	123	1	6	f117.bmp
+413.77890909089996	n/a	103444.7273	left_press	n/a	n/a	123	n/a	256	n/a
+414.1070909091	n/a	103526.7727	show_circle	n/a	n/a	123	n/a	0	circle.bmp
+415.80709090910005	n/a	103951.7727	show_cross	n/a	n/a	124	n/a	n/a	cross.bmp
+416.2825454545	n/a	104070.6364	show_face	scrambled_face	delayed_repeat	124	13	19	s144.bmp
+417.2334545455	n/a	104308.3636	show_circle	n/a	n/a	124	n/a	0	circle.bmp
+417.4225454545	n/a	104355.6364	left_press	n/a	n/a	124	n/a	256	n/a
+418.9334545455	n/a	104733.3636	show_cross	n/a	n/a	125	n/a	n/a	cross.bmp
+419.4234545455	n/a	104855.8636	show_face	unfamiliar_face	first_show	125	n/a	13	u070.bmp
+420.15890909089995	n/a	105039.7273	left_press	n/a	n/a	125	n/a	256	n/a
+420.43709090910005	n/a	105109.2727	show_circle	n/a	n/a	125	n/a	0	circle.bmp
+422.13709090910004	n/a	105534.2727	show_cross	n/a	n/a	126	n/a	n/a	cross.bmp
+422.64709090910003	n/a	105661.7727	show_face	scrambled_face	first_show	126	n/a	17	s002.bmp
+423.45527272730004	n/a	105863.8182	right_press	n/a	n/a	126	n/a	4096	n/a
+423.5343636364	n/a	105883.5909	show_circle	n/a	n/a	126	n/a	0	circle.bmp
+425.2343636364	n/a	106308.5909	show_cross	n/a	n/a	127	n/a	n/a	cross.bmp
+425.7043636364	n/a	106426.0909	show_face	unfamiliar_face	delayed_repeat	127	11	15	u003.bmp
+426.59072727269995	n/a	106647.6818	show_circle	n/a	n/a	127	n/a	0	circle.bmp
+426.6143636364	n/a	106653.5909	right_press	n/a	n/a	127	n/a	4096	n/a
+428.29072727269994	n/a	107072.6818	show_cross	n/a	n/a	128	n/a	n/a	cross.bmp
+428.878	n/a	107219.5	show_face	unfamiliar_face	first_show	128	n/a	13	u007.bmp
+429.5816363636	n/a	107395.4091	left_press	n/a	n/a	128	n/a	256	n/a
+429.81163636360003	n/a	107452.9091	show_circle	n/a	n/a	128	n/a	0	circle.bmp
+431.5116363636	n/a	107877.9091	show_cross	n/a	n/a	129	n/a	n/a	cross.bmp
+432.00254545449997	n/a	108000.6364	show_face	scrambled_face	delayed_repeat	129	11	19	s093.bmp
+432.848	n/a	108212.0	show_circle	n/a	n/a	129	n/a	0	circle.bmp
+432.95709090910003	n/a	108239.2727	left_press	n/a	n/a	129	n/a	256	n/a
+434.548	n/a	108637.0	show_cross	n/a	n/a	130	n/a	n/a	cross.bmp
+435.19254545449996	n/a	108798.1364	show_face	scrambled_face	first_show	130	n/a	17	s123.bmp
+435.84072727269995	n/a	108960.1818	left_press	n/a	n/a	130	n/a	256	n/a
+436.0643636364	n/a	109016.0909	show_circle	n/a	n/a	130	n/a	0	circle.bmp
+437.7643636364	n/a	109441.0909	show_cross	n/a	n/a	131	n/a	n/a	cross.bmp
+438.2998181818	n/a	109574.9545	show_face	scrambled_face	immediate_repeat	131	1	18	s123.bmp
+439.04709090910006	n/a	109761.7727	left_press	n/a	n/a	131	n/a	256	n/a
+439.1289090909	n/a	109782.2273	show_circle	n/a	n/a	131	n/a	0	circle.bmp
+439.1298181818	n/a	109782.4545	show_circle	n/a	n/a	131	n/a	0	circle.bmp
+440.82890909089997	n/a	110207.2273	show_cross	n/a	n/a	132	n/a	n/a	cross.bmp
+440.8298181818	n/a	110207.4545	show_cross	n/a	n/a	133	n/a	n/a	cross.bmp
+441.30709090910005	n/a	110326.7727	show_face	scrambled_face	first_show	133	n/a	17	s011.bmp
+441.93527272730006	n/a	110483.8182	right_press	n/a	n/a	133	n/a	4096	n/a
+442.1516363636	n/a	110537.9091	show_circle	n/a	n/a	133	n/a	0	circle.bmp
+443.8516363636	n/a	110962.9091	show_cross	n/a	n/a	134	n/a	n/a	cross.bmp
+444.4807272727	n/a	111120.1818	show_face	scrambled_face	immediate_repeat	134	1	18	s011.bmp
+444.90890909089995	n/a	111227.2273	right_press	n/a	n/a	134	n/a	4096	n/a
+445.36709090910006	n/a	111341.7727	show_circle	n/a	n/a	134	n/a	0	circle.bmp
+447.06709090910005	n/a	111766.7727	show_cross	n/a	n/a	135	n/a	n/a	cross.bmp
+447.7216363636	n/a	111930.4091	show_face	unfamiliar_face	first_show	135	n/a	13	u029.bmp
+448.34345454550004	n/a	112085.8636	right_press	n/a	n/a	135	n/a	4096	n/a
+448.5507272727	n/a	112137.6818	show_circle	n/a	n/a	135	n/a	0	circle.bmp
+450.2507272727	n/a	112562.6818	show_cross	n/a	n/a	136	n/a	n/a	cross.bmp
+450.7952727273	n/a	112698.8182	show_face	unfamiliar_face	immediate_repeat	136	1	14	u029.bmp
+451.2643636364	n/a	112816.0909	right_press	n/a	n/a	136	n/a	4096	n/a
+451.64072727269996	n/a	112910.1818	show_circle	n/a	n/a	136	n/a	0	circle.bmp
+453.34072727269995	n/a	113335.1818	show_cross	n/a	n/a	137	n/a	n/a	cross.bmp
+453.8361818182	n/a	113459.0455	show_face	unfamiliar_face	delayed_repeat	137	12	15	u070.bmp
+454.6098181818	n/a	113652.4545	right_press	n/a	n/a	137	n/a	4096	n/a
+454.7507272727	n/a	113687.6818	show_circle	n/a	n/a	137	n/a	0	circle.bmp
+456.45072727269996	n/a	114112.6818	show_cross	n/a	n/a	138	n/a	n/a	cross.bmp
+457.09345454550004	n/a	114273.3636	show_face	scrambled_face	first_show	138	n/a	17	s010.bmp
+457.9716363636	n/a	114492.9091	right_press	n/a	n/a	138	n/a	4096	n/a
+458.03072727269995	n/a	114507.6818	show_circle	n/a	n/a	138	n/a	0	circle.bmp
+459.7307272727	n/a	114932.6818	show_cross	n/a	n/a	139	n/a	n/a	cross.bmp
+460.3007272727	n/a	115075.1818	show_face	scrambled_face	immediate_repeat	139	1	18	s010.bmp
+461.268	n/a	115317.0	show_circle	n/a	n/a	139	n/a	0	circle.bmp
+461.4198181818	n/a	115354.9545	right_press	n/a	n/a	139	n/a	4096	n/a
+462.968	n/a	115742.0	show_cross	n/a	n/a	140	n/a	n/a	cross.bmp
+463.5416363636	n/a	115885.4091	show_face	scrambled_face	delayed_repeat	140	14	19	s002.bmp
+464.3007272727	n/a	116075.1818	left_press	n/a	n/a	140	n/a	256	n/a
+464.5443636364	n/a	116136.0909	show_circle	n/a	n/a	140	n/a	0	circle.bmp
+466.2443636364	n/a	116561.0909	show_cross	n/a	n/a	141	n/a	n/a	cross.bmp
+466.7661818182	n/a	116691.5455	show_face	famous_face	first_show	141	n/a	5	f012.bmp
+467.39890909089996	n/a	116849.7273	right_press	n/a	n/a	141	n/a	4096	n/a
+467.7116363636	n/a	116927.9091	show_circle	n/a	n/a	141	n/a	0	circle.bmp
+469.4116363636	n/a	117352.9091	show_cross	n/a	n/a	142	n/a	n/a	cross.bmp
+470.0398181818	n/a	117509.9545	show_face	unfamiliar_face	delayed_repeat	142	14	15	u007.bmp
+470.6516363636	n/a	117662.9091	right_press	n/a	n/a	142	n/a	4096	n/a
+470.9098181818	n/a	117727.4545	show_circle	n/a	n/a	142	n/a	0	circle.bmp
+472.6098181818	n/a	118152.4545	show_cross	n/a	n/a	143	n/a	n/a	cross.bmp
+473.24709090910005	n/a	118311.7727	show_face	unfamiliar_face	first_show	143	n/a	13	u009.bmp
+474.0516363636	n/a	118512.9091	left_press	n/a	n/a	143	n/a	256	n/a
+474.13072727269997	n/a	118532.6818	show_circle	n/a	n/a	143	n/a	0	circle.bmp
+475.83072727269996	n/a	118957.6818	show_cross	n/a	n/a	144	n/a	n/a	cross.bmp
+476.45527272730004	n/a	119113.8182	show_face	unfamiliar_face	immediate_repeat	144	1	14	u009.bmp
+476.96345454550004	n/a	119240.8636	left_press	n/a	n/a	144	n/a	256	n/a
+477.33345454550005	n/a	119333.3636	show_circle	n/a	n/a	144	n/a	0	circle.bmp
+479.03345454550004	n/a	119758.3636	show_cross	n/a	n/a	145	n/a	n/a	cross.bmp
+479.5452727273	n/a	119886.3182	show_face	unfamiliar_face	first_show	145	n/a	13	u068.bmp
+480.2261818182	n/a	120056.5455	right_press	n/a	n/a	145	n/a	4096	n/a
+480.5543636364	n/a	120138.5909	show_circle	n/a	n/a	145	n/a	0	circle.bmp
+482.2543636364	n/a	120563.5909	show_cross	n/a	n/a	146	n/a	n/a	cross.bmp
+482.76890909089997	n/a	120692.2273	show_face	famous_face	first_show	146	n/a	5	f054.bmp
+483.41890909089994	n/a	120854.7273	left_press	n/a	n/a	146	n/a	256	n/a
+483.5998181818	n/a	120899.9545	show_circle	n/a	n/a	146	n/a	0	circle.bmp
+485.2998181818	n/a	121324.9545	show_cross	n/a	n/a	147	n/a	n/a	cross.bmp
+485.9434545455	n/a	121485.8636	show_face	scrambled_face	first_show	147	n/a	17	s049.bmp
+486.588	n/a	121647.0	left_press	n/a	n/a	147	n/a	256	n/a
+486.8161818182	n/a	121704.0455	show_circle	n/a	n/a	147	n/a	0	circle.bmp
+488.5161818182	n/a	122129.0455	show_cross	n/a	n/a	148	n/a	n/a	cross.bmp
+489.11709090910006	n/a	122279.2727	show_face	scrambled_face	immediate_repeat	148	1	18	s049.bmp
+489.5952727273	n/a	122398.8182	left_press	n/a	n/a	148	n/a	256	n/a
+490.0361818182	n/a	122509.0455	show_circle	n/a	n/a	148	n/a	0	circle.bmp
+491.7361818182	n/a	122934.0455	show_cross	n/a	n/a	149	n/a	n/a	cross.bmp

--- a/eeg_hed_small/sub-003/eeg/sub-003_task-FacePerception_run-3_events.tsv
+++ b/eeg_hed_small/sub-003/eeg/sub-003_task-FacePerception_run-3_events.tsv
@@ -1,587 +1,587 @@
-onset	duration	sample	event_type	face_type	repetition_type	trigger	stim_file
-0.0040000000	n/a	1	setup	n/a	n/a	n/a	n/a
-0.0040000000	n/a	1	right_sym	n/a	n/a	n/a	n/a
-27.5589090909	n/a	6889.7273	show_face	scrambled_face	first_show	17	s044.bmp
-28.2207272727	n/a	7055.1818	left_press	n/a	n/a	256	n/a
-28.4352727273	n/a	7108.8182	show_circle	n/a	n/a	0	circle.bmp
-30.1352727273	n/a	7533.8182	show_cross	n/a	n/a	n/a	cross.bmp
-30.7489090909	n/a	7687.2273	show_face	scrambled_face	immediate_repeat	18	s044.bmp
-31.3243636364	n/a	7831.0909	left_press	n/a	n/a	256	n/a
-31.6498181818	n/a	7912.4545	show_circle	n/a	n/a	0	circle.bmp
-33.3498181818	n/a	8337.4545	show_cross	n/a	n/a	n/a	cross.bmp
-33.8398181818	n/a	8459.9545	show_face	unfamiliar_face	first_show	13	u055.bmp
-34.6625454545	n/a	8665.6364	show_circle	n/a	n/a	0	circle.bmp
-34.8761818182	n/a	8719.0455	right_press	n/a	n/a	4096	n/a
-36.3625454545	n/a	9090.6364	show_cross	n/a	n/a	n/a	cross.bmp
-36.9298181818	n/a	9232.4545	show_face	unfamiliar_face	first_show	13	u079.bmp
-37.6543636364	n/a	9413.5909	left_press	n/a	n/a	256	n/a
-37.9389090909	n/a	9484.7273	show_circle	n/a	n/a	0	circle.bmp
-39.6389090909	n/a	9909.7273	show_cross	n/a	n/a	n/a	cross.bmp
-40.2207272727	n/a	10055.1818	show_face	unfamiliar_face	immediate_repeat	14	u079.bmp
-40.6980000000	n/a	10174.5	left_press	n/a	n/a	256	n/a
-41.1752727273	n/a	10293.8182	show_circle	n/a	n/a	0	circle.bmp
-42.8752727273	n/a	10718.8182	show_cross	n/a	n/a	n/a	cross.bmp
-43.4289090909	n/a	10857.2273	show_face	famous_face	first_show	5	f121.bmp
-44.0425454545	n/a	11010.6364	right_press	n/a	n/a	4096	n/a
-44.2707272727	n/a	11067.6818	show_circle	n/a	n/a	0	circle.bmp
-45.9707272727	n/a	11492.6818	show_cross	n/a	n/a	n/a	cross.bmp
-46.4689090909	n/a	11617.2273	show_face	famous_face	first_show	5	f033.bmp
-47.2470909091	n/a	11811.7727	left_press	n/a	n/a	256	n/a
-47.4616363636	n/a	11865.4091	show_circle	n/a	n/a	0	circle.bmp
-49.1616363636	n/a	12290.4091	show_cross	n/a	n/a	n/a	cross.bmp
-49.7598181818	n/a	12439.9545	show_face	famous_face	immediate_repeat	6	f033.bmp
-50.2089090909	n/a	12552.2273	left_press	n/a	n/a	256	n/a
-50.7361818182	n/a	12684.0455	show_circle	n/a	n/a	0	circle.bmp
-52.4361818182	n/a	13109.0455	show_cross	n/a	n/a	n/a	cross.bmp
-53.0670909091	n/a	13266.7727	show_face	scrambled_face	first_show	17	s028.bmp
-53.8870909091	n/a	13471.7727	right_press	n/a	n/a	4096	n/a
-53.8916363636	n/a	13472.9091	show_circle	n/a	n/a	0	circle.bmp
-55.5916363636	n/a	13897.9091	show_cross	n/a	n/a	n/a	cross.bmp
-56.2080000000	n/a	14052	show_face	scrambled_face	first_show	17	s135.bmp
-56.8361818182	n/a	14209.0455	left_press	n/a	n/a	256	n/a
-57.1770909091	n/a	14294.2727	show_circle	n/a	n/a	0	circle.bmp
-58.8770909091	n/a	14719.2727	show_cross	n/a	n/a	n/a	cross.bmp
-59.4152727273	n/a	14853.8182	show_face	scrambled_face	immediate_repeat	18	s135.bmp
-59.8952727273	n/a	14973.8182	left_press	n/a	n/a	256	n/a
-60.3707272727	n/a	15092.6818	show_circle	n/a	n/a	0	circle.bmp
-62.0707272727	n/a	15517.6818	show_cross	n/a	n/a	n/a	cross.bmp
-62.6725454545	n/a	15668.1364	show_face	unfamiliar_face	delayed_repeat	15	u055.bmp
-63.5234545455	n/a	15880.8636	right_press	n/a	n/a	4096	n/a
-63.5716363636	n/a	15892.9091	show_circle	n/a	n/a	0	circle.bmp
-65.2716363636	n/a	16317.9091	show_cross	n/a	n/a	n/a	cross.bmp
-65.7634545455	n/a	16440.8636	show_face	famous_face	first_show	5	f072.bmp
-66.2652727273	n/a	16566.3182	left_press	n/a	n/a	256	n/a
-66.7370909091	n/a	16684.2727	show_circle	n/a	n/a	0	circle.bmp
-68.4370909091	n/a	17109.2727	show_cross	n/a	n/a	n/a	cross.bmp
-68.9370909091	n/a	17234.2727	show_face	scrambled_face	first_show	17	s066.bmp
-69.5961818182	n/a	17399.0455	left_press	n/a	n/a	256	n/a
-69.9207272727	n/a	17480.1818	show_circle	n/a	n/a	0	circle.bmp
-71.6207272727	n/a	17905.1818	show_cross	n/a	n/a	n/a	cross.bmp
-72.1443636364	n/a	18036.0909	show_face	scrambled_face	immediate_repeat	18	s066.bmp
-72.6952727273	n/a	18173.8182	left_press	n/a	n/a	256	n/a
-73.1443636364	n/a	18286.0909	show_circle	n/a	n/a	0	circle.bmp
-74.8443636364	n/a	18711.0909	show_cross	n/a	n/a	n/a	cross.bmp
-75.3525454545	n/a	18838.1364	show_face	famous_face	delayed_repeat	7	f121.bmp
-76.2289090909	n/a	19057.2273	show_circle	n/a	n/a	0	circle.bmp
-76.2334545455	n/a	19058.3636	right_press	n/a	n/a	4096	n/a
-77.9289090909	n/a	19482.2273	show_cross	n/a	n/a	n/a	cross.bmp
-78.6098181818	n/a	19652.4545	show_face	famous_face	first_show	5	f063.bmp
-79.2552727273	n/a	19813.8182	right_press	n/a	n/a	4096	n/a
-79.5625454545	n/a	19890.6364	show_circle	n/a	n/a	0	circle.bmp
-81.2625454545	n/a	20315.6364	show_cross	n/a	n/a	n/a	cross.bmp
-81.7170909091	n/a	20429.2727	show_face	unfamiliar_face	first_show	13	u139.bmp
-82.3361818182	n/a	20584.0455	right_press	n/a	n/a	4096	n/a
-82.5570909091	n/a	20639.2727	show_circle	n/a	n/a	0	circle.bmp
-84.2570909091	n/a	21064.2727	show_cross	n/a	n/a	n/a	cross.bmp
-84.8570909091	n/a	21214.2727	show_face	scrambled_face	delayed_repeat	19	s028.bmp
-85.5416363636	n/a	21385.4091	left_press	n/a	n/a	256	n/a
-85.7370909091	n/a	21434.2727	show_circle	n/a	n/a	0	circle.bmp
-87.4370909091	n/a	21859.2727	show_cross	n/a	n/a	n/a	cross.bmp
-88.0480000000	n/a	22012	show_face	scrambled_face	first_show	17	s018.bmp
-88.9025454545	n/a	22225.6364	left_press	n/a	n/a	256	n/a
-89.0361818182	n/a	22259.0455	show_circle	n/a	n/a	0	circle.bmp
-90.7361818182	n/a	22684.0455	show_cross	n/a	n/a	n/a	cross.bmp
-91.3389090909	n/a	22834.7273	show_face	famous_face	first_show	5	f076.bmp
-91.9316363636	n/a	22982.9091	right_press	n/a	n/a	4096	n/a
-92.2161818182	n/a	23054.0455	show_circle	n/a	n/a	0	circle.bmp
-93.9161818182	n/a	23479.0455	show_cross	n/a	n/a	n/a	cross.bmp
-94.4798181818	n/a	23619.9545	show_face	famous_face	immediate_repeat	6	f076.bmp
-94.9570909091	n/a	23739.2727	right_press	n/a	n/a	4096	n/a
-95.3343636364	n/a	23833.5909	show_circle	n/a	n/a	0	circle.bmp
-97.0343636364	n/a	24258.5909	show_cross	n/a	n/a	n/a	cross.bmp
-97.5361818182	n/a	24384.0455	show_face	famous_face	delayed_repeat	7	f072.bmp
-98.3889090909	n/a	24597.2273	show_circle	n/a	n/a	0	circle.bmp
-98.3916363636	n/a	24597.9091	right_press	n/a	n/a	4096	n/a
-100.0889090909	n/a	25022.2273	show_cross	n/a	n/a	n/a	cross.bmp
-100.5770909091	n/a	25144.2727	show_face	scrambled_face	first_show	17	s121.bmp
-101.4770909091	n/a	25369.2727	left_press	n/a	n/a	256	n/a
-101.5325454545	n/a	25383.1364	show_circle	n/a	n/a	0	circle.bmp
-103.2325454545	n/a	25808.1364	show_cross	n/a	n/a	n/a	cross.bmp
-103.7843636364	n/a	25946.0909	show_face	scrambled_face	first_show	17	s051.bmp
-104.2780000000	n/a	26069.5	left_press	n/a	n/a	256	n/a
-104.7534545455	n/a	26188.3636	show_circle	n/a	n/a	0	circle.bmp
-106.4534545455	n/a	26613.3636	show_cross	n/a	n/a	n/a	cross.bmp
-106.9416363636	n/a	26735.4091	show_face	famous_face	delayed_repeat	7	f063.bmp
-107.5680000000	n/a	26892	right_press	n/a	n/a	4096	n/a
-107.8307272727	n/a	26957.6818	show_circle	n/a	n/a	0	circle.bmp
-109.5307272727	n/a	27382.6818	show_cross	n/a	n/a	n/a	cross.bmp
-110.0652727273	n/a	27516.3182	show_face	unfamiliar_face	first_show	13	u140.bmp
-110.8180000000	n/a	27704.5	right_press	n/a	n/a	4096	n/a
-110.8852727273	n/a	27721.3182	show_circle	n/a	n/a	0	circle.bmp
-112.5852727273	n/a	28146.3182	show_cross	n/a	n/a	n/a	cross.bmp
-113.1725454545	n/a	28293.1364	show_face	unfamiliar_face	delayed_repeat	15	u139.bmp
-113.8161818182	n/a	28454.0455	right_press	n/a	n/a	4096	n/a
-114.1098181818	n/a	28527.4545	show_circle	n/a	n/a	0	circle.bmp
-115.8098181818	n/a	28952.4545	show_cross	n/a	n/a	n/a	cross.bmp
-116.4634545455	n/a	29115.8636	show_face	unfamiliar_face	first_show	13	u124.bmp
-117.3498181818	n/a	29337.4545	show_circle	n/a	n/a	0	circle.bmp
-117.3570909091	n/a	29339.2727	right_press	n/a	n/a	4096	n/a
-119.0498181818	n/a	29762.4545	show_cross	n/a	n/a	n/a	cross.bmp
-119.5707272727	n/a	29892.6818	show_face	unfamiliar_face	immediate_repeat	14	u124.bmp
-120.0643636364	n/a	30016.0909	right_press	n/a	n/a	4096	n/a
-120.4670909091	n/a	30116.7727	show_circle	n/a	n/a	0	circle.bmp
-122.1670909091	n/a	30541.7727	show_cross	n/a	n/a	n/a	cross.bmp
-122.6780000000	n/a	30669.5	show_face	scrambled_face	delayed_repeat	19	s018.bmp
-123.5234545455	n/a	30880.8636	right_press	n/a	n/a	4096	n/a
-123.5352727273	n/a	30883.8182	show_circle	n/a	n/a	0	circle.bmp
-125.2352727273	n/a	31308.8182	show_cross	n/a	n/a	n/a	cross.bmp
-125.8180000000	n/a	31454.5	show_face	famous_face	first_show	5	f150.bmp
-126.4752727273	n/a	31618.8182	right_press	n/a	n/a	4096	n/a
-126.7643636364	n/a	31691.0909	show_circle	n/a	n/a	0	circle.bmp
-128.4643636364	n/a	32116.0909	show_cross	n/a	n/a	n/a	cross.bmp
-129.0598181818	n/a	32264.9545	show_face	famous_face	immediate_repeat	6	f150.bmp
-129.6489090909	n/a	32412.2273	right_press	n/a	n/a	4096	n/a
-129.9980000000	n/a	32499.5	show_circle	n/a	n/a	0	circle.bmp
-131.6980000000	n/a	32924.5	show_cross	n/a	n/a	n/a	cross.bmp
-132.2998181818	n/a	33074.9545	show_face	scrambled_face	first_show	17	s053.bmp
-133.1852727273	n/a	33296.3182	show_circle	n/a	n/a	0	circle.bmp
-133.2098181818	n/a	33302.4545	left_press	n/a	n/a	256	n/a
-134.8852727273	n/a	33721.3182	show_cross	n/a	n/a	n/a	cross.bmp
-135.4570909091	n/a	33864.2727	show_face	scrambled_face	immediate_repeat	18	s053.bmp
-136.0698181818	n/a	34017.4545	left_press	n/a	n/a	256	n/a
-136.4252727273	n/a	34106.3182	show_circle	n/a	n/a	0	circle.bmp
-138.1252727273	n/a	34531.3182	show_cross	n/a	n/a	n/a	cross.bmp
-138.6816363636	n/a	34670.4091	show_face	scrambled_face	delayed_repeat	19	s121.bmp
-139.3943636364	n/a	34848.5909	right_press	n/a	n/a	4096	n/a
-139.5307272727	n/a	34882.6818	show_circle	n/a	n/a	0	circle.bmp
-141.2307272727	n/a	35307.6818	show_cross	n/a	n/a	n/a	cross.bmp
-141.7716363636	n/a	35442.9091	show_face	unfamiliar_face	first_show	13	u089.bmp
-142.4716363636	n/a	35617.9091	right_press	n/a	n/a	4096	n/a
-142.6725454545	n/a	35668.1364	show_circle	n/a	n/a	0	circle.bmp
-144.3725454545	n/a	36093.1364	show_cross	n/a	n/a	n/a	cross.bmp
-144.9789090909	n/a	36244.7273	show_face	scrambled_face	delayed_repeat	19	s051.bmp
-145.6980000000	n/a	36424.5	right_press	n/a	n/a	4096	n/a
-145.9007272727	n/a	36475.1818	show_circle	n/a	n/a	0	circle.bmp
-147.6007272727	n/a	36900.1818	show_cross	n/a	n/a	n/a	cross.bmp
-148.1870909091	n/a	37046.7727	show_face	scrambled_face	first_show	17	s052.bmp
-148.8143636364	n/a	37203.5909	left_press	n/a	n/a	256	n/a
-149.1043636364	n/a	37276.0909	show_circle	n/a	n/a	0	circle.bmp
-150.8043636364	n/a	37701.0909	show_cross	n/a	n/a	n/a	cross.bmp
-151.3443636364	n/a	37836.0909	show_face	scrambled_face	immediate_repeat	18	s052.bmp
-151.8952727273	n/a	37973.8182	left_press	n/a	n/a	256	n/a
-152.2989090909	n/a	38074.7273	show_circle	n/a	n/a	0	circle.bmp
-153.9989090909	n/a	38499.7273	show_cross	n/a	n/a	n/a	cross.bmp
-154.6016363636	n/a	38650.4091	show_face	unfamiliar_face	delayed_repeat	15	u140.bmp
-155.2343636364	n/a	38808.5909	right_press	n/a	n/a	4096	n/a
-155.5961818182	n/a	38899.0455	show_circle	n/a	n/a	0	circle.bmp
-157.2961818182	n/a	39324.0455	show_cross	n/a	n/a	n/a	cross.bmp
-157.8925454545	n/a	39473.1364	show_face	famous_face	first_show	5	f139.bmp
-158.9089090909	n/a	39727.2273	show_circle	n/a	n/a	0	circle.bmp
-158.9498181818	n/a	39737.4545	left_press	n/a	n/a	256	n/a
-160.6089090909	n/a	40152.2273	show_cross	n/a	n/a	n/a	cross.bmp
-161.2334545455	n/a	40308.3636	show_face	scrambled_face	first_show	17	s138.bmp
-162.0670909091	n/a	40516.7727	show_circle	n/a	n/a	0	circle.bmp
-162.2807272727	n/a	40570.1818	right_press	n/a	n/a	4096	n/a
-163.7670909091	n/a	40941.7727	show_cross	n/a	n/a	n/a	cross.bmp
-164.2407272727	n/a	41060.1818	show_face	scrambled_face	immediate_repeat	18	s138.bmp
-164.8425454545	n/a	41210.6364	right_press	n/a	n/a	4096	n/a
-165.1225454545	n/a	41280.6364	show_circle	n/a	n/a	0	circle.bmp
-166.8225454545	n/a	41705.6364	show_cross	n/a	n/a	n/a	cross.bmp
-167.3470909091	n/a	41836.7727	show_face	unfamiliar_face	first_show	13	u128.bmp
-168.0043636364	n/a	42001.0909	left_press	n/a	n/a	256	n/a
-168.2189090909	n/a	42054.7273	show_circle	n/a	n/a	0	circle.bmp
-169.9189090909	n/a	42479.7273	show_cross	n/a	n/a	n/a	cross.bmp
-170.4716363636	n/a	42617.9091	show_face	unfamiliar_face	immediate_repeat	14	u128.bmp
-170.8770909091	n/a	42719.2727	left_press	n/a	n/a	256	n/a
-171.3543636364	n/a	42838.5909	show_circle	n/a	n/a	0	circle.bmp
-173.0543636364	n/a	43263.5909	show_cross	n/a	n/a	n/a	cross.bmp
-173.5280000000	n/a	43382	show_face	famous_face	first_show	5	f124.bmp
-174.3698181818	n/a	43592.4545	show_circle	n/a	n/a	0	circle.bmp
-174.3807272727	n/a	43595.1818	right_press	n/a	n/a	4096	n/a
-176.0698181818	n/a	44017.4545	show_cross	n/a	n/a	n/a	cross.bmp
-176.5689090909	n/a	44142.2273	show_face	unfamiliar_face	delayed_repeat	15	u089.bmp
-177.3143636364	n/a	44328.5909	right_press	n/a	n/a	4096	n/a
-177.5352727273	n/a	44383.8182	show_circle	n/a	n/a	0	circle.bmp
-179.2352727273	n/a	44808.8182	show_cross	n/a	n/a	n/a	cross.bmp
-179.7598181818	n/a	44939.9545	show_face	unfamiliar_face	first_show	13	u044.bmp
-180.3743636364	n/a	45093.5909	left_press	n/a	n/a	256	n/a
-180.7252727273	n/a	45181.3182	show_circle	n/a	n/a	0	circle.bmp
-182.4252727273	n/a	45606.3182	show_cross	n/a	n/a	n/a	cross.bmp
-183.0507272727	n/a	45762.6818	show_face	unfamiliar_face	first_show	13	u086.bmp
-183.7498181818	n/a	45937.4545	left_press	n/a	n/a	256	n/a
-183.8734545455	n/a	45968.3636	show_circle	n/a	n/a	0	circle.bmp
-185.5734545455	n/a	46393.3636	show_cross	n/a	n/a	n/a	cross.bmp
-186.0570909091	n/a	46514.2727	show_face	unfamiliar_face	immediate_repeat	14	u086.bmp
-186.6661818182	n/a	46666.5455	left_press	n/a	n/a	256	n/a
-186.9116363636	n/a	46727.9091	show_circle	n/a	n/a	0	circle.bmp
-188.6116363636	n/a	47152.9091	show_cross	n/a	n/a	n/a	cross.bmp
-189.2316363636	n/a	47307.9091	show_face	famous_face	delayed_repeat	7	f139.bmp
-189.9398181818	n/a	47484.9545	left_press	n/a	n/a	256	n/a
-190.0625454545	n/a	47515.6364	show_circle	n/a	n/a	0	circle.bmp
-191.7625454545	n/a	47940.6364	show_cross	n/a	n/a	n/a	cross.bmp
-192.3889090909	n/a	48097.2273	show_face	famous_face	first_show	5	f091.bmp
-192.8789090909	n/a	48219.7273	right_press	n/a	n/a	4096	n/a
-193.2107272727	n/a	48302.6818	show_circle	n/a	n/a	0	circle.bmp
-194.9107272727	n/a	48727.6818	show_cross	n/a	n/a	n/a	cross.bmp
-195.4452727273	n/a	48861.3182	show_face	famous_face	immediate_repeat	6	f091.bmp
-195.9670909091	n/a	48991.7727	right_press	n/a	n/a	4096	n/a
-196.4534545455	n/a	49113.3636	show_circle	n/a	n/a	0	circle.bmp
-198.1534545455	n/a	49538.3636	show_cross	n/a	n/a	n/a	cross.bmp
-198.6861818182	n/a	49671.5455	show_face	scrambled_face	first_show	17	s105.bmp
-199.4925454545	n/a	49873.1364	right_press	n/a	n/a	4096	n/a
-199.6716363636	n/a	49917.9091	show_circle	n/a	n/a	0	circle.bmp
-201.3716363636	n/a	50342.9091	show_cross	n/a	n/a	n/a	cross.bmp
-201.9607272727	n/a	50490.1818	show_face	scrambled_face	first_show	17	s022.bmp
-202.5943636364	n/a	50648.5909	left_press	n/a	n/a	256	n/a
-202.9725454545	n/a	50743.1364	show_circle	n/a	n/a	0	circle.bmp
-204.6725454545	n/a	51168.1364	show_cross	n/a	n/a	n/a	cross.bmp
-205.2516363636	n/a	51312.9091	show_face	scrambled_face	immediate_repeat	18	s022.bmp
-205.7198181818	n/a	51429.9545	left_press	n/a	n/a	256	n/a
-206.1361818182	n/a	51534.0455	show_circle	n/a	n/a	0	circle.bmp
-207.8361818182	n/a	51959.0455	show_cross	n/a	n/a	n/a	cross.bmp
-208.3752727273	n/a	52093.8182	show_face	famous_face	delayed_repeat	7	f124.bmp
-209.1698181818	n/a	52292.4545	right_press	n/a	n/a	4096	n/a
-209.3898181818	n/a	52347.4545	show_circle	n/a	n/a	0	circle.bmp
-211.0898181818	n/a	52772.4545	show_cross	n/a	n/a	n/a	cross.bmp
-211.6834545455	n/a	52920.8636	show_face	scrambled_face	first_show	17	s091.bmp
-212.4670909091	n/a	53116.7727	left_press	n/a	n/a	256	n/a
-212.5525454545	n/a	53138.1364	show_circle	n/a	n/a	0	circle.bmp
-214.2525454545	n/a	53563.1364	show_cross	n/a	n/a	n/a	cross.bmp
-214.7398181818	n/a	53684.9545	show_face	scrambled_face	immediate_repeat	18	s091.bmp
-215.2789090909	n/a	53819.7273	left_press	n/a	n/a	256	n/a
-215.6552727273	n/a	53913.8182	show_circle	n/a	n/a	0	circle.bmp
-217.3552727273	n/a	54338.8182	show_cross	n/a	n/a	n/a	cross.bmp
-217.9143636364	n/a	54478.5909	show_face	unfamiliar_face	delayed_repeat	15	u044.bmp
-218.7198181818	n/a	54679.9545	right_press	n/a	n/a	4096	n/a
-218.8134545455	n/a	54703.3636	show_circle	n/a	n/a	0	circle.bmp
-220.5134545455	n/a	55128.3636	show_cross	n/a	n/a	n/a	cross.bmp
-221.1552727273	n/a	55288.8182	show_face	famous_face	first_show	5	f082.bmp
-221.7761818182	n/a	55444.0455	left_press	n/a	n/a	256	n/a
-222.1416363636	n/a	55535.4091	show_circle	n/a	n/a	0	circle.bmp
-223.8416363636	n/a	55960.4091	show_cross	n/a	n/a	n/a	cross.bmp
-224.4289090909	n/a	56107.2273	show_face	famous_face	immediate_repeat	6	f082.bmp
-224.8634545455	n/a	56215.8636	left_press	n/a	n/a	256	n/a
-225.4025454545	n/a	56350.6364	show_circle	n/a	n/a	0	circle.bmp
-227.1025454545	n/a	56775.6364	show_cross	n/a	n/a	n/a	cross.bmp
-227.6861818182	n/a	56921.5455	show_face	unfamiliar_face	first_show	13	u147.bmp
-228.5661818182	n/a	57141.5455	right_press	n/a	n/a	4096	n/a
-228.5707272727	n/a	57142.6818	show_circle	n/a	n/a	0	circle.bmp
-230.2707272727	n/a	57567.6818	show_cross	n/a	n/a	n/a	cross.bmp
-230.8107272727	n/a	57702.6818	show_face	unfamiliar_face	immediate_repeat	14	u147.bmp
-231.3189090909	n/a	57829.7273	right_press	n/a	n/a	4096	n/a
-231.8280000000	n/a	57957	show_circle	n/a	n/a	0	circle.bmp
-233.5280000000	n/a	58382	show_cross	n/a	n/a	n/a	cross.bmp
-234.0016363636	n/a	58500.4091	show_face	famous_face	first_show	5	f010.bmp
-234.7198181818	n/a	58679.9545	right_press	n/a	n/a	4096	n/a
-234.8961818182	n/a	58724.0455	show_circle	n/a	n/a	0	circle.bmp
-236.5961818182	n/a	59149.0455	show_cross	n/a	n/a	n/a	cross.bmp
-237.0916363636	n/a	59272.9091	show_face	scrambled_face	delayed_repeat	19	s105.bmp
-237.8325454545	n/a	59458.1364	left_press	n/a	n/a	256	n/a
-237.9752727273	n/a	59493.8182	show_circle	n/a	n/a	0	circle.bmp
-239.6752727273	n/a	59918.8182	show_cross	n/a	n/a	n/a	cross.bmp
-240.1489090909	n/a	60037.2273	show_face	unfamiliar_face	first_show	13	u144.bmp
-240.9225454545	n/a	60230.6364	right_press	n/a	n/a	4096	n/a
-241.0425454545	n/a	60260.6364	show_circle	n/a	n/a	0	circle.bmp
-242.7425454545	n/a	60685.6364	show_cross	n/a	n/a	n/a	cross.bmp
-243.3898181818	n/a	60847.4545	show_face	unfamiliar_face	immediate_repeat	14	u144.bmp
-243.8980000000	n/a	60974.5	right_press	n/a	n/a	4096	n/a
-244.2589090909	n/a	61064.7273	show_circle	n/a	n/a	0	circle.bmp
-245.9589090909	n/a	61489.7273	show_cross	n/a	n/a	n/a	cross.bmp
-246.5134545455	n/a	61628.3636	show_face	famous_face	first_show	5	f052.bmp
-247.2952727273	n/a	61823.8182	right_press	n/a	n/a	4096	n/a
-247.4543636364	n/a	61863.5909	show_circle	n/a	n/a	0	circle.bmp
-249.1543636364	n/a	62288.5909	show_cross	n/a	n/a	n/a	cross.bmp
-249.8043636364	n/a	62451.0909	show_face	scrambled_face	first_show	17	s035.bmp
-250.4070909091	n/a	62601.7727	left_press	n/a	n/a	256	n/a
-250.7807272727	n/a	62695.1818	show_circle	n/a	n/a	0	circle.bmp
-252.4807272727	n/a	63120.1818	show_cross	n/a	n/a	n/a	cross.bmp
-252.9780000000	n/a	63244.5	show_face	scrambled_face	immediate_repeat	18	s035.bmp
-253.6516363636	n/a	63412.9091	left_press	n/a	n/a	256	n/a
-253.9098181818	n/a	63477.4545	show_circle	n/a	n/a	0	circle.bmp
-255.6098181818	n/a	63902.4545	show_cross	n/a	n/a	n/a	cross.bmp
-256.2189090909	n/a	64054.7273	show_face	famous_face	first_show	5	f090.bmp
-257.0443636364	n/a	64261.0909	right_press	n/a	n/a	4096	n/a
-257.1598181818	n/a	64289.9545	show_circle	n/a	n/a	0	circle.bmp
-258.8598181818	n/a	64714.9545	show_cross	n/a	n/a	n/a	cross.bmp
-259.3761818182	n/a	64844.0455	show_face	famous_face	first_show	5	f037.bmp
-260.0734545455	n/a	65018.3636	right_press	n/a	n/a	4096	n/a
-260.3443636364	n/a	65086.0909	show_circle	n/a	n/a	0	circle.bmp
-262.0443636364	n/a	65511.0909	show_cross	n/a	n/a	n/a	cross.bmp
-262.5670909091	n/a	65641.7727	show_face	famous_face	immediate_repeat	6	f037.bmp
-263.1780000000	n/a	65794.5	left_press	n/a	n/a	256	n/a
-263.5107272727	n/a	65877.6818	show_circle	n/a	n/a	0	circle.bmp
-265.2107272727	n/a	66302.6818	show_cross	n/a	n/a	n/a	cross.bmp
-265.8080000000	n/a	66452	show_face	famous_face	delayed_repeat	7	f010.bmp
-266.3643636364	n/a	66591.0909	right_press	n/a	n/a	4096	n/a
-266.6789090909	n/a	66669.7273	show_circle	n/a	n/a	0	circle.bmp
-268.3789090909	n/a	67094.7273	show_cross	n/a	n/a	n/a	cross.bmp
-268.9316363636	n/a	67232.9091	show_face	scrambled_face	first_show	17	s127.bmp
-269.8016363636	n/a	67450.4091	right_press	n/a	n/a	4096	n/a
-269.8670909091	n/a	67466.7727	show_circle	n/a	n/a	0	circle.bmp
-271.5670909091	n/a	67891.7727	show_cross	n/a	n/a	n/a	cross.bmp
-272.1052727273	n/a	68026.3182	show_face	scrambled_face	immediate_repeat	18	s127.bmp
-273.0643636364	n/a	68266.0909	right_press	n/a	n/a	4096	n/a
-273.0834545455	n/a	68270.8636	show_circle	n/a	n/a	0	circle.bmp
-274.7834545455	n/a	68695.8636	show_cross	n/a	n/a	n/a	cross.bmp
-275.3961818182	n/a	68849.0455	show_face	scrambled_face	first_show	17	s128.bmp
-276.0461818182	n/a	69011.5455	left_press	n/a	n/a	256	n/a
-276.3198181818	n/a	69079.9545	show_circle	n/a	n/a	0	circle.bmp
-278.0198181818	n/a	69504.9545	show_cross	n/a	n/a	n/a	cross.bmp
-278.5034545455	n/a	69625.8636	show_face	famous_face	delayed_repeat	7	f052.bmp
-279.0861818182	n/a	69771.5455	right_press	n/a	n/a	4096	n/a
-279.3870909091	n/a	69846.7727	show_circle	n/a	n/a	0	circle.bmp
-281.0870909091	n/a	70271.7727	show_cross	n/a	n/a	n/a	cross.bmp
-281.5770909091	n/a	70394.2727	show_face	unfamiliar_face	first_show	13	u120.bmp
-282.5234545455	n/a	70630.8636	left_press	n/a	n/a	256	n/a
-282.5516363636	n/a	70637.9091	show_circle	n/a	n/a	0	circle.bmp
-284.2516363636	n/a	71062.9091	show_cross	n/a	n/a	n/a	cross.bmp
-284.8180000000	n/a	71204.5	show_face	unfamiliar_face	first_show	13	u040.bmp
-285.8325454545	n/a	71458.1364	show_circle	n/a	n/a	0	circle.bmp
-285.9143636364	n/a	71478.5909	right_press	n/a	n/a	4096	n/a
-287.5325454545	n/a	71883.1364	show_cross	n/a	n/a	n/a	cross.bmp
-287.9752727273	n/a	71993.8182	show_face	unfamiliar_face	immediate_repeat	14	u040.bmp
-288.5180000000	n/a	72129.5	right_press	n/a	n/a	4096	n/a
-288.9016363636	n/a	72225.4091	show_circle	n/a	n/a	0	circle.bmp
-290.6016363636	n/a	72650.4091	show_cross	n/a	n/a	n/a	cross.bmp
-291.2161818182	n/a	72804.0455	show_face	famous_face	delayed_repeat	7	f090.bmp
-291.8561818182	n/a	72964.0455	left_press	n/a	n/a	256	n/a
-292.2152727273	n/a	73053.8182	show_circle	n/a	n/a	0	circle.bmp
-293.9152727273	n/a	73478.8182	show_cross	n/a	n/a	n/a	cross.bmp
-294.4743636364	n/a	73618.5909	show_face	unfamiliar_face	first_show	13	u146.bmp
-295.3343636364	n/a	73833.5909	right_press	n/a	n/a	4096	n/a
-295.4634545455	n/a	73865.8636	show_circle	n/a	n/a	0	circle.bmp
-297.1634545455	n/a	74290.8636	show_cross	n/a	n/a	n/a	cross.bmp
-297.6980000000	n/a	74424.5	show_face	famous_face	first_show	5	f017.bmp
-298.4834545455	n/a	74620.8636	left_press	n/a	n/a	256	n/a
-298.6670909091	n/a	74666.7727	show_circle	n/a	n/a	0	circle.bmp
-300.3670909091	n/a	75091.7727	show_cross	n/a	n/a	n/a	cross.bmp
-300.8552727273	n/a	75213.8182	show_face	famous_face	immediate_repeat	6	f017.bmp
-301.3780000000	n/a	75344.5	left_press	n/a	n/a	256	n/a
-301.8270909091	n/a	75456.7727	show_circle	n/a	n/a	0	circle.bmp
-303.5270909091	n/a	75881.7727	show_cross	n/a	n/a	n/a	cross.bmp
-304.0461818182	n/a	76011.5455	show_face	unfamiliar_face	first_show	13	u048.bmp
-304.7161818182	n/a	76179.0455	right_press	n/a	n/a	4096	n/a
-305.0107272727	n/a	76252.6818	show_circle	n/a	n/a	0	circle.bmp
-306.7107272727	n/a	76677.6818	show_cross	n/a	n/a	n/a	cross.bmp
-307.2370909091	n/a	76809.2727	show_face	scrambled_face	delayed_repeat	19	s128.bmp
-307.8616363636	n/a	76965.4091	left_press	n/a	n/a	256	n/a
-308.2343636364	n/a	77058.5909	show_circle	n/a	n/a	0	circle.bmp
-309.9343636364	n/a	77483.5909	show_cross	n/a	n/a	n/a	cross.bmp
-310.4607272727	n/a	77615.1818	show_face	unfamiliar_face	first_show	13	u019.bmp
-311.1961818182	n/a	77799.0455	left_press	n/a	n/a	256	n/a
-311.4425454545	n/a	77860.6364	show_circle	n/a	n/a	0	circle.bmp
-313.1425454545	n/a	78285.6364	show_cross	n/a	n/a	n/a	cross.bmp
-313.6016363636	n/a	78400.4091	show_face	unfamiliar_face	delayed_repeat	15	u120.bmp
-314.3316363636	n/a	78582.9091	left_press	n/a	n/a	256	n/a
-314.6043636364	n/a	78651.0909	show_circle	n/a	n/a	0	circle.bmp
-316.3043636364	n/a	79076.0909	show_cross	n/a	n/a	n/a	cross.bmp
-316.8589090909	n/a	79214.7273	show_face	unfamiliar_face	first_show	13	u092.bmp
-317.5280000000	n/a	79382	left_press	n/a	n/a	256	n/a
-317.8507272727	n/a	79462.6818	show_circle	n/a	n/a	0	circle.bmp
-319.5507272727	n/a	79887.6818	show_cross	n/a	n/a	n/a	cross.bmp
-320.0825454545	n/a	80020.6364	show_face	famous_face	first_show	5	f066.bmp
-320.9861818182	n/a	80246.5455	show_circle	n/a	n/a	0	circle.bmp
-321.2325454545	n/a	80308.1364	left_press	n/a	n/a	256	n/a
-322.6861818182	n/a	80671.5455	show_cross	n/a	n/a	n/a	cross.bmp
-323.2734545455	n/a	80818.3636	show_face	unfamiliar_face	delayed_repeat	15	u146.bmp
-323.9725454545	n/a	80993.1364	right_press	n/a	n/a	4096	n/a
-324.2652727273	n/a	81066.3182	show_circle	n/a	n/a	0	circle.bmp
-325.9652727273	n/a	81491.3182	show_cross	n/a	n/a	n/a	cross.bmp
-326.4980000000	n/a	81624.5	show_face	unfamiliar_face	first_show	13	u078.bmp
-327.0416363636	n/a	81760.4091	right_press	n/a	n/a	4096	n/a
-327.4225454545	n/a	81855.6364	show_circle	n/a	n/a	0	circle.bmp
-329.1225454545	n/a	82280.6364	show_cross	n/a	n/a	n/a	cross.bmp
-329.7552727273	n/a	82438.8182	show_face	famous_face	first_show	5	f145.bmp
-330.5007272727	n/a	82625.1818	right_press	n/a	n/a	4096	n/a
-330.7698181818	n/a	82692.4545	show_circle	n/a	n/a	0	circle.bmp
-332.4698181818	n/a	83117.4545	show_cross	n/a	n/a	n/a	cross.bmp
-333.0961818182	n/a	83274.0455	show_face	famous_face	immediate_repeat	6	f145.bmp
-333.9443636364	n/a	83486.0909	right_press	n/a	n/a	4096	n/a
-333.9598181818	n/a	83489.9545	show_circle	n/a	n/a	0	circle.bmp
-335.6598181818	n/a	83914.9545	show_cross	n/a	n/a	n/a	cross.bmp
-336.1370909091	n/a	84034.2727	show_face	unfamiliar_face	delayed_repeat	15	u048.bmp
-336.9470909091	n/a	84236.7727	right_press	n/a	n/a	4096	n/a
-337.0361818182	n/a	84259.0455	show_circle	n/a	n/a	0	circle.bmp
-338.7361818182	n/a	84684.0455	show_cross	n/a	n/a	n/a	cross.bmp
-339.3607272727	n/a	84840.1818	show_face	famous_face	first_show	5	f011.bmp
-340.3098181818	n/a	85077.4545	show_circle	n/a	n/a	0	circle.bmp
-340.3889090909	n/a	85097.2273	right_press	n/a	n/a	4096	n/a
-342.0098181818	n/a	85502.4545	show_cross	n/a	n/a	n/a	cross.bmp
-342.5180000000	n/a	85629.5	show_face	unfamiliar_face	delayed_repeat	15	u019.bmp
-343.4325454545	n/a	85858.1364	show_circle	n/a	n/a	0	circle.bmp
-343.4434545455	n/a	85860.8636	right_press	n/a	n/a	4096	n/a
-345.1325454545	n/a	86283.1364	show_cross	n/a	n/a	n/a	cross.bmp
-345.6416363636	n/a	86410.4091	show_face	famous_face	first_show	5	f106.bmp
-346.3980000000	n/a	86599.5	right_press	n/a	n/a	4096	n/a
-346.6298181818	n/a	86657.4545	show_circle	n/a	n/a	0	circle.bmp
-348.3298181818	n/a	87082.4545	show_cross	n/a	n/a	n/a	cross.bmp
-348.9325454545	n/a	87233.1364	show_face	famous_face	immediate_repeat	6	f106.bmp
-349.4789090909	n/a	87369.7273	right_press	n/a	n/a	4096	n/a
-349.9198181818	n/a	87479.9545	show_circle	n/a	n/a	0	circle.bmp
-351.6198181818	n/a	87904.9545	show_cross	n/a	n/a	n/a	cross.bmp
-352.1570909091	n/a	88039.2727	show_face	unfamiliar_face	delayed_repeat	15	u092.bmp
-352.7761818182	n/a	88194.0455	left_press	n/a	n/a	256	n/a
-353.0370909091	n/a	88259.2727	show_circle	n/a	n/a	0	circle.bmp
-354.7370909091	n/a	88684.2727	show_cross	n/a	n/a	n/a	cross.bmp
-355.3807272727	n/a	88845.1818	show_face	scrambled_face	first_show	17	s012.bmp
-356.0580000000	n/a	89014.5	right_press	n/a	n/a	4096	n/a
-356.2089090909	n/a	89052.2273	show_circle	n/a	n/a	0	circle.bmp
-357.9089090909	n/a	89477.2273	show_cross	n/a	n/a	n/a	cross.bmp
-358.4043636364	n/a	89601.0909	show_face	famous_face	delayed_repeat	7	f066.bmp
-359.0770909091	n/a	89769.2727	left_press	n/a	n/a	256	n/a
-359.3852727273	n/a	89846.3182	show_circle	n/a	n/a	0	circle.bmp
-361.0852727273	n/a	90271.3182	show_cross	n/a	n/a	n/a	cross.bmp
-361.6116363636	n/a	90402.9091	show_face	unfamiliar_face	first_show	13	u130.bmp
-362.3570909091	n/a	90589.2727	right_press	n/a	n/a	4096	n/a
-362.4343636364	n/a	90608.5909	show_circle	n/a	n/a	0	circle.bmp
-364.1343636364	n/a	91033.5909	show_cross	n/a	n/a	n/a	cross.bmp
-364.7189090909	n/a	91179.7273	show_face	unfamiliar_face	delayed_repeat	15	u078.bmp
-365.2725454545	n/a	91318.1364	right_press	n/a	n/a	4096	n/a
-365.7089090909	n/a	91427.2273	show_circle	n/a	n/a	0	circle.bmp
-367.4089090909	n/a	91852.2273	show_cross	n/a	n/a	n/a	cross.bmp
-368.0434545455	n/a	92010.8636	show_face	famous_face	first_show	5	f027.bmp
-368.8443636364	n/a	92211.0909	left_press	n/a	n/a	256	n/a
-369.0407272727	n/a	92260.1818	show_circle	n/a	n/a	0	circle.bmp
-370.7407272727	n/a	92685.1818	show_cross	n/a	n/a	n/a	cross.bmp
-371.3680000000	n/a	92842	show_face	scrambled_face	first_show	17	s041.bmp
-372.2152727273	n/a	93053.8182	left_press	n/a	n/a	256	n/a
-372.3425454545	n/a	93085.6364	show_circle	n/a	n/a	0	circle.bmp
-374.0425454545	n/a	93510.6364	show_cross	n/a	n/a	n/a	cross.bmp
-374.6252727273	n/a	93656.3182	show_face	scrambled_face	immediate_repeat	18	s041.bmp
-375.5116363636	n/a	93877.9091	show_circle	n/a	n/a	0	circle.bmp
-377.2116363636	n/a	94302.9091	show_cross	n/a	n/a	n/a	cross.bmp
-377.7325454545	n/a	94433.1364	show_face	famous_face	delayed_repeat	7	f011.bmp
-378.5752727273	n/a	94643.8182	show_circle	n/a	n/a	0	circle.bmp
-380.2752727273	n/a	95068.8182	show_cross	n/a	n/a	n/a	cross.bmp
-380.9234545455	n/a	95230.8636	show_face	unfamiliar_face	first_show	13	u073.bmp
-381.5407272727	n/a	95385.1818	left_press	n/a	n/a	256	n/a
-381.8343636364	n/a	95458.5909	show_circle	n/a	n/a	0	circle.bmp
-383.5343636364	n/a	95883.5909	show_cross	n/a	n/a	n/a	cross.bmp
-384.1470909091	n/a	96036.7727	show_face	unfamiliar_face	immediate_repeat	14	u073.bmp
-384.6234545455	n/a	96155.8636	left_press	n/a	n/a	256	n/a
-384.9880000000	n/a	96247	show_circle	n/a	n/a	0	circle.bmp
-386.6880000000	n/a	96672	show_cross	n/a	n/a	n/a	cross.bmp
-387.1543636364	n/a	96788.5909	show_face	famous_face	first_show	5	f067.bmp
-387.8170909091	n/a	96954.2727	left_press	n/a	n/a	256	n/a
-388.1107272727	n/a	97027.6818	show_circle	n/a	n/a	0	circle.bmp
-389.8107272727	n/a	97452.6818	show_cross	n/a	n/a	n/a	cross.bmp
-390.4116363636	n/a	97602.9091	show_face	scrambled_face	delayed_repeat	19	s012.bmp
-391.0707272727	n/a	97767.6818	right_press	n/a	n/a	4096	n/a
-391.3816363636	n/a	97845.4091	show_circle	n/a	n/a	0	circle.bmp
-393.0816363636	n/a	98270.4091	show_cross	n/a	n/a	n/a	cross.bmp
-393.5525454545	n/a	98388.1364	show_face	famous_face	first_show	5	f127.bmp
-394.2843636364	n/a	98571.0909	right_press	n/a	n/a	4096	n/a
-394.5189090909	n/a	98629.7273	show_circle	n/a	n/a	0	circle.bmp
-396.2189090909	n/a	99054.7273	show_cross	n/a	n/a	n/a	cross.bmp
-396.7934545455	n/a	99198.3636	show_face	unfamiliar_face	delayed_repeat	15	u130.bmp
-397.4680000000	n/a	99367	right_press	n/a	n/a	4096	n/a
-397.7652727273	n/a	99441.3182	show_circle	n/a	n/a	0	circle.bmp
-399.4652727273	n/a	99866.3182	show_cross	n/a	n/a	n/a	cross.bmp
-399.9834545455	n/a	99995.8636	show_face	scrambled_face	first_show	17	s056.bmp
-400.5043636364	n/a	100126.0909	right_press	n/a	n/a	4096	n/a
-400.8152727273	n/a	100203.8182	show_circle	n/a	n/a	0	circle.bmp
-402.5152727273	n/a	100628.8182	show_cross	n/a	n/a	n/a	cross.bmp
-403.1243636364	n/a	100781.0909	show_face	famous_face	delayed_repeat	7	f027.bmp
-403.6543636364	n/a	100913.5909	left_press	n/a	n/a	256	n/a
-404.0507272727	n/a	101012.6818	show_circle	n/a	n/a	0	circle.bmp
-405.7507272727	n/a	101437.6818	show_cross	n/a	n/a	n/a	cross.bmp
-406.3816363636	n/a	101595.4091	show_face	scrambled_face	first_show	17	s115.bmp
-407.0052727273	n/a	101751.3182	right_press	n/a	n/a	4096	n/a
-407.3661818182	n/a	101841.5455	show_circle	n/a	n/a	0	circle.bmp
-409.0661818182	n/a	102266.5455	show_cross	n/a	n/a	n/a	cross.bmp
-409.5725454545	n/a	102393.1364	show_face	scrambled_face	immediate_repeat	18	s115.bmp
-410.0480000000	n/a	102512	right_press	n/a	n/a	4096	n/a
-410.4934545455	n/a	102623.3636	show_circle	n/a	n/a	0	circle.bmp
-412.1934545455	n/a	103048.3636	show_cross	n/a	n/a	n/a	cross.bmp
-412.8134545455	n/a	103203.3636	show_face	famous_face	first_show	5	f128.bmp
-413.4507272727	n/a	103362.6818	left_press	n/a	n/a	256	n/a
-413.7489090909	n/a	103437.2273	show_circle	n/a	n/a	0	circle.bmp
-415.4489090909	n/a	103862.2273	show_cross	n/a	n/a	n/a	cross.bmp
-415.9543636364	n/a	103988.5909	show_face	famous_face	immediate_repeat	6	f128.bmp
-416.7616363636	n/a	104190.4091	right_press	n/a	n/a	4096	n/a
-416.9098181818	n/a	104227.4545	show_circle	n/a	n/a	0	circle.bmp
-418.6098181818	n/a	104652.4545	show_cross	n/a	n/a	n/a	cross.bmp
-419.1616363636	n/a	104790.4091	show_face	scrambled_face	first_show	17	s016.bmp
-419.7570909091	n/a	104939.2727	right_press	n/a	n/a	4096	n/a
-420.0661818182	n/a	105016.5455	show_circle	n/a	n/a	0	circle.bmp
-421.7661818182	n/a	105441.5455	show_cross	n/a	n/a	n/a	cross.bmp
-422.3689090909	n/a	105592.2273	show_face	famous_face	delayed_repeat	7	f067.bmp
-423.1570909091	n/a	105789.2727	left_press	n/a	n/a	256	n/a
-423.2189090909	n/a	105804.7273	show_circle	n/a	n/a	0	circle.bmp
-424.9189090909	n/a	106229.7273	show_cross	n/a	n/a	n/a	cross.bmp
-425.5089090909	n/a	106377.2273	show_face	famous_face	first_show	5	f084.bmp
-426.0507272727	n/a	106512.6818	right_press	n/a	n/a	4096	n/a
-426.4361818182	n/a	106609.0455	show_circle	n/a	n/a	0	circle.bmp
-428.1361818182	n/a	107034.0455	show_cross	n/a	n/a	n/a	cross.bmp
-428.7670909091	n/a	107191.7727	show_face	famous_face	immediate_repeat	6	f084.bmp
-429.2116363636	n/a	107302.9091	right_press	n/a	n/a	4096	n/a
-429.7725454545	n/a	107443.1364	show_circle	n/a	n/a	0	circle.bmp
-431.4725454545	n/a	107868.1364	show_cross	n/a	n/a	n/a	cross.bmp
-432.1243636364	n/a	108031.0909	show_face	famous_face	delayed_repeat	7	f127.bmp
-432.6834545455	n/a	108170.8636	right_press	n/a	n/a	4096	n/a
-432.9916363636	n/a	108247.9091	show_circle	n/a	n/a	0	circle.bmp
-434.6916363636	n/a	108672.9091	show_cross	n/a	n/a	n/a	cross.bmp
-435.2652727273	n/a	108816.3182	show_face	unfamiliar_face	first_show	13	u065.bmp
-435.8361818182	n/a	108959.0455	left_press	n/a	n/a	256	n/a
-436.1152727273	n/a	109028.8182	show_circle	n/a	n/a	0	circle.bmp
-437.8152727273	n/a	109453.8182	show_cross	n/a	n/a	n/a	cross.bmp
-438.4389090909	n/a	109609.7273	show_face	unfamiliar_face	immediate_repeat	14	u065.bmp
-438.9689090909	n/a	109742.2273	left_press	n/a	n/a	256	n/a
-439.2861818182	n/a	109821.5455	show_circle	n/a	n/a	0	circle.bmp
-440.9861818182	n/a	110246.5455	show_cross	n/a	n/a	n/a	cross.bmp
-441.5461818182	n/a	110386.5455	show_face	scrambled_face	delayed_repeat	19	s056.bmp
-442.4061818182	n/a	110601.5455	show_circle	n/a	n/a	0	circle.bmp
-442.5907272727	n/a	110647.6818	left_press	n/a	n/a	256	n/a
-444.1061818182	n/a	111026.5455	show_cross	n/a	n/a	n/a	cross.bmp
-444.6534545455	n/a	111163.3636	show_face	unfamiliar_face	first_show	13	u037.bmp
-445.2452727273	n/a	111311.3182	left_press	n/a	n/a	256	n/a
-445.5025454545	n/a	111375.6364	show_circle	n/a	n/a	0	circle.bmp
-445.5034545455	n/a	111375.8636	show_circle	n/a	n/a	0	circle.bmp
-447.2025454545	n/a	111800.6364	show_cross	n/a	n/a	n/a	cross.bmp
-447.2034545455	n/a	111800.8636	show_cross	n/a	n/a	n/a	cross.bmp
-447.6607272727	n/a	111915.1818	show_face	unfamiliar_face	first_show	13	u090.bmp
-448.4198181818	n/a	112104.9545	right_press	n/a	n/a	4096	n/a
-448.4789090909	n/a	112119.7273	show_circle	n/a	n/a	0	circle.bmp
-450.1789090909	n/a	112544.7273	show_cross	n/a	n/a	n/a	cross.bmp
-450.7843636364	n/a	112696.0909	show_face	unfamiliar_face	immediate_repeat	14	u090.bmp
-451.3480000000	n/a	112837	left_press	n/a	n/a	256	n/a
-451.7152727273	n/a	112928.8182	show_circle	n/a	n/a	0	circle.bmp
-453.4152727273	n/a	113353.8182	show_cross	n/a	n/a	n/a	cross.bmp
-454.0589090909	n/a	113514.7273	show_face	scrambled_face	first_show	17	s045.bmp
-454.7607272727	n/a	113690.1818	left_press	n/a	n/a	256	n/a
-454.9980000000	n/a	113749.5	show_circle	n/a	n/a	0	circle.bmp
-456.6980000000	n/a	114174.5	show_cross	n/a	n/a	n/a	cross.bmp
-457.3325454545	n/a	114333.1364	show_face	scrambled_face	immediate_repeat	18	s045.bmp
-457.7998181818	n/a	114449.9545	left_press	n/a	n/a	256	n/a
-458.1843636364	n/a	114546.0909	show_circle	n/a	n/a	0	circle.bmp
-459.8843636364	n/a	114971.0909	show_cross	n/a	n/a	n/a	cross.bmp
-460.4561818182	n/a	115114.0455	show_face	scrambled_face	delayed_repeat	19	s016.bmp
-461.2407272727	n/a	115310.1818	left_press	n/a	n/a	256	n/a
-461.3443636364	n/a	115336.0909	show_circle	n/a	n/a	0	circle.bmp
-463.0443636364	n/a	115761.0909	show_cross	n/a	n/a	n/a	cross.bmp
-463.5807272727	n/a	115895.1818	show_face	scrambled_face	first_show	17	s122.bmp
-464.4443636364	n/a	116111.0909	left_press	n/a	n/a	256	n/a
-464.5689090909	n/a	116142.2273	show_circle	n/a	n/a	0	circle.bmp
-466.2689090909	n/a	116567.2273	show_cross	n/a	n/a	n/a	cross.bmp
-466.8043636364	n/a	116701.0909	show_face	scrambled_face	immediate_repeat	18	s122.bmp
-467.3325454545	n/a	116833.1364	left_press	n/a	n/a	256	n/a
-467.7261818182	n/a	116931.5455	show_circle	n/a	n/a	0	circle.bmp
-469.4261818182	n/a	117356.5455	show_cross	n/a	n/a	n/a	cross.bmp
-469.9280000000	n/a	117482	show_face	famous_face	first_show	5	f081.bmp
-470.7370909091	n/a	117684.2727	left_press	n/a	n/a	256	n/a
-470.8352727273	n/a	117708.8182	show_circle	n/a	n/a	0	circle.bmp
-472.5352727273	n/a	118133.8182	show_cross	n/a	n/a	n/a	cross.bmp
-473.1361818182	n/a	118284.0455	show_face	famous_face	immediate_repeat	6	f081.bmp
-473.7043636364	n/a	118426.0909	left_press	n/a	n/a	256	n/a
-474.0589090909	n/a	118514.7273	show_circle	n/a	n/a	0	circle.bmp
-475.7589090909	n/a	118939.7273	show_cross	n/a	n/a	n/a	cross.bmp
-476.4098181818	n/a	119102.4545	show_face	scrambled_face	first_show	17	s099.bmp
-477.2289090909	n/a	119307.2273	show_circle	n/a	n/a	0	circle.bmp
-477.2861818182	n/a	119321.5455	right_press	n/a	n/a	4096	n/a
-478.9289090909	n/a	119732.2273	show_cross	n/a	n/a	n/a	cross.bmp
-479.5170909091	n/a	119879.2727	show_face	unfamiliar_face	delayed_repeat	15	u037.bmp
-480.2225454545	n/a	120055.6364	left_press	n/a	n/a	256	n/a
-480.4025454545	n/a	120100.6364	show_circle	n/a	n/a	0	circle.bmp
-482.1025454545	n/a	120525.6364	show_cross	n/a	n/a	n/a	cross.bmp
-482.6580000000	n/a	120664.5	show_face	unfamiliar_face	first_show	13	u148.bmp
-483.4707272727	n/a	120867.6818	right_press	n/a	n/a	4096	n/a
-483.5870909091	n/a	120896.7727	show_circle	n/a	n/a	0	circle.bmp
-485.2870909091	n/a	121321.7727	show_cross	n/a	n/a	n/a	cross.bmp
-485.7652727273	n/a	121441.3182	show_face	scrambled_face	first_show	17	s063.bmp
-486.4825454545	n/a	121620.6364	right_press	n/a	n/a	4096	n/a
-486.6489090909	n/a	121662.2273	show_circle	n/a	n/a	0	circle.bmp
-488.3489090909	n/a	122087.2273	show_cross	n/a	n/a	n/a	cross.bmp
-488.9389090909	n/a	122234.7273	show_face	unfamiliar_face	first_show	13	u101.bmp
-489.6416363636	n/a	122410.4091	right_press	n/a	n/a	4096	n/a
-489.9434545455	n/a	122485.8636	show_circle	n/a	n/a	0	circle.bmp
-491.6434545455	n/a	122910.8636	show_cross	n/a	n/a	n/a	cross.bmp
+onset	duration	sample	event_type	face_type	repetition_type	trial	trial_lag	trigger	stim_file
+0.004	n/a	1.0	setup	n/a	n/a	n/a	n/a	n/a	n/a
+0.004	n/a	1.0	right_sym	n/a	n/a	n/a	n/a	n/a	n/a
+27.558909090900002	n/a	6889.7273	show_face	scrambled_face	first_show	1	n/a	17	s044.bmp
+28.2207272727	n/a	7055.1818	left_press	n/a	n/a	1	n/a	256	n/a
+28.4352727273	n/a	7108.8182	show_circle	n/a	n/a	1	n/a	0	circle.bmp
+30.1352727273	n/a	7533.8182	show_cross	n/a	n/a	2	n/a	n/a	cross.bmp
+30.7489090909	n/a	7687.2273	show_face	scrambled_face	immediate_repeat	2	1	18	s044.bmp
+31.324363636399998	n/a	7831.0909	left_press	n/a	n/a	2	n/a	256	n/a
+31.649818181799997	n/a	7912.4545	show_circle	n/a	n/a	2	n/a	0	circle.bmp
+33.349818181799996	n/a	8337.4545	show_cross	n/a	n/a	3	n/a	n/a	cross.bmp
+33.8398181818	n/a	8459.9545	show_face	unfamiliar_face	first_show	3	n/a	13	u055.bmp
+34.6625454545	n/a	8665.6364	show_circle	n/a	n/a	3	n/a	0	circle.bmp
+34.8761818182	n/a	8719.0455	right_press	n/a	n/a	3	n/a	4096	n/a
+36.3625454545	n/a	9090.6364	show_cross	n/a	n/a	4	n/a	n/a	cross.bmp
+36.9298181818	n/a	9232.4545	show_face	unfamiliar_face	first_show	4	n/a	13	u079.bmp
+37.6543636364	n/a	9413.5909	left_press	n/a	n/a	4	n/a	256	n/a
+37.938909090900005	n/a	9484.7273	show_circle	n/a	n/a	4	n/a	0	circle.bmp
+39.6389090909	n/a	9909.7273	show_cross	n/a	n/a	5	n/a	n/a	cross.bmp
+40.2207272727	n/a	10055.1818	show_face	unfamiliar_face	immediate_repeat	5	1	14	u079.bmp
+40.698	n/a	10174.5	left_press	n/a	n/a	5	n/a	256	n/a
+41.1752727273	n/a	10293.8182	show_circle	n/a	n/a	5	n/a	0	circle.bmp
+42.8752727273	n/a	10718.8182	show_cross	n/a	n/a	6	n/a	n/a	cross.bmp
+43.4289090909	n/a	10857.2273	show_face	famous_face	first_show	6	n/a	5	f121.bmp
+44.0425454545	n/a	11010.6364	right_press	n/a	n/a	6	n/a	4096	n/a
+44.27072727270001	n/a	11067.6818	show_circle	n/a	n/a	6	n/a	0	circle.bmp
+45.9707272727	n/a	11492.6818	show_cross	n/a	n/a	7	n/a	n/a	cross.bmp
+46.4689090909	n/a	11617.2273	show_face	famous_face	first_show	7	n/a	5	f033.bmp
+47.247090909099995	n/a	11811.7727	left_press	n/a	n/a	7	n/a	256	n/a
+47.46163636359999	n/a	11865.4091	show_circle	n/a	n/a	7	n/a	0	circle.bmp
+49.161636363599996	n/a	12290.4091	show_cross	n/a	n/a	8	n/a	n/a	cross.bmp
+49.7598181818	n/a	12439.9545	show_face	famous_face	immediate_repeat	8	1	6	f033.bmp
+50.2089090909	n/a	12552.2273	left_press	n/a	n/a	8	n/a	256	n/a
+50.736181818199995	n/a	12684.0455	show_circle	n/a	n/a	8	n/a	0	circle.bmp
+52.4361818182	n/a	13109.0455	show_cross	n/a	n/a	9	n/a	n/a	cross.bmp
+53.067090909099996	n/a	13266.7727	show_face	scrambled_face	first_show	9	n/a	17	s028.bmp
+53.887090909099996	n/a	13471.7727	right_press	n/a	n/a	9	n/a	4096	n/a
+53.8916363636	n/a	13472.9091	show_circle	n/a	n/a	9	n/a	0	circle.bmp
+55.591636363599996	n/a	13897.9091	show_cross	n/a	n/a	10	n/a	n/a	cross.bmp
+56.208	n/a	14052.0	show_face	scrambled_face	first_show	10	n/a	17	s135.bmp
+56.8361818182	n/a	14209.0455	left_press	n/a	n/a	10	n/a	256	n/a
+57.177090909099995	n/a	14294.2727	show_circle	n/a	n/a	10	n/a	0	circle.bmp
+58.8770909091	n/a	14719.2727	show_cross	n/a	n/a	11	n/a	n/a	cross.bmp
+59.41527272729999	n/a	14853.8182	show_face	scrambled_face	immediate_repeat	11	1	18	s135.bmp
+59.8952727273	n/a	14973.8182	left_press	n/a	n/a	11	n/a	256	n/a
+60.3707272727	n/a	15092.6818	show_circle	n/a	n/a	11	n/a	0	circle.bmp
+62.070727272700005	n/a	15517.6818	show_cross	n/a	n/a	12	n/a	n/a	cross.bmp
+62.672545454499996	n/a	15668.1364	show_face	unfamiliar_face	delayed_repeat	12	9	15	u055.bmp
+63.5234545455	n/a	15880.8636	right_press	n/a	n/a	12	n/a	4096	n/a
+63.5716363636	n/a	15892.9091	show_circle	n/a	n/a	12	n/a	0	circle.bmp
+65.2716363636	n/a	16317.9091	show_cross	n/a	n/a	13	n/a	n/a	cross.bmp
+65.7634545455	n/a	16440.8636	show_face	famous_face	first_show	13	n/a	5	f072.bmp
+66.2652727273	n/a	16566.3182	left_press	n/a	n/a	13	n/a	256	n/a
+66.7370909091	n/a	16684.2727	show_circle	n/a	n/a	13	n/a	0	circle.bmp
+68.4370909091	n/a	17109.2727	show_cross	n/a	n/a	14	n/a	n/a	cross.bmp
+68.9370909091	n/a	17234.2727	show_face	scrambled_face	first_show	14	n/a	17	s066.bmp
+69.5961818182	n/a	17399.0455	left_press	n/a	n/a	14	n/a	256	n/a
+69.9207272727	n/a	17480.1818	show_circle	n/a	n/a	14	n/a	0	circle.bmp
+71.62072727270001	n/a	17905.1818	show_cross	n/a	n/a	15	n/a	n/a	cross.bmp
+72.1443636364	n/a	18036.0909	show_face	scrambled_face	immediate_repeat	15	1	18	s066.bmp
+72.6952727273	n/a	18173.8182	left_press	n/a	n/a	15	n/a	256	n/a
+73.1443636364	n/a	18286.0909	show_circle	n/a	n/a	15	n/a	0	circle.bmp
+74.8443636364	n/a	18711.0909	show_cross	n/a	n/a	16	n/a	n/a	cross.bmp
+75.3525454545	n/a	18838.1364	show_face	famous_face	delayed_repeat	16	10	7	f121.bmp
+76.2289090909	n/a	19057.2273	show_circle	n/a	n/a	16	n/a	0	circle.bmp
+76.2334545455	n/a	19058.3636	right_press	n/a	n/a	16	n/a	4096	n/a
+77.9289090909	n/a	19482.2273	show_cross	n/a	n/a	17	n/a	n/a	cross.bmp
+78.60981818180001	n/a	19652.4545	show_face	famous_face	first_show	17	n/a	5	f063.bmp
+79.2552727273	n/a	19813.8182	right_press	n/a	n/a	17	n/a	4096	n/a
+79.5625454545	n/a	19890.6364	show_circle	n/a	n/a	17	n/a	0	circle.bmp
+81.2625454545	n/a	20315.6364	show_cross	n/a	n/a	18	n/a	n/a	cross.bmp
+81.7170909091	n/a	20429.2727	show_face	unfamiliar_face	first_show	18	n/a	13	u139.bmp
+82.3361818182	n/a	20584.0455	right_press	n/a	n/a	18	n/a	4096	n/a
+82.5570909091	n/a	20639.2727	show_circle	n/a	n/a	18	n/a	0	circle.bmp
+84.2570909091	n/a	21064.2727	show_cross	n/a	n/a	19	n/a	n/a	cross.bmp
+84.8570909091	n/a	21214.2727	show_face	scrambled_face	delayed_repeat	19	10	19	s028.bmp
+85.54163636359999	n/a	21385.4091	left_press	n/a	n/a	19	n/a	256	n/a
+85.7370909091	n/a	21434.2727	show_circle	n/a	n/a	19	n/a	0	circle.bmp
+87.4370909091	n/a	21859.2727	show_cross	n/a	n/a	20	n/a	n/a	cross.bmp
+88.048	n/a	22012.0	show_face	scrambled_face	first_show	20	n/a	17	s018.bmp
+88.90254545450001	n/a	22225.6364	left_press	n/a	n/a	20	n/a	256	n/a
+89.03618181819999	n/a	22259.0455	show_circle	n/a	n/a	20	n/a	0	circle.bmp
+90.7361818182	n/a	22684.0455	show_cross	n/a	n/a	21	n/a	n/a	cross.bmp
+91.3389090909	n/a	22834.7273	show_face	famous_face	first_show	21	n/a	5	f076.bmp
+91.9316363636	n/a	22982.9091	right_press	n/a	n/a	21	n/a	4096	n/a
+92.2161818182	n/a	23054.0455	show_circle	n/a	n/a	21	n/a	0	circle.bmp
+93.9161818182	n/a	23479.0455	show_cross	n/a	n/a	22	n/a	n/a	cross.bmp
+94.4798181818	n/a	23619.9545	show_face	famous_face	immediate_repeat	22	1	6	f076.bmp
+94.9570909091	n/a	23739.2727	right_press	n/a	n/a	22	n/a	4096	n/a
+95.3343636364	n/a	23833.5909	show_circle	n/a	n/a	22	n/a	0	circle.bmp
+97.03436363639999	n/a	24258.5909	show_cross	n/a	n/a	23	n/a	n/a	cross.bmp
+97.53618181819999	n/a	24384.0455	show_face	famous_face	delayed_repeat	23	10	7	f072.bmp
+98.3889090909	n/a	24597.2273	show_circle	n/a	n/a	23	n/a	0	circle.bmp
+98.3916363636	n/a	24597.9091	right_press	n/a	n/a	23	n/a	4096	n/a
+100.0889090909	n/a	25022.2273	show_cross	n/a	n/a	24	n/a	n/a	cross.bmp
+100.5770909091	n/a	25144.2727	show_face	scrambled_face	first_show	24	n/a	17	s121.bmp
+101.4770909091	n/a	25369.2727	left_press	n/a	n/a	24	n/a	256	n/a
+101.53254545450001	n/a	25383.1364	show_circle	n/a	n/a	24	n/a	0	circle.bmp
+103.23254545450001	n/a	25808.1364	show_cross	n/a	n/a	25	n/a	n/a	cross.bmp
+103.78436363639999	n/a	25946.0909	show_face	scrambled_face	first_show	25	n/a	17	s051.bmp
+104.278	n/a	26069.5	left_press	n/a	n/a	25	n/a	256	n/a
+104.75345454549999	n/a	26188.3636	show_circle	n/a	n/a	25	n/a	0	circle.bmp
+106.4534545455	n/a	26613.3636	show_cross	n/a	n/a	26	n/a	n/a	cross.bmp
+106.94163636360001	n/a	26735.4091	show_face	famous_face	delayed_repeat	26	9	7	f063.bmp
+107.568	n/a	26892.0	right_press	n/a	n/a	26	n/a	4096	n/a
+107.8307272727	n/a	26957.6818	show_circle	n/a	n/a	26	n/a	0	circle.bmp
+109.5307272727	n/a	27382.6818	show_cross	n/a	n/a	27	n/a	n/a	cross.bmp
+110.0652727273	n/a	27516.3182	show_face	unfamiliar_face	first_show	27	n/a	13	u140.bmp
+110.818	n/a	27704.5	right_press	n/a	n/a	27	n/a	4096	n/a
+110.88527272729999	n/a	27721.3182	show_circle	n/a	n/a	27	n/a	0	circle.bmp
+112.5852727273	n/a	28146.3182	show_cross	n/a	n/a	28	n/a	n/a	cross.bmp
+113.17254545450001	n/a	28293.1364	show_face	unfamiliar_face	delayed_repeat	28	10	15	u139.bmp
+113.8161818182	n/a	28454.0455	right_press	n/a	n/a	28	n/a	4096	n/a
+114.10981818180001	n/a	28527.4545	show_circle	n/a	n/a	28	n/a	0	circle.bmp
+115.8098181818	n/a	28952.4545	show_cross	n/a	n/a	29	n/a	n/a	cross.bmp
+116.4634545455	n/a	29115.8636	show_face	unfamiliar_face	first_show	29	n/a	13	u124.bmp
+117.3498181818	n/a	29337.4545	show_circle	n/a	n/a	29	n/a	0	circle.bmp
+117.3570909091	n/a	29339.2727	right_press	n/a	n/a	29	n/a	4096	n/a
+119.0498181818	n/a	29762.4545	show_cross	n/a	n/a	30	n/a	n/a	cross.bmp
+119.57072727270001	n/a	29892.6818	show_face	unfamiliar_face	immediate_repeat	30	1	14	u124.bmp
+120.06436363639999	n/a	30016.0909	right_press	n/a	n/a	30	n/a	4096	n/a
+120.4670909091	n/a	30116.7727	show_circle	n/a	n/a	30	n/a	0	circle.bmp
+122.1670909091	n/a	30541.7727	show_cross	n/a	n/a	31	n/a	n/a	cross.bmp
+122.678	n/a	30669.5	show_face	scrambled_face	delayed_repeat	31	11	19	s018.bmp
+123.52345454549999	n/a	30880.8636	right_press	n/a	n/a	31	n/a	4096	n/a
+123.5352727273	n/a	30883.8182	show_circle	n/a	n/a	31	n/a	0	circle.bmp
+125.2352727273	n/a	31308.8182	show_cross	n/a	n/a	32	n/a	n/a	cross.bmp
+125.818	n/a	31454.5	show_face	famous_face	first_show	32	n/a	5	f150.bmp
+126.4752727273	n/a	31618.8182	right_press	n/a	n/a	32	n/a	4096	n/a
+126.76436363639999	n/a	31691.0909	show_circle	n/a	n/a	32	n/a	0	circle.bmp
+128.46436363639998	n/a	32116.0909	show_cross	n/a	n/a	33	n/a	n/a	cross.bmp
+129.0598181818	n/a	32264.9545	show_face	famous_face	immediate_repeat	33	1	6	f150.bmp
+129.6489090909	n/a	32412.2273	right_press	n/a	n/a	33	n/a	4096	n/a
+129.998	n/a	32499.5	show_circle	n/a	n/a	33	n/a	0	circle.bmp
+131.698	n/a	32924.5	show_cross	n/a	n/a	34	n/a	n/a	cross.bmp
+132.2998181818	n/a	33074.9545	show_face	scrambled_face	first_show	34	n/a	17	s053.bmp
+133.1852727273	n/a	33296.3182	show_circle	n/a	n/a	34	n/a	0	circle.bmp
+133.20981818180002	n/a	33302.4545	left_press	n/a	n/a	34	n/a	256	n/a
+134.8852727273	n/a	33721.3182	show_cross	n/a	n/a	35	n/a	n/a	cross.bmp
+135.4570909091	n/a	33864.2727	show_face	scrambled_face	immediate_repeat	35	1	18	s053.bmp
+136.0698181818	n/a	34017.4545	left_press	n/a	n/a	35	n/a	256	n/a
+136.42527272729998	n/a	34106.3182	show_circle	n/a	n/a	35	n/a	0	circle.bmp
+138.1252727273	n/a	34531.3182	show_cross	n/a	n/a	36	n/a	n/a	cross.bmp
+138.6816363636	n/a	34670.4091	show_face	scrambled_face	delayed_repeat	36	12	19	s121.bmp
+139.3943636364	n/a	34848.5909	right_press	n/a	n/a	36	n/a	4096	n/a
+139.5307272727	n/a	34882.6818	show_circle	n/a	n/a	36	n/a	0	circle.bmp
+141.2307272727	n/a	35307.6818	show_cross	n/a	n/a	37	n/a	n/a	cross.bmp
+141.7716363636	n/a	35442.9091	show_face	unfamiliar_face	first_show	37	n/a	13	u089.bmp
+142.4716363636	n/a	35617.9091	right_press	n/a	n/a	37	n/a	4096	n/a
+142.6725454545	n/a	35668.1364	show_circle	n/a	n/a	37	n/a	0	circle.bmp
+144.3725454545	n/a	36093.1364	show_cross	n/a	n/a	38	n/a	n/a	cross.bmp
+144.9789090909	n/a	36244.7273	show_face	scrambled_face	delayed_repeat	38	13	19	s051.bmp
+145.698	n/a	36424.5	right_press	n/a	n/a	38	n/a	4096	n/a
+145.9007272727	n/a	36475.1818	show_circle	n/a	n/a	38	n/a	0	circle.bmp
+147.6007272727	n/a	36900.1818	show_cross	n/a	n/a	39	n/a	n/a	cross.bmp
+148.1870909091	n/a	37046.7727	show_face	scrambled_face	first_show	39	n/a	17	s052.bmp
+148.8143636364	n/a	37203.5909	left_press	n/a	n/a	39	n/a	256	n/a
+149.1043636364	n/a	37276.0909	show_circle	n/a	n/a	39	n/a	0	circle.bmp
+150.80436363639998	n/a	37701.0909	show_cross	n/a	n/a	40	n/a	n/a	cross.bmp
+151.3443636364	n/a	37836.0909	show_face	scrambled_face	immediate_repeat	40	1	18	s052.bmp
+151.89527272729998	n/a	37973.8182	left_press	n/a	n/a	40	n/a	256	n/a
+152.2989090909	n/a	38074.7273	show_circle	n/a	n/a	40	n/a	0	circle.bmp
+153.9989090909	n/a	38499.7273	show_cross	n/a	n/a	41	n/a	n/a	cross.bmp
+154.6016363636	n/a	38650.4091	show_face	unfamiliar_face	delayed_repeat	41	14	15	u140.bmp
+155.2343636364	n/a	38808.5909	right_press	n/a	n/a	41	n/a	4096	n/a
+155.5961818182	n/a	38899.0455	show_circle	n/a	n/a	41	n/a	0	circle.bmp
+157.29618181819998	n/a	39324.0455	show_cross	n/a	n/a	42	n/a	n/a	cross.bmp
+157.8925454545	n/a	39473.1364	show_face	famous_face	first_show	42	n/a	5	f139.bmp
+158.9089090909	n/a	39727.2273	show_circle	n/a	n/a	42	n/a	0	circle.bmp
+158.9498181818	n/a	39737.4545	left_press	n/a	n/a	42	n/a	256	n/a
+160.6089090909	n/a	40152.2273	show_cross	n/a	n/a	43	n/a	n/a	cross.bmp
+161.2334545455	n/a	40308.3636	show_face	scrambled_face	first_show	43	n/a	17	s138.bmp
+162.0670909091	n/a	40516.7727	show_circle	n/a	n/a	43	n/a	0	circle.bmp
+162.2807272727	n/a	40570.1818	right_press	n/a	n/a	43	n/a	4096	n/a
+163.7670909091	n/a	40941.7727	show_cross	n/a	n/a	44	n/a	n/a	cross.bmp
+164.2407272727	n/a	41060.1818	show_face	scrambled_face	immediate_repeat	44	1	18	s138.bmp
+164.8425454545	n/a	41210.6364	right_press	n/a	n/a	44	n/a	4096	n/a
+165.1225454545	n/a	41280.6364	show_circle	n/a	n/a	44	n/a	0	circle.bmp
+166.82254545450002	n/a	41705.6364	show_cross	n/a	n/a	45	n/a	n/a	cross.bmp
+167.3470909091	n/a	41836.7727	show_face	unfamiliar_face	first_show	45	n/a	13	u128.bmp
+168.0043636364	n/a	42001.0909	left_press	n/a	n/a	45	n/a	256	n/a
+168.2189090909	n/a	42054.7273	show_circle	n/a	n/a	45	n/a	0	circle.bmp
+169.9189090909	n/a	42479.7273	show_cross	n/a	n/a	46	n/a	n/a	cross.bmp
+170.4716363636	n/a	42617.9091	show_face	unfamiliar_face	immediate_repeat	46	1	14	u128.bmp
+170.8770909091	n/a	42719.2727	left_press	n/a	n/a	46	n/a	256	n/a
+171.3543636364	n/a	42838.5909	show_circle	n/a	n/a	46	n/a	0	circle.bmp
+173.05436363639998	n/a	43263.5909	show_cross	n/a	n/a	47	n/a	n/a	cross.bmp
+173.528	n/a	43382.0	show_face	famous_face	first_show	47	n/a	5	f124.bmp
+174.3698181818	n/a	43592.4545	show_circle	n/a	n/a	47	n/a	0	circle.bmp
+174.3807272727	n/a	43595.1818	right_press	n/a	n/a	47	n/a	4096	n/a
+176.0698181818	n/a	44017.4545	show_cross	n/a	n/a	48	n/a	n/a	cross.bmp
+176.5689090909	n/a	44142.2273	show_face	unfamiliar_face	delayed_repeat	48	11	15	u089.bmp
+177.3143636364	n/a	44328.5909	right_press	n/a	n/a	48	n/a	4096	n/a
+177.5352727273	n/a	44383.8182	show_circle	n/a	n/a	48	n/a	0	circle.bmp
+179.23527272729999	n/a	44808.8182	show_cross	n/a	n/a	49	n/a	n/a	cross.bmp
+179.7598181818	n/a	44939.9545	show_face	unfamiliar_face	first_show	49	n/a	13	u044.bmp
+180.3743636364	n/a	45093.5909	left_press	n/a	n/a	49	n/a	256	n/a
+180.7252727273	n/a	45181.3182	show_circle	n/a	n/a	49	n/a	0	circle.bmp
+182.42527272729998	n/a	45606.3182	show_cross	n/a	n/a	50	n/a	n/a	cross.bmp
+183.05072727270002	n/a	45762.6818	show_face	unfamiliar_face	first_show	50	n/a	13	u086.bmp
+183.7498181818	n/a	45937.4545	left_press	n/a	n/a	50	n/a	256	n/a
+183.87345454549998	n/a	45968.3636	show_circle	n/a	n/a	50	n/a	0	circle.bmp
+185.5734545455	n/a	46393.3636	show_cross	n/a	n/a	51	n/a	n/a	cross.bmp
+186.0570909091	n/a	46514.2727	show_face	unfamiliar_face	immediate_repeat	51	1	14	u086.bmp
+186.6661818182	n/a	46666.5455	left_press	n/a	n/a	51	n/a	256	n/a
+186.9116363636	n/a	46727.9091	show_circle	n/a	n/a	51	n/a	0	circle.bmp
+188.6116363636	n/a	47152.9091	show_cross	n/a	n/a	52	n/a	n/a	cross.bmp
+189.23163636360002	n/a	47307.9091	show_face	famous_face	delayed_repeat	52	10	7	f139.bmp
+189.9398181818	n/a	47484.9545	left_press	n/a	n/a	52	n/a	256	n/a
+190.0625454545	n/a	47515.6364	show_circle	n/a	n/a	52	n/a	0	circle.bmp
+191.7625454545	n/a	47940.6364	show_cross	n/a	n/a	53	n/a	n/a	cross.bmp
+192.3889090909	n/a	48097.2273	show_face	famous_face	first_show	53	n/a	5	f091.bmp
+192.8789090909	n/a	48219.7273	right_press	n/a	n/a	53	n/a	4096	n/a
+193.2107272727	n/a	48302.6818	show_circle	n/a	n/a	53	n/a	0	circle.bmp
+194.9107272727	n/a	48727.6818	show_cross	n/a	n/a	54	n/a	n/a	cross.bmp
+195.4452727273	n/a	48861.3182	show_face	famous_face	immediate_repeat	54	1	6	f091.bmp
+195.9670909091	n/a	48991.7727	right_press	n/a	n/a	54	n/a	4096	n/a
+196.4534545455	n/a	49113.3636	show_circle	n/a	n/a	54	n/a	0	circle.bmp
+198.15345454549998	n/a	49538.3636	show_cross	n/a	n/a	55	n/a	n/a	cross.bmp
+198.6861818182	n/a	49671.5455	show_face	scrambled_face	first_show	55	n/a	17	s105.bmp
+199.4925454545	n/a	49873.1364	right_press	n/a	n/a	55	n/a	4096	n/a
+199.67163636360002	n/a	49917.9091	show_circle	n/a	n/a	55	n/a	0	circle.bmp
+201.3716363636	n/a	50342.9091	show_cross	n/a	n/a	56	n/a	n/a	cross.bmp
+201.9607272727	n/a	50490.1818	show_face	scrambled_face	first_show	56	n/a	17	s022.bmp
+202.5943636364	n/a	50648.5909	left_press	n/a	n/a	56	n/a	256	n/a
+202.97254545450002	n/a	50743.1364	show_circle	n/a	n/a	56	n/a	0	circle.bmp
+204.6725454545	n/a	51168.1364	show_cross	n/a	n/a	57	n/a	n/a	cross.bmp
+205.2516363636	n/a	51312.9091	show_face	scrambled_face	immediate_repeat	57	1	18	s022.bmp
+205.7198181818	n/a	51429.9545	left_press	n/a	n/a	57	n/a	256	n/a
+206.1361818182	n/a	51534.0455	show_circle	n/a	n/a	57	n/a	0	circle.bmp
+207.8361818182	n/a	51959.0455	show_cross	n/a	n/a	58	n/a	n/a	cross.bmp
+208.3752727273	n/a	52093.8182	show_face	famous_face	delayed_repeat	58	11	7	f124.bmp
+209.1698181818	n/a	52292.4545	right_press	n/a	n/a	58	n/a	4096	n/a
+209.3898181818	n/a	52347.4545	show_circle	n/a	n/a	58	n/a	0	circle.bmp
+211.0898181818	n/a	52772.4545	show_cross	n/a	n/a	59	n/a	n/a	cross.bmp
+211.68345454549998	n/a	52920.8636	show_face	scrambled_face	first_show	59	n/a	17	s091.bmp
+212.4670909091	n/a	53116.7727	left_press	n/a	n/a	59	n/a	256	n/a
+212.5525454545	n/a	53138.1364	show_circle	n/a	n/a	59	n/a	0	circle.bmp
+214.2525454545	n/a	53563.1364	show_cross	n/a	n/a	60	n/a	n/a	cross.bmp
+214.7398181818	n/a	53684.9545	show_face	scrambled_face	immediate_repeat	60	1	18	s091.bmp
+215.27890909090002	n/a	53819.7273	left_press	n/a	n/a	60	n/a	256	n/a
+215.6552727273	n/a	53913.8182	show_circle	n/a	n/a	60	n/a	0	circle.bmp
+217.3552727273	n/a	54338.8182	show_cross	n/a	n/a	61	n/a	n/a	cross.bmp
+217.9143636364	n/a	54478.5909	show_face	unfamiliar_face	delayed_repeat	61	12	15	u044.bmp
+218.7198181818	n/a	54679.9545	right_press	n/a	n/a	61	n/a	4096	n/a
+218.81345454549998	n/a	54703.3636	show_circle	n/a	n/a	61	n/a	0	circle.bmp
+220.5134545455	n/a	55128.3636	show_cross	n/a	n/a	62	n/a	n/a	cross.bmp
+221.1552727273	n/a	55288.8182	show_face	famous_face	first_show	62	n/a	5	f082.bmp
+221.7761818182	n/a	55444.0455	left_press	n/a	n/a	62	n/a	256	n/a
+222.1416363636	n/a	55535.4091	show_circle	n/a	n/a	62	n/a	0	circle.bmp
+223.8416363636	n/a	55960.4091	show_cross	n/a	n/a	63	n/a	n/a	cross.bmp
+224.4289090909	n/a	56107.2273	show_face	famous_face	immediate_repeat	63	1	6	f082.bmp
+224.8634545455	n/a	56215.8636	left_press	n/a	n/a	63	n/a	256	n/a
+225.4025454545	n/a	56350.6364	show_circle	n/a	n/a	63	n/a	0	circle.bmp
+227.10254545450002	n/a	56775.6364	show_cross	n/a	n/a	64	n/a	n/a	cross.bmp
+227.6861818182	n/a	56921.5455	show_face	unfamiliar_face	first_show	64	n/a	13	u147.bmp
+228.5661818182	n/a	57141.5455	right_press	n/a	n/a	64	n/a	4096	n/a
+228.5707272727	n/a	57142.6818	show_circle	n/a	n/a	64	n/a	0	circle.bmp
+230.27072727270001	n/a	57567.6818	show_cross	n/a	n/a	65	n/a	n/a	cross.bmp
+230.8107272727	n/a	57702.6818	show_face	unfamiliar_face	immediate_repeat	65	1	14	u147.bmp
+231.3189090909	n/a	57829.7273	right_press	n/a	n/a	65	n/a	4096	n/a
+231.828	n/a	57957.0	show_circle	n/a	n/a	65	n/a	0	circle.bmp
+233.528	n/a	58382.0	show_cross	n/a	n/a	66	n/a	n/a	cross.bmp
+234.0016363636	n/a	58500.4091	show_face	famous_face	first_show	66	n/a	5	f010.bmp
+234.7198181818	n/a	58679.9545	right_press	n/a	n/a	66	n/a	4096	n/a
+234.8961818182	n/a	58724.0455	show_circle	n/a	n/a	66	n/a	0	circle.bmp
+236.5961818182	n/a	59149.0455	show_cross	n/a	n/a	67	n/a	n/a	cross.bmp
+237.0916363636	n/a	59272.9091	show_face	scrambled_face	delayed_repeat	67	12	19	s105.bmp
+237.8325454545	n/a	59458.1364	left_press	n/a	n/a	67	n/a	256	n/a
+237.9752727273	n/a	59493.8182	show_circle	n/a	n/a	67	n/a	0	circle.bmp
+239.67527272729998	n/a	59918.8182	show_cross	n/a	n/a	68	n/a	n/a	cross.bmp
+240.1489090909	n/a	60037.2273	show_face	unfamiliar_face	first_show	68	n/a	13	u144.bmp
+240.9225454545	n/a	60230.6364	right_press	n/a	n/a	68	n/a	4096	n/a
+241.04254545450002	n/a	60260.6364	show_circle	n/a	n/a	68	n/a	0	circle.bmp
+242.7425454545	n/a	60685.6364	show_cross	n/a	n/a	69	n/a	n/a	cross.bmp
+243.3898181818	n/a	60847.4545	show_face	unfamiliar_face	immediate_repeat	69	1	14	u144.bmp
+243.898	n/a	60974.5	right_press	n/a	n/a	69	n/a	4096	n/a
+244.2589090909	n/a	61064.7273	show_circle	n/a	n/a	69	n/a	0	circle.bmp
+245.9589090909	n/a	61489.7273	show_cross	n/a	n/a	70	n/a	n/a	cross.bmp
+246.5134545455	n/a	61628.3636	show_face	famous_face	first_show	70	n/a	5	f052.bmp
+247.2952727273	n/a	61823.8182	right_press	n/a	n/a	70	n/a	4096	n/a
+247.4543636364	n/a	61863.5909	show_circle	n/a	n/a	70	n/a	0	circle.bmp
+249.1543636364	n/a	62288.5909	show_cross	n/a	n/a	71	n/a	n/a	cross.bmp
+249.80436363639998	n/a	62451.0909	show_face	scrambled_face	first_show	71	n/a	17	s035.bmp
+250.4070909091	n/a	62601.7727	left_press	n/a	n/a	71	n/a	256	n/a
+250.7807272727	n/a	62695.1818	show_circle	n/a	n/a	71	n/a	0	circle.bmp
+252.4807272727	n/a	63120.1818	show_cross	n/a	n/a	72	n/a	n/a	cross.bmp
+252.978	n/a	63244.5	show_face	scrambled_face	immediate_repeat	72	1	18	s035.bmp
+253.6516363636	n/a	63412.9091	left_press	n/a	n/a	72	n/a	256	n/a
+253.9098181818	n/a	63477.4545	show_circle	n/a	n/a	72	n/a	0	circle.bmp
+255.6098181818	n/a	63902.4545	show_cross	n/a	n/a	73	n/a	n/a	cross.bmp
+256.2189090909	n/a	64054.7273	show_face	famous_face	first_show	73	n/a	5	f090.bmp
+257.0443636364	n/a	64261.0909	right_press	n/a	n/a	73	n/a	4096	n/a
+257.1598181818	n/a	64289.9545	show_circle	n/a	n/a	73	n/a	0	circle.bmp
+258.8598181818	n/a	64714.9545	show_cross	n/a	n/a	74	n/a	n/a	cross.bmp
+259.3761818182	n/a	64844.0455	show_face	famous_face	first_show	74	n/a	5	f037.bmp
+260.0734545455	n/a	65018.3636	right_press	n/a	n/a	74	n/a	4096	n/a
+260.3443636364	n/a	65086.0909	show_circle	n/a	n/a	74	n/a	0	circle.bmp
+262.0443636364	n/a	65511.0909	show_cross	n/a	n/a	75	n/a	n/a	cross.bmp
+262.5670909091	n/a	65641.7727	show_face	famous_face	immediate_repeat	75	1	6	f037.bmp
+263.178	n/a	65794.5	left_press	n/a	n/a	75	n/a	256	n/a
+263.5107272727	n/a	65877.6818	show_circle	n/a	n/a	75	n/a	0	circle.bmp
+265.2107272727	n/a	66302.6818	show_cross	n/a	n/a	76	n/a	n/a	cross.bmp
+265.808	n/a	66452.0	show_face	famous_face	delayed_repeat	76	10	7	f010.bmp
+266.3643636364	n/a	66591.0909	right_press	n/a	n/a	76	n/a	4096	n/a
+266.6789090909	n/a	66669.7273	show_circle	n/a	n/a	76	n/a	0	circle.bmp
+268.3789090909	n/a	67094.7273	show_cross	n/a	n/a	77	n/a	n/a	cross.bmp
+268.9316363636	n/a	67232.9091	show_face	scrambled_face	first_show	77	n/a	17	s127.bmp
+269.8016363636	n/a	67450.4091	right_press	n/a	n/a	77	n/a	4096	n/a
+269.8670909091	n/a	67466.7727	show_circle	n/a	n/a	77	n/a	0	circle.bmp
+271.5670909091	n/a	67891.7727	show_cross	n/a	n/a	78	n/a	n/a	cross.bmp
+272.1052727273	n/a	68026.3182	show_face	scrambled_face	immediate_repeat	78	1	18	s127.bmp
+273.0643636364	n/a	68266.0909	right_press	n/a	n/a	78	n/a	4096	n/a
+273.0834545455	n/a	68270.8636	show_circle	n/a	n/a	78	n/a	0	circle.bmp
+274.7834545455	n/a	68695.8636	show_cross	n/a	n/a	79	n/a	n/a	cross.bmp
+275.3961818182	n/a	68849.0455	show_face	scrambled_face	first_show	79	n/a	17	s128.bmp
+276.0461818182	n/a	69011.5455	left_press	n/a	n/a	79	n/a	256	n/a
+276.31981818180003	n/a	69079.9545	show_circle	n/a	n/a	79	n/a	0	circle.bmp
+278.0198181818	n/a	69504.9545	show_cross	n/a	n/a	80	n/a	n/a	cross.bmp
+278.5034545455	n/a	69625.8636	show_face	famous_face	delayed_repeat	80	10	7	f052.bmp
+279.0861818182	n/a	69771.5455	right_press	n/a	n/a	80	n/a	4096	n/a
+279.3870909091	n/a	69846.7727	show_circle	n/a	n/a	80	n/a	0	circle.bmp
+281.08709090909997	n/a	70271.7727	show_cross	n/a	n/a	81	n/a	n/a	cross.bmp
+281.5770909091	n/a	70394.2727	show_face	unfamiliar_face	first_show	81	n/a	13	u120.bmp
+282.5234545455	n/a	70630.8636	left_press	n/a	n/a	81	n/a	256	n/a
+282.5516363636	n/a	70637.9091	show_circle	n/a	n/a	81	n/a	0	circle.bmp
+284.2516363636	n/a	71062.9091	show_cross	n/a	n/a	82	n/a	n/a	cross.bmp
+284.818	n/a	71204.5	show_face	unfamiliar_face	first_show	82	n/a	13	u040.bmp
+285.8325454545	n/a	71458.1364	show_circle	n/a	n/a	82	n/a	0	circle.bmp
+285.91436363639997	n/a	71478.5909	right_press	n/a	n/a	82	n/a	4096	n/a
+287.5325454545	n/a	71883.1364	show_cross	n/a	n/a	83	n/a	n/a	cross.bmp
+287.9752727273	n/a	71993.8182	show_face	unfamiliar_face	immediate_repeat	83	1	14	u040.bmp
+288.518	n/a	72129.5	right_press	n/a	n/a	83	n/a	4096	n/a
+288.9016363636	n/a	72225.4091	show_circle	n/a	n/a	83	n/a	0	circle.bmp
+290.6016363636	n/a	72650.4091	show_cross	n/a	n/a	84	n/a	n/a	cross.bmp
+291.21618181819997	n/a	72804.0455	show_face	famous_face	delayed_repeat	84	11	7	f090.bmp
+291.8561818182	n/a	72964.0455	left_press	n/a	n/a	84	n/a	256	n/a
+292.2152727273	n/a	73053.8182	show_circle	n/a	n/a	84	n/a	0	circle.bmp
+293.9152727273	n/a	73478.8182	show_cross	n/a	n/a	85	n/a	n/a	cross.bmp
+294.47436363639997	n/a	73618.5909	show_face	unfamiliar_face	first_show	85	n/a	13	u146.bmp
+295.3343636364	n/a	73833.5909	right_press	n/a	n/a	85	n/a	4096	n/a
+295.4634545455	n/a	73865.8636	show_circle	n/a	n/a	85	n/a	0	circle.bmp
+297.1634545455	n/a	74290.8636	show_cross	n/a	n/a	86	n/a	n/a	cross.bmp
+297.698	n/a	74424.5	show_face	famous_face	first_show	86	n/a	5	f017.bmp
+298.48345454549997	n/a	74620.8636	left_press	n/a	n/a	86	n/a	256	n/a
+298.6670909091	n/a	74666.7727	show_circle	n/a	n/a	86	n/a	0	circle.bmp
+300.3670909091	n/a	75091.7727	show_cross	n/a	n/a	87	n/a	n/a	cross.bmp
+300.8552727273	n/a	75213.8182	show_face	famous_face	immediate_repeat	87	1	6	f017.bmp
+301.378	n/a	75344.5	left_press	n/a	n/a	87	n/a	256	n/a
+301.8270909091	n/a	75456.7727	show_circle	n/a	n/a	87	n/a	0	circle.bmp
+303.5270909091	n/a	75881.7727	show_cross	n/a	n/a	88	n/a	n/a	cross.bmp
+304.0461818182	n/a	76011.5455	show_face	unfamiliar_face	first_show	88	n/a	13	u048.bmp
+304.71618181819997	n/a	76179.0455	right_press	n/a	n/a	88	n/a	4096	n/a
+305.0107272727	n/a	76252.6818	show_circle	n/a	n/a	88	n/a	0	circle.bmp
+306.7107272727	n/a	76677.6818	show_cross	n/a	n/a	89	n/a	n/a	cross.bmp
+307.2370909091	n/a	76809.2727	show_face	scrambled_face	delayed_repeat	89	10	19	s128.bmp
+307.8616363636	n/a	76965.4091	left_press	n/a	n/a	89	n/a	256	n/a
+308.2343636364	n/a	77058.5909	show_circle	n/a	n/a	89	n/a	0	circle.bmp
+309.9343636364	n/a	77483.5909	show_cross	n/a	n/a	90	n/a	n/a	cross.bmp
+310.4607272727	n/a	77615.1818	show_face	unfamiliar_face	first_show	90	n/a	13	u019.bmp
+311.1961818182	n/a	77799.0455	left_press	n/a	n/a	90	n/a	256	n/a
+311.4425454545	n/a	77860.6364	show_circle	n/a	n/a	90	n/a	0	circle.bmp
+313.1425454545	n/a	78285.6364	show_cross	n/a	n/a	91	n/a	n/a	cross.bmp
+313.6016363636	n/a	78400.4091	show_face	unfamiliar_face	delayed_repeat	91	10	15	u120.bmp
+314.3316363636	n/a	78582.9091	left_press	n/a	n/a	91	n/a	256	n/a
+314.60436363639997	n/a	78651.0909	show_circle	n/a	n/a	91	n/a	0	circle.bmp
+316.3043636364	n/a	79076.0909	show_cross	n/a	n/a	92	n/a	n/a	cross.bmp
+316.8589090909	n/a	79214.7273	show_face	unfamiliar_face	first_show	92	n/a	13	u092.bmp
+317.528	n/a	79382.0	left_press	n/a	n/a	92	n/a	256	n/a
+317.8507272727	n/a	79462.6818	show_circle	n/a	n/a	92	n/a	0	circle.bmp
+319.5507272727	n/a	79887.6818	show_cross	n/a	n/a	93	n/a	n/a	cross.bmp
+320.0825454545	n/a	80020.6364	show_face	famous_face	first_show	93	n/a	5	f066.bmp
+320.9861818182	n/a	80246.5455	show_circle	n/a	n/a	93	n/a	0	circle.bmp
+321.2325454545	n/a	80308.1364	left_press	n/a	n/a	93	n/a	256	n/a
+322.6861818182	n/a	80671.5455	show_cross	n/a	n/a	94	n/a	n/a	cross.bmp
+323.2734545455	n/a	80818.3636	show_face	unfamiliar_face	delayed_repeat	94	9	15	u146.bmp
+323.9725454545	n/a	80993.1364	right_press	n/a	n/a	94	n/a	4096	n/a
+324.2652727273	n/a	81066.3182	show_circle	n/a	n/a	94	n/a	0	circle.bmp
+325.9652727273	n/a	81491.3182	show_cross	n/a	n/a	95	n/a	n/a	cross.bmp
+326.498	n/a	81624.5	show_face	unfamiliar_face	first_show	95	n/a	13	u078.bmp
+327.0416363636	n/a	81760.4091	right_press	n/a	n/a	95	n/a	4096	n/a
+327.4225454545	n/a	81855.6364	show_circle	n/a	n/a	95	n/a	0	circle.bmp
+329.1225454545	n/a	82280.6364	show_cross	n/a	n/a	96	n/a	n/a	cross.bmp
+329.7552727273	n/a	82438.8182	show_face	famous_face	first_show	96	n/a	5	f145.bmp
+330.50072727270003	n/a	82625.1818	right_press	n/a	n/a	96	n/a	4096	n/a
+330.7698181818	n/a	82692.4545	show_circle	n/a	n/a	96	n/a	0	circle.bmp
+332.4698181818	n/a	83117.4545	show_cross	n/a	n/a	97	n/a	n/a	cross.bmp
+333.0961818182	n/a	83274.0455	show_face	famous_face	immediate_repeat	97	1	6	f145.bmp
+333.9443636364	n/a	83486.0909	right_press	n/a	n/a	97	n/a	4096	n/a
+333.9598181818	n/a	83489.9545	show_circle	n/a	n/a	97	n/a	0	circle.bmp
+335.6598181818	n/a	83914.9545	show_cross	n/a	n/a	98	n/a	n/a	cross.bmp
+336.1370909091	n/a	84034.2727	show_face	unfamiliar_face	delayed_repeat	98	10	15	u048.bmp
+336.9470909091	n/a	84236.7727	right_press	n/a	n/a	98	n/a	4096	n/a
+337.0361818182	n/a	84259.0455	show_circle	n/a	n/a	98	n/a	0	circle.bmp
+338.7361818182	n/a	84684.0455	show_cross	n/a	n/a	99	n/a	n/a	cross.bmp
+339.3607272727	n/a	84840.1818	show_face	famous_face	first_show	99	n/a	5	f011.bmp
+340.3098181818	n/a	85077.4545	show_circle	n/a	n/a	99	n/a	0	circle.bmp
+340.38890909090003	n/a	85097.2273	right_press	n/a	n/a	99	n/a	4096	n/a
+342.00981818180003	n/a	85502.4545	show_cross	n/a	n/a	100	n/a	n/a	cross.bmp
+342.518	n/a	85629.5	show_face	unfamiliar_face	delayed_repeat	100	10	15	u019.bmp
+343.43254545450003	n/a	85858.1364	show_circle	n/a	n/a	100	n/a	0	circle.bmp
+343.4434545455	n/a	85860.8636	right_press	n/a	n/a	100	n/a	4096	n/a
+345.13254545449996	n/a	86283.1364	show_cross	n/a	n/a	101	n/a	n/a	cross.bmp
+345.6416363636	n/a	86410.4091	show_face	famous_face	first_show	101	n/a	5	f106.bmp
+346.398	n/a	86599.5	right_press	n/a	n/a	101	n/a	4096	n/a
+346.6298181818	n/a	86657.4545	show_circle	n/a	n/a	101	n/a	0	circle.bmp
+348.3298181818	n/a	87082.4545	show_cross	n/a	n/a	102	n/a	n/a	cross.bmp
+348.9325454545	n/a	87233.1364	show_face	famous_face	immediate_repeat	102	1	6	f106.bmp
+349.47890909089995	n/a	87369.7273	right_press	n/a	n/a	102	n/a	4096	n/a
+349.9198181818	n/a	87479.9545	show_circle	n/a	n/a	102	n/a	0	circle.bmp
+351.6198181818	n/a	87904.9545	show_cross	n/a	n/a	103	n/a	n/a	cross.bmp
+352.1570909091	n/a	88039.2727	show_face	unfamiliar_face	delayed_repeat	103	11	15	u092.bmp
+352.7761818182	n/a	88194.0455	left_press	n/a	n/a	103	n/a	256	n/a
+353.0370909091	n/a	88259.2727	show_circle	n/a	n/a	103	n/a	0	circle.bmp
+354.73709090910006	n/a	88684.2727	show_cross	n/a	n/a	104	n/a	n/a	cross.bmp
+355.38072727269997	n/a	88845.1818	show_face	scrambled_face	first_show	104	n/a	17	s012.bmp
+356.058	n/a	89014.5	right_press	n/a	n/a	104	n/a	4096	n/a
+356.20890909089997	n/a	89052.2273	show_circle	n/a	n/a	104	n/a	0	circle.bmp
+357.90890909089995	n/a	89477.2273	show_cross	n/a	n/a	105	n/a	n/a	cross.bmp
+358.4043636364	n/a	89601.0909	show_face	famous_face	delayed_repeat	105	12	7	f066.bmp
+359.07709090910004	n/a	89769.2727	left_press	n/a	n/a	105	n/a	256	n/a
+359.38527272730005	n/a	89846.3182	show_circle	n/a	n/a	105	n/a	0	circle.bmp
+361.08527272730004	n/a	90271.3182	show_cross	n/a	n/a	106	n/a	n/a	cross.bmp
+361.6116363636	n/a	90402.9091	show_face	unfamiliar_face	first_show	106	n/a	13	u130.bmp
+362.3570909091	n/a	90589.2727	right_press	n/a	n/a	106	n/a	4096	n/a
+362.4343636364	n/a	90608.5909	show_circle	n/a	n/a	106	n/a	0	circle.bmp
+364.1343636364	n/a	91033.5909	show_cross	n/a	n/a	107	n/a	n/a	cross.bmp
+364.71890909089996	n/a	91179.7273	show_face	unfamiliar_face	delayed_repeat	107	12	15	u078.bmp
+365.27254545449995	n/a	91318.1364	right_press	n/a	n/a	107	n/a	4096	n/a
+365.70890909089997	n/a	91427.2273	show_circle	n/a	n/a	107	n/a	0	circle.bmp
+367.40890909089995	n/a	91852.2273	show_cross	n/a	n/a	108	n/a	n/a	cross.bmp
+368.0434545455	n/a	92010.8636	show_face	famous_face	first_show	108	n/a	5	f027.bmp
+368.8443636364	n/a	92211.0909	left_press	n/a	n/a	108	n/a	256	n/a
+369.04072727269994	n/a	92260.1818	show_circle	n/a	n/a	108	n/a	0	circle.bmp
+370.7407272727	n/a	92685.1818	show_cross	n/a	n/a	109	n/a	n/a	cross.bmp
+371.368	n/a	92842.0	show_face	scrambled_face	first_show	109	n/a	17	s041.bmp
+372.21527272730003	n/a	93053.8182	left_press	n/a	n/a	109	n/a	256	n/a
+372.34254545449994	n/a	93085.6364	show_circle	n/a	n/a	109	n/a	0	circle.bmp
+374.0425454545	n/a	93510.6364	show_cross	n/a	n/a	110	n/a	n/a	cross.bmp
+374.62527272730006	n/a	93656.3182	show_face	scrambled_face	immediate_repeat	110	1	18	s041.bmp
+375.5116363636	n/a	93877.9091	show_circle	n/a	n/a	110	n/a	0	circle.bmp
+377.2116363636	n/a	94302.9091	show_cross	n/a	n/a	111	n/a	n/a	cross.bmp
+377.7325454545	n/a	94433.1364	show_face	famous_face	delayed_repeat	111	12	7	f011.bmp
+378.57527272730005	n/a	94643.8182	show_circle	n/a	n/a	111	n/a	0	circle.bmp
+380.27527272730003	n/a	95068.8182	show_cross	n/a	n/a	112	n/a	n/a	cross.bmp
+380.9234545455	n/a	95230.8636	show_face	unfamiliar_face	first_show	112	n/a	13	u073.bmp
+381.54072727269994	n/a	95385.1818	left_press	n/a	n/a	112	n/a	256	n/a
+381.8343636364	n/a	95458.5909	show_circle	n/a	n/a	112	n/a	0	circle.bmp
+383.5343636364	n/a	95883.5909	show_cross	n/a	n/a	113	n/a	n/a	cross.bmp
+384.14709090910003	n/a	96036.7727	show_face	unfamiliar_face	immediate_repeat	113	1	14	u073.bmp
+384.6234545455	n/a	96155.8636	left_press	n/a	n/a	113	n/a	256	n/a
+384.988	n/a	96247.0	show_circle	n/a	n/a	113	n/a	0	circle.bmp
+386.688	n/a	96672.0	show_cross	n/a	n/a	114	n/a	n/a	cross.bmp
+387.1543636364	n/a	96788.5909	show_face	famous_face	first_show	114	n/a	5	f067.bmp
+387.81709090910005	n/a	96954.2727	left_press	n/a	n/a	114	n/a	256	n/a
+388.1107272727	n/a	97027.6818	show_circle	n/a	n/a	114	n/a	0	circle.bmp
+389.8107272727	n/a	97452.6818	show_cross	n/a	n/a	115	n/a	n/a	cross.bmp
+390.4116363636	n/a	97602.9091	show_face	scrambled_face	delayed_repeat	115	11	19	s012.bmp
+391.07072727269997	n/a	97767.6818	right_press	n/a	n/a	115	n/a	4096	n/a
+391.3816363636	n/a	97845.4091	show_circle	n/a	n/a	115	n/a	0	circle.bmp
+393.0816363636	n/a	98270.4091	show_cross	n/a	n/a	116	n/a	n/a	cross.bmp
+393.5525454545	n/a	98388.1364	show_face	famous_face	first_show	116	n/a	5	f127.bmp
+394.2843636364	n/a	98571.0909	right_press	n/a	n/a	116	n/a	4096	n/a
+394.51890909089997	n/a	98629.7273	show_circle	n/a	n/a	116	n/a	0	circle.bmp
+396.21890909089996	n/a	99054.7273	show_cross	n/a	n/a	117	n/a	n/a	cross.bmp
+396.7934545455	n/a	99198.3636	show_face	unfamiliar_face	delayed_repeat	117	11	15	u130.bmp
+397.468	n/a	99367.0	right_press	n/a	n/a	117	n/a	4096	n/a
+397.76527272730004	n/a	99441.3182	show_circle	n/a	n/a	117	n/a	0	circle.bmp
+399.46527272730003	n/a	99866.3182	show_cross	n/a	n/a	118	n/a	n/a	cross.bmp
+399.9834545455	n/a	99995.8636	show_face	scrambled_face	first_show	118	n/a	17	s056.bmp
+400.5043636364	n/a	100126.0909	right_press	n/a	n/a	118	n/a	4096	n/a
+400.81527272730006	n/a	100203.8182	show_circle	n/a	n/a	118	n/a	0	circle.bmp
+402.51527272730004	n/a	100628.8182	show_cross	n/a	n/a	119	n/a	n/a	cross.bmp
+403.1243636364	n/a	100781.0909	show_face	famous_face	delayed_repeat	119	11	7	f027.bmp
+403.6543636364	n/a	100913.5909	left_press	n/a	n/a	119	n/a	256	n/a
+404.0507272727	n/a	101012.6818	show_circle	n/a	n/a	119	n/a	0	circle.bmp
+405.7507272727	n/a	101437.6818	show_cross	n/a	n/a	120	n/a	n/a	cross.bmp
+406.3816363636	n/a	101595.4091	show_face	scrambled_face	first_show	120	n/a	17	s115.bmp
+407.00527272730005	n/a	101751.3182	right_press	n/a	n/a	120	n/a	4096	n/a
+407.3661818182	n/a	101841.5455	show_circle	n/a	n/a	120	n/a	0	circle.bmp
+409.0661818182	n/a	102266.5455	show_cross	n/a	n/a	121	n/a	n/a	cross.bmp
+409.57254545449996	n/a	102393.1364	show_face	scrambled_face	immediate_repeat	121	1	18	s115.bmp
+410.048	n/a	102512.0	right_press	n/a	n/a	121	n/a	4096	n/a
+410.4934545455	n/a	102623.3636	show_circle	n/a	n/a	121	n/a	0	circle.bmp
+412.1934545455	n/a	103048.3636	show_cross	n/a	n/a	122	n/a	n/a	cross.bmp
+412.8134545455	n/a	103203.3636	show_face	famous_face	first_show	122	n/a	5	f128.bmp
+413.45072727269996	n/a	103362.6818	left_press	n/a	n/a	122	n/a	256	n/a
+413.7489090909	n/a	103437.2273	show_circle	n/a	n/a	122	n/a	0	circle.bmp
+415.4489090909	n/a	103862.2273	show_cross	n/a	n/a	123	n/a	n/a	cross.bmp
+415.9543636364	n/a	103988.5909	show_face	famous_face	immediate_repeat	123	1	6	f128.bmp
+416.7616363636	n/a	104190.4091	right_press	n/a	n/a	123	n/a	4096	n/a
+416.9098181818	n/a	104227.4545	show_circle	n/a	n/a	123	n/a	0	circle.bmp
+418.6098181818	n/a	104652.4545	show_cross	n/a	n/a	124	n/a	n/a	cross.bmp
+419.1616363636	n/a	104790.4091	show_face	scrambled_face	first_show	124	n/a	17	s016.bmp
+419.75709090910004	n/a	104939.2727	right_press	n/a	n/a	124	n/a	4096	n/a
+420.0661818182	n/a	105016.5455	show_circle	n/a	n/a	124	n/a	0	circle.bmp
+421.7661818182	n/a	105441.5455	show_cross	n/a	n/a	125	n/a	n/a	cross.bmp
+422.3689090909	n/a	105592.2273	show_face	famous_face	delayed_repeat	125	11	7	f067.bmp
+423.1570909091	n/a	105789.2727	left_press	n/a	n/a	125	n/a	256	n/a
+423.21890909089996	n/a	105804.7273	show_circle	n/a	n/a	125	n/a	0	circle.bmp
+424.91890909089994	n/a	106229.7273	show_cross	n/a	n/a	126	n/a	n/a	cross.bmp
+425.5089090909	n/a	106377.2273	show_face	famous_face	first_show	126	n/a	5	f084.bmp
+426.0507272727	n/a	106512.6818	right_press	n/a	n/a	126	n/a	4096	n/a
+426.4361818182	n/a	106609.0455	show_circle	n/a	n/a	126	n/a	0	circle.bmp
+428.1361818182	n/a	107034.0455	show_cross	n/a	n/a	127	n/a	n/a	cross.bmp
+428.76709090910003	n/a	107191.7727	show_face	famous_face	immediate_repeat	127	1	6	f084.bmp
+429.2116363636	n/a	107302.9091	right_press	n/a	n/a	127	n/a	4096	n/a
+429.77254545449995	n/a	107443.1364	show_circle	n/a	n/a	127	n/a	0	circle.bmp
+431.4725454545	n/a	107868.1364	show_cross	n/a	n/a	128	n/a	n/a	cross.bmp
+432.1243636364	n/a	108031.0909	show_face	famous_face	delayed_repeat	128	12	7	f127.bmp
+432.6834545455	n/a	108170.8636	right_press	n/a	n/a	128	n/a	4096	n/a
+432.9916363636	n/a	108247.9091	show_circle	n/a	n/a	128	n/a	0	circle.bmp
+434.6916363636	n/a	108672.9091	show_cross	n/a	n/a	129	n/a	n/a	cross.bmp
+435.26527272730004	n/a	108816.3182	show_face	unfamiliar_face	first_show	129	n/a	13	u065.bmp
+435.8361818182	n/a	108959.0455	left_press	n/a	n/a	129	n/a	256	n/a
+436.1152727273	n/a	109028.8182	show_circle	n/a	n/a	129	n/a	0	circle.bmp
+437.81527272730006	n/a	109453.8182	show_cross	n/a	n/a	130	n/a	n/a	cross.bmp
+438.4389090909	n/a	109609.7273	show_face	unfamiliar_face	immediate_repeat	130	1	14	u065.bmp
+438.96890909089996	n/a	109742.2273	left_press	n/a	n/a	130	n/a	256	n/a
+439.2861818182	n/a	109821.5455	show_circle	n/a	n/a	130	n/a	0	circle.bmp
+440.9861818182	n/a	110246.5455	show_cross	n/a	n/a	131	n/a	n/a	cross.bmp
+441.5461818182	n/a	110386.5455	show_face	scrambled_face	delayed_repeat	131	13	19	s056.bmp
+442.4061818182	n/a	110601.5455	show_circle	n/a	n/a	131	n/a	0	circle.bmp
+442.59072727269995	n/a	110647.6818	left_press	n/a	n/a	131	n/a	256	n/a
+444.1061818182	n/a	111026.5455	show_cross	n/a	n/a	132	n/a	n/a	cross.bmp
+444.65345454550004	n/a	111163.3636	show_face	unfamiliar_face	first_show	132	n/a	13	u037.bmp
+445.24527272730006	n/a	111311.3182	left_press	n/a	n/a	132	n/a	256	n/a
+445.50254545449997	n/a	111375.6364	show_circle	n/a	n/a	132	n/a	0	circle.bmp
+445.5034545455	n/a	111375.8636	show_circle	n/a	n/a	132	n/a	0	circle.bmp
+447.20254545449995	n/a	111800.6364	show_cross	n/a	n/a	133	n/a	n/a	cross.bmp
+447.20345454550005	n/a	111800.8636	show_cross	n/a	n/a	134	n/a	n/a	cross.bmp
+447.66072727269994	n/a	111915.1818	show_face	unfamiliar_face	first_show	134	n/a	13	u090.bmp
+448.4198181818	n/a	112104.9545	right_press	n/a	n/a	134	n/a	4096	n/a
+448.47890909089995	n/a	112119.7273	show_circle	n/a	n/a	134	n/a	0	circle.bmp
+450.17890909089994	n/a	112544.7273	show_cross	n/a	n/a	135	n/a	n/a	cross.bmp
+450.7843636364	n/a	112696.0909	show_face	unfamiliar_face	immediate_repeat	135	1	14	u090.bmp
+451.348	n/a	112837.0	left_press	n/a	n/a	135	n/a	256	n/a
+451.71527272730003	n/a	112928.8182	show_circle	n/a	n/a	135	n/a	0	circle.bmp
+453.4152727273	n/a	113353.8182	show_cross	n/a	n/a	136	n/a	n/a	cross.bmp
+454.0589090909	n/a	113514.7273	show_face	scrambled_face	first_show	136	n/a	17	s045.bmp
+454.76072727269997	n/a	113690.1818	left_press	n/a	n/a	136	n/a	256	n/a
+454.998	n/a	113749.5	show_circle	n/a	n/a	136	n/a	0	circle.bmp
+456.698	n/a	114174.5	show_cross	n/a	n/a	137	n/a	n/a	cross.bmp
+457.33254545449995	n/a	114333.1364	show_face	scrambled_face	immediate_repeat	137	1	18	s045.bmp
+457.7998181818	n/a	114449.9545	left_press	n/a	n/a	137	n/a	256	n/a
+458.1843636364	n/a	114546.0909	show_circle	n/a	n/a	137	n/a	0	circle.bmp
+459.8843636364	n/a	114971.0909	show_cross	n/a	n/a	138	n/a	n/a	cross.bmp
+460.4561818182	n/a	115114.0455	show_face	scrambled_face	delayed_repeat	138	14	19	s016.bmp
+461.2407272727	n/a	115310.1818	left_press	n/a	n/a	138	n/a	256	n/a
+461.3443636364	n/a	115336.0909	show_circle	n/a	n/a	138	n/a	0	circle.bmp
+463.0443636364	n/a	115761.0909	show_cross	n/a	n/a	139	n/a	n/a	cross.bmp
+463.58072727269996	n/a	115895.1818	show_face	scrambled_face	first_show	139	n/a	17	s122.bmp
+464.4443636364	n/a	116111.0909	left_press	n/a	n/a	139	n/a	256	n/a
+464.5689090909	n/a	116142.2273	show_circle	n/a	n/a	139	n/a	0	circle.bmp
+466.26890909089997	n/a	116567.2273	show_cross	n/a	n/a	140	n/a	n/a	cross.bmp
+466.8043636364	n/a	116701.0909	show_face	scrambled_face	immediate_repeat	140	1	18	s122.bmp
+467.33254545449995	n/a	116833.1364	left_press	n/a	n/a	140	n/a	256	n/a
+467.7261818182	n/a	116931.5455	show_circle	n/a	n/a	140	n/a	0	circle.bmp
+469.4261818182	n/a	117356.5455	show_cross	n/a	n/a	141	n/a	n/a	cross.bmp
+469.928	n/a	117482.0	show_face	famous_face	first_show	141	n/a	5	f081.bmp
+470.73709090910006	n/a	117684.2727	left_press	n/a	n/a	141	n/a	256	n/a
+470.83527272730004	n/a	117708.8182	show_circle	n/a	n/a	141	n/a	0	circle.bmp
+472.5352727273	n/a	118133.8182	show_cross	n/a	n/a	142	n/a	n/a	cross.bmp
+473.1361818182	n/a	118284.0455	show_face	famous_face	immediate_repeat	142	1	6	f081.bmp
+473.7043636364	n/a	118426.0909	left_press	n/a	n/a	142	n/a	256	n/a
+474.0589090909	n/a	118514.7273	show_circle	n/a	n/a	142	n/a	0	circle.bmp
+475.7589090909	n/a	118939.7273	show_cross	n/a	n/a	143	n/a	n/a	cross.bmp
+476.4098181818	n/a	119102.4545	show_face	scrambled_face	first_show	143	n/a	17	s099.bmp
+477.22890909089995	n/a	119307.2273	show_circle	n/a	n/a	143	n/a	0	circle.bmp
+477.2861818182	n/a	119321.5455	right_press	n/a	n/a	143	n/a	4096	n/a
+478.92890909089994	n/a	119732.2273	show_cross	n/a	n/a	144	n/a	n/a	cross.bmp
+479.51709090910003	n/a	119879.2727	show_face	unfamiliar_face	delayed_repeat	144	12	15	u037.bmp
+480.2225454545	n/a	120055.6364	left_press	n/a	n/a	144	n/a	256	n/a
+480.40254545449994	n/a	120100.6364	show_circle	n/a	n/a	144	n/a	0	circle.bmp
+482.1025454545	n/a	120525.6364	show_cross	n/a	n/a	145	n/a	n/a	cross.bmp
+482.658	n/a	120664.5	show_face	unfamiliar_face	first_show	145	n/a	13	u148.bmp
+483.47072727269995	n/a	120867.6818	right_press	n/a	n/a	145	n/a	4096	n/a
+483.5870909091	n/a	120896.7727	show_circle	n/a	n/a	145	n/a	0	circle.bmp
+485.2870909091	n/a	121321.7727	show_cross	n/a	n/a	146	n/a	n/a	cross.bmp
+485.76527272730004	n/a	121441.3182	show_face	scrambled_face	first_show	146	n/a	17	s063.bmp
+486.4825454545	n/a	121620.6364	right_press	n/a	n/a	146	n/a	4096	n/a
+486.64890909089996	n/a	121662.2273	show_circle	n/a	n/a	146	n/a	0	circle.bmp
+488.34890909089995	n/a	122087.2273	show_cross	n/a	n/a	147	n/a	n/a	cross.bmp
+488.9389090909	n/a	122234.7273	show_face	unfamiliar_face	first_show	147	n/a	13	u101.bmp
+489.6416363636	n/a	122410.4091	right_press	n/a	n/a	147	n/a	4096	n/a
+489.9434545455	n/a	122485.8636	show_circle	n/a	n/a	147	n/a	0	circle.bmp
+491.64345454550005	n/a	122910.8636	show_cross	n/a	n/a	148	n/a	n/a	cross.bmp

--- a/eeg_hed_small/sub-003/eeg/sub-003_task-FacePerception_run-4_events.tsv
+++ b/eeg_hed_small/sub-003/eeg/sub-003_task-FacePerception_run-4_events.tsv
@@ -1,588 +1,588 @@
-onset	duration	sample	event_type	face_type	repetition_type	trigger	stim_file
-0.0040000000	n/a	1	setup	n/a	n/a	n/a	n/a
-0.0040000000	n/a	1	right_sym	n/a	n/a	n/a	n/a
-24.7916363636	n/a	6197.9091	show_face	unfamiliar_face	first_show	13	u025.bmp
-25.3434545455	n/a	6335.8636	left_press	n/a	n/a	256	n/a
-25.7798181818	n/a	6444.9545	show_circle	n/a	n/a	0	circle.bmp
-27.4798181818	n/a	6869.9545	show_cross	n/a	n/a	n/a	cross.bmp
-27.9825454545	n/a	6995.6364	show_face	unfamiliar_face	immediate_repeat	14	u025.bmp
-28.5261818182	n/a	7131.5455	left_press	n/a	n/a	256	n/a
-28.8961818182	n/a	7224.0455	show_circle	n/a	n/a	0	circle.bmp
-30.5961818182	n/a	7649.0455	show_cross	n/a	n/a	n/a	cross.bmp
-31.1734545455	n/a	7793.3636	show_face	scrambled_face	first_show	17	s146.bmp
-31.7680000000	n/a	7942	left_press	n/a	n/a	256	n/a
-32.1525454545	n/a	8038.1364	show_circle	n/a	n/a	0	circle.bmp
-33.8525454545	n/a	8463.1364	show_cross	n/a	n/a	n/a	cross.bmp
-34.3634545455	n/a	8590.8636	show_face	scrambled_face	immediate_repeat	18	s146.bmp
-34.7961818182	n/a	8699.0455	left_press	n/a	n/a	256	n/a
-35.2752727273	n/a	8818.8182	show_circle	n/a	n/a	0	circle.bmp
-36.9752727273	n/a	9243.8182	show_cross	n/a	n/a	n/a	cross.bmp
-37.4707272727	n/a	9367.6818	show_face	scrambled_face	first_show	17	s143.bmp
-38.0307272727	n/a	9507.6818	right_press	n/a	n/a	4096	n/a
-38.4870909091	n/a	9621.7727	show_circle	n/a	n/a	0	circle.bmp
-40.1870909091	n/a	10046.7727	show_cross	n/a	n/a	n/a	cross.bmp
-40.7616363636	n/a	10190.4091	show_face	scrambled_face	immediate_repeat	18	s143.bmp
-41.1507272727	n/a	10287.6818	right_press	n/a	n/a	4096	n/a
-41.6889090909	n/a	10422.2273	show_circle	n/a	n/a	0	circle.bmp
-43.3889090909	n/a	10847.2273	show_cross	n/a	n/a	n/a	cross.bmp
-44.0034545455	n/a	11000.8636	show_face	scrambled_face	first_show	17	s087.bmp
-44.6343636364	n/a	11158.5909	left_press	n/a	n/a	256	n/a
-44.8361818182	n/a	11209.0455	show_circle	n/a	n/a	0	circle.bmp
-46.5361818182	n/a	11634.0455	show_cross	n/a	n/a	n/a	cross.bmp
-46.9934545455	n/a	11748.3636	show_face	scrambled_face	first_show	17	s114.bmp
-47.6734545455	n/a	11918.3636	left_press	n/a	n/a	256	n/a
-47.9980000000	n/a	11999.5	show_circle	n/a	n/a	0	circle.bmp
-49.6980000000	n/a	12424.5	show_cross	n/a	n/a	n/a	cross.bmp
-50.3007272727	n/a	12575.1818	show_face	famous_face	first_show	5	f098.bmp
-50.9461818182	n/a	12736.5455	left_press	n/a	n/a	256	n/a
-51.1998181818	n/a	12799.9545	show_circle	n/a	n/a	0	circle.bmp
-52.8998181818	n/a	13224.9545	show_cross	n/a	n/a	n/a	cross.bmp
-53.4752727273	n/a	13368.8182	show_face	scrambled_face	first_show	17	s090.bmp
-54.0661818182	n/a	13516.5455	left_press	n/a	n/a	256	n/a
-54.3561818182	n/a	13589.0455	show_circle	n/a	n/a	0	circle.bmp
-56.0561818182	n/a	14014.0455	show_cross	n/a	n/a	n/a	cross.bmp
-56.6489090909	n/a	14162.2273	show_face	scrambled_face	first_show	17	s068.bmp
-57.4361818182	n/a	14359.0455	left_press	n/a	n/a	256	n/a
-57.6016363636	n/a	14400.4091	show_circle	n/a	n/a	0	circle.bmp
-59.3016363636	n/a	14825.4091	show_cross	n/a	n/a	n/a	cross.bmp
-59.8725454545	n/a	14968.1364	show_face	famous_face	first_show	5	f070.bmp
-60.5207272727	n/a	15130.1818	right_press	n/a	n/a	4096	n/a
-60.7461818182	n/a	15186.5455	show_circle	n/a	n/a	0	circle.bmp
-62.4461818182	n/a	15611.5455	show_cross	n/a	n/a	n/a	cross.bmp
-63.0470909091	n/a	15761.7727	show_face	famous_face	immediate_repeat	6	f070.bmp
-63.5961818182	n/a	15899.0455	right_press	n/a	n/a	4096	n/a
-63.9470909091	n/a	15986.7727	show_circle	n/a	n/a	0	circle.bmp
-65.6470909091	n/a	16411.7727	show_cross	n/a	n/a	n/a	cross.bmp
-66.2043636364	n/a	16551.0909	show_face	scrambled_face	delayed_repeat	19	s087.bmp
-66.9525454545	n/a	16738.1364	left_press	n/a	n/a	256	n/a
-67.0370909091	n/a	16759.2727	show_circle	n/a	n/a	0	circle.bmp
-68.7370909091	n/a	17184.2727	show_cross	n/a	n/a	n/a	cross.bmp
-69.2280000000	n/a	17307	show_face	scrambled_face	first_show	17	s124.bmp
-69.9070909091	n/a	17476.7727	left_press	n/a	n/a	256	n/a
-70.2452727273	n/a	17561.3182	show_circle	n/a	n/a	0	circle.bmp
-71.9452727273	n/a	17986.3182	show_cross	n/a	n/a	n/a	cross.bmp
-72.4680000000	n/a	18117	show_face	scrambled_face	immediate_repeat	18	s124.bmp
-72.9761818182	n/a	18244.0455	left_press	n/a	n/a	256	n/a
-73.3580000000	n/a	18339.5	show_circle	n/a	n/a	0	circle.bmp
-75.0580000000	n/a	18764.5	show_cross	n/a	n/a	n/a	cross.bmp
-75.5589090909	n/a	18889.7273	show_face	scrambled_face	delayed_repeat	19	s114.bmp
-76.4025454545	n/a	19100.6364	show_circle	n/a	n/a	0	circle.bmp
-76.8434545455	n/a	19210.8636	left_press	n/a	n/a	256	n/a
-78.1025454545	n/a	19525.6364	show_cross	n/a	n/a	n/a	cross.bmp
-78.7661818182	n/a	19691.5455	show_face	famous_face	first_show	5	f134.bmp
-79.2952727273	n/a	19823.8182	right_press	n/a	n/a	4096	n/a
-79.6134545455	n/a	19903.3636	show_circle	n/a	n/a	0	circle.bmp
-81.3134545455	n/a	20328.3636	show_cross	n/a	n/a	n/a	cross.bmp
-81.8234545455	n/a	20455.8636	show_face	famous_face	immediate_repeat	6	f134.bmp
-82.3389090909	n/a	20584.7273	right_press	n/a	n/a	4096	n/a
-82.7080000000	n/a	20677	show_circle	n/a	n/a	0	circle.bmp
-84.4080000000	n/a	21102	show_cross	n/a	n/a	n/a	cross.bmp
-84.9807272727	n/a	21245.1818	show_face	famous_face	delayed_repeat	7	f098.bmp
-85.8807272727	n/a	21470.1818	show_circle	n/a	n/a	0	circle.bmp
-86.0498181818	n/a	21512.4545	right_press	n/a	n/a	4096	n/a
-87.5807272727	n/a	21895.1818	show_cross	n/a	n/a	n/a	cross.bmp
-88.0707272727	n/a	22017.6818	show_face	scrambled_face	first_show	17	s148.bmp
-88.8570909091	n/a	22214.2727	right_press	n/a	n/a	4096	n/a
-88.9589090909	n/a	22239.7273	show_circle	n/a	n/a	0	circle.bmp
-90.6589090909	n/a	22664.7273	show_cross	n/a	n/a	n/a	cross.bmp
-91.1443636364	n/a	22786.0909	show_face	scrambled_face	delayed_repeat	19	s090.bmp
-92.0552727273	n/a	23013.8182	left_press	n/a	n/a	256	n/a
-92.0634545455	n/a	23015.8636	show_circle	n/a	n/a	0	circle.bmp
-93.7634545455	n/a	23440.8636	show_cross	n/a	n/a	n/a	cross.bmp
-94.2352727273	n/a	23558.8182	show_face	unfamiliar_face	first_show	13	u136.bmp
-94.9252727273	n/a	23731.3182	right_press	n/a	n/a	4096	n/a
-95.1189090909	n/a	23779.7273	show_circle	n/a	n/a	0	circle.bmp
-96.8189090909	n/a	24204.7273	show_cross	n/a	n/a	n/a	cross.bmp
-97.4598181818	n/a	24364.9545	show_face	scrambled_face	delayed_repeat	19	s068.bmp
-98.1989090909	n/a	24549.7273	left_press	n/a	n/a	256	n/a
-98.2843636364	n/a	24571.0909	show_circle	n/a	n/a	0	circle.bmp
-99.9843636364	n/a	24996.0909	show_cross	n/a	n/a	n/a	cross.bmp
-100.5334545455	n/a	25133.3636	show_face	unfamiliar_face	first_show	13	u053.bmp
-101.3070909091	n/a	25326.7727	right_press	n/a	n/a	4096	n/a
-101.3889090909	n/a	25347.2273	show_circle	n/a	n/a	0	circle.bmp
-103.0889090909	n/a	25772.2273	show_cross	n/a	n/a	n/a	cross.bmp
-103.6734545455	n/a	25918.3636	show_face	scrambled_face	first_show	17	s082.bmp
-104.4361818182	n/a	26109.0455	right_press	n/a	n/a	4096	n/a
-104.6880000000	n/a	26172	show_circle	n/a	n/a	0	circle.bmp
-106.3880000000	n/a	26597	show_cross	n/a	n/a	n/a	cross.bmp
-107.0143636364	n/a	26753.5909	show_face	scrambled_face	immediate_repeat	18	s082.bmp
-107.7452727273	n/a	26936.3182	left_press	n/a	n/a	256	n/a
-107.8761818182	n/a	26969.0455	show_circle	n/a	n/a	0	circle.bmp
-109.5761818182	n/a	27394.0455	show_cross	n/a	n/a	n/a	cross.bmp
-110.1552727273	n/a	27538.8182	show_face	unfamiliar_face	first_show	13	u002.bmp
-110.7816363636	n/a	27695.4091	right_press	n/a	n/a	4096	n/a
-111.0698181818	n/a	27767.4545	show_circle	n/a	n/a	0	circle.bmp
-112.7698181818	n/a	28192.4545	show_cross	n/a	n/a	n/a	cross.bmp
-113.2625454545	n/a	28315.6364	show_face	unfamiliar_face	immediate_repeat	14	u002.bmp
-113.8698181818	n/a	28467.4545	right_press	n/a	n/a	4096	n/a
-114.1716363636	n/a	28542.9091	show_circle	n/a	n/a	0	circle.bmp
-115.8716363636	n/a	28967.9091	show_cross	n/a	n/a	n/a	cross.bmp
-116.3861818182	n/a	29096.5455	show_face	unfamiliar_face	first_show	13	u058.bmp
-117.1889090909	n/a	29297.2273	right_press	n/a	n/a	4096	n/a
-117.2580000000	n/a	29314.5	show_circle	n/a	n/a	0	circle.bmp
-118.9580000000	n/a	29739.5	show_cross	n/a	n/a	n/a	cross.bmp
-119.4434545455	n/a	29860.8636	show_face	scrambled_face	delayed_repeat	19	s148.bmp
-120.2852727273	n/a	30071.3182	right_press	n/a	n/a	4096	n/a
-120.4080000000	n/a	30102	show_circle	n/a	n/a	0	circle.bmp
-122.1080000000	n/a	30527	show_cross	n/a	n/a	n/a	cross.bmp
-122.5670909091	n/a	30641.7727	show_face	unfamiliar_face	first_show	13	u013.bmp
-123.1843636364	n/a	30796.0909	right_press	n/a	n/a	4096	n/a
-123.5170909091	n/a	30879.2727	show_circle	n/a	n/a	0	circle.bmp
-125.2170909091	n/a	31304.2727	show_cross	n/a	n/a	n/a	cross.bmp
-125.8080000000	n/a	31452	show_face	unfamiliar_face	delayed_repeat	15	u136.bmp
-126.3852727273	n/a	31596.3182	right_press	n/a	n/a	4096	n/a
-126.7361818182	n/a	31684.0455	show_circle	n/a	n/a	0	circle.bmp
-128.4361818182	n/a	32109.0455	show_cross	n/a	n/a	n/a	cross.bmp
-128.9489090909	n/a	32237.2273	show_face	famous_face	first_show	5	f003.bmp
-129.6707272727	n/a	32417.6818	left_press	n/a	n/a	256	n/a
-129.8007272727	n/a	32450.1818	show_circle	n/a	n/a	0	circle.bmp
-131.5007272727	n/a	32875.1818	show_cross	n/a	n/a	n/a	cross.bmp
-132.0725454545	n/a	33018.1364	show_face	unfamiliar_face	delayed_repeat	15	u053.bmp
-132.9625454545	n/a	33240.6364	show_circle	n/a	n/a	0	circle.bmp
-133.1043636364	n/a	33276.0909	right_press	n/a	n/a	4096	n/a
-134.6625454545	n/a	33665.6364	show_cross	n/a	n/a	n/a	cross.bmp
-135.2461818182	n/a	33811.5455	show_face	scrambled_face	first_show	17	s086.bmp
-136.1189090909	n/a	34029.7273	left_press	n/a	n/a	256	n/a
-136.2589090909	n/a	34064.7273	show_circle	n/a	n/a	0	circle.bmp
-137.9589090909	n/a	34489.7273	show_cross	n/a	n/a	n/a	cross.bmp
-138.4870909091	n/a	34621.7727	show_face	famous_face	first_show	5	f043.bmp
-139.0307272727	n/a	34757.6818	right_press	n/a	n/a	4096	n/a
-139.4798181818	n/a	34869.9545	show_circle	n/a	n/a	0	circle.bmp
-141.1798181818	n/a	35294.9545	show_cross	n/a	n/a	n/a	cross.bmp
-141.8280000000	n/a	35457	show_face	famous_face	immediate_repeat	6	f043.bmp
-142.2925454545	n/a	35573.1364	right_press	n/a	n/a	4096	n/a
-142.6989090909	n/a	35674.7273	show_circle	n/a	n/a	0	circle.bmp
-144.3989090909	n/a	36099.7273	show_cross	n/a	n/a	n/a	cross.bmp
-144.8689090909	n/a	36217.2273	show_face	unfamiliar_face	first_show	13	u014.bmp
-145.8043636364	n/a	36451.0909	show_circle	n/a	n/a	0	circle.bmp
-145.9652727273	n/a	36491.3182	left_press	n/a	n/a	256	n/a
-147.5043636364	n/a	36876.0909	show_cross	n/a	n/a	n/a	cross.bmp
-148.1425454545	n/a	37035.6364	show_face	unfamiliar_face	delayed_repeat	15	u058.bmp
-149.0734545455	n/a	37268.3636	show_circle	n/a	n/a	0	circle.bmp
-149.2380000000	n/a	37309.5	left_press	n/a	n/a	256	n/a
-150.7734545455	n/a	37693.3636	show_cross	n/a	n/a	n/a	cross.bmp
-151.3170909091	n/a	37829.2727	show_face	famous_face	first_show	5	f110.bmp
-152.1380000000	n/a	38034.5	show_circle	n/a	n/a	0	circle.bmp
-152.2443636364	n/a	38061.0909	right_press	n/a	n/a	4096	n/a
-153.8380000000	n/a	38459.5	show_cross	n/a	n/a	n/a	cross.bmp
-154.4743636364	n/a	38618.5909	show_face	famous_face	immediate_repeat	6	f110.bmp
-155.2389090909	n/a	38809.7273	right_press	n/a	n/a	4096	n/a
-155.3134545455	n/a	38828.3636	show_circle	n/a	n/a	0	circle.bmp
-157.0134545455	n/a	39253.3636	show_cross	n/a	n/a	n/a	cross.bmp
-157.5816363636	n/a	39395.4091	show_face	unfamiliar_face	delayed_repeat	15	u013.bmp
-158.4916363636	n/a	39622.9091	show_circle	n/a	n/a	0	circle.bmp
-158.8516363636	n/a	39712.9091	left_press	n/a	n/a	256	n/a
-160.1916363636	n/a	40047.9091	show_cross	n/a	n/a	n/a	cross.bmp
-160.6889090909	n/a	40172.2273	show_face	scrambled_face	first_show	17	s032.bmp
-161.5570909091	n/a	40389.2727	right_press	n/a	n/a	4096	n/a
-161.6052727273	n/a	40401.3182	show_circle	n/a	n/a	0	circle.bmp
-163.3052727273	n/a	40826.3182	show_cross	n/a	n/a	n/a	cross.bmp
-163.7952727273	n/a	40948.8182	show_face	scrambled_face	immediate_repeat	18	s032.bmp
-164.2398181818	n/a	41059.9545	right_press	n/a	n/a	4096	n/a
-164.8080000000	n/a	41202	show_circle	n/a	n/a	0	circle.bmp
-166.5080000000	n/a	41627	show_cross	n/a	n/a	n/a	cross.bmp
-167.0361818182	n/a	41759.0455	show_face	famous_face	delayed_repeat	7	f003.bmp
-167.7598181818	n/a	41939.9545	right_press	n/a	n/a	4096	n/a
-168.0189090909	n/a	42004.7273	show_circle	n/a	n/a	0	circle.bmp
-169.7189090909	n/a	42429.7273	show_cross	n/a	n/a	n/a	cross.bmp
-170.2107272727	n/a	42552.6818	show_face	famous_face	first_show	5	f030.bmp
-170.8698181818	n/a	42717.4545	right_press	n/a	n/a	4096	n/a
-171.2098181818	n/a	42802.4545	show_circle	n/a	n/a	0	circle.bmp
-172.9098181818	n/a	43227.4545	show_cross	n/a	n/a	n/a	cross.bmp
-173.5016363636	n/a	43375.4091	show_face	famous_face	immediate_repeat	6	f030.bmp
-174.1289090909	n/a	43532.2273	right_press	n/a	n/a	4096	n/a
-174.4652727273	n/a	43616.3182	show_circle	n/a	n/a	0	circle.bmp
-176.1652727273	n/a	44041.3182	show_cross	n/a	n/a	n/a	cross.bmp
-176.7252727273	n/a	44181.3182	show_face	scrambled_face	delayed_repeat	19	s086.bmp
-177.4107272727	n/a	44352.6818	left_press	n/a	n/a	256	n/a
-177.6443636364	n/a	44411.0909	show_circle	n/a	n/a	0	circle.bmp
-179.3443636364	n/a	44836.0909	show_cross	n/a	n/a	n/a	cross.bmp
-179.8325454545	n/a	44958.1364	show_face	scrambled_face	first_show	17	s069.bmp
-180.4280000000	n/a	45107	left_press	n/a	n/a	256	n/a
-180.7589090909	n/a	45189.7273	show_circle	n/a	n/a	0	circle.bmp
-182.4589090909	n/a	45614.7273	show_cross	n/a	n/a	n/a	cross.bmp
-182.9734545455	n/a	45743.3636	show_face	scrambled_face	immediate_repeat	18	s069.bmp
-183.9816363636	n/a	45995.4091	show_circle	n/a	n/a	0	circle.bmp
-184.0825454545	n/a	46020.6364	right_press	n/a	n/a	4096	n/a
-185.6816363636	n/a	46420.4091	show_cross	n/a	n/a	n/a	cross.bmp
-186.3307272727	n/a	46582.6818	show_face	scrambled_face	first_show	17	s096.bmp
-187.0725454545	n/a	46768.1364	left_press	n/a	n/a	256	n/a
-187.3234545455	n/a	46830.8636	show_circle	n/a	n/a	0	circle.bmp
-189.0234545455	n/a	47255.8636	show_cross	n/a	n/a	n/a	cross.bmp
-189.4725454545	n/a	47368.1364	show_face	unfamiliar_face	delayed_repeat	15	u014.bmp
-190.2198181818	n/a	47554.9545	left_press	n/a	n/a	256	n/a
-190.3361818182	n/a	47584.0455	show_circle	n/a	n/a	0	circle.bmp
-192.0361818182	n/a	48009.0455	show_cross	n/a	n/a	n/a	cross.bmp
-192.5452727273	n/a	48136.3182	show_face	famous_face	first_show	5	f009.bmp
-193.3334545455	n/a	48333.3636	right_press	n/a	n/a	4096	n/a
-193.5161818182	n/a	48379.0455	show_circle	n/a	n/a	0	circle.bmp
-195.2161818182	n/a	48804.0455	show_cross	n/a	n/a	n/a	cross.bmp
-195.6525454545	n/a	48913.1364	show_face	famous_face	immediate_repeat	6	f009.bmp
-196.1398181818	n/a	49034.9545	right_press	n/a	n/a	4096	n/a
-196.6534545455	n/a	49163.3636	show_circle	n/a	n/a	0	circle.bmp
-198.3534545455	n/a	49588.3636	show_cross	n/a	n/a	n/a	cross.bmp
-198.9770909091	n/a	49744.2727	show_face	famous_face	first_show	5	f100.bmp
-199.7307272727	n/a	49932.6818	right_press	n/a	n/a	4096	n/a
-199.9707272727	n/a	49992.6818	show_circle	n/a	n/a	0	circle.bmp
-201.6707272727	n/a	50417.6818	show_cross	n/a	n/a	n/a	cross.bmp
-202.3180000000	n/a	50579.5	show_face	unfamiliar_face	first_show	13	u030.bmp
-203.3080000000	n/a	50827	show_circle	n/a	n/a	0	circle.bmp
-203.7234545455	n/a	50930.8636	left_press	n/a	n/a	256	n/a
-205.0080000000	n/a	51252	show_cross	n/a	n/a	n/a	cross.bmp
-205.5416363636	n/a	51385.4091	show_face	famous_face	first_show	5	f111.bmp
-206.2670909091	n/a	51566.7727	right_press	n/a	n/a	4096	n/a
-206.4043636364	n/a	51601.0909	show_circle	n/a	n/a	0	circle.bmp
-208.1043636364	n/a	52026.0909	show_cross	n/a	n/a	n/a	cross.bmp
-208.6661818182	n/a	52166.5455	show_face	famous_face	immediate_repeat	6	f111.bmp
-209.1443636364	n/a	52286.0909	right_press	n/a	n/a	4096	n/a
-209.5389090909	n/a	52384.7273	show_circle	n/a	n/a	0	circle.bmp
-211.2389090909	n/a	52809.7273	show_cross	n/a	n/a	n/a	cross.bmp
-211.7225454545	n/a	52930.6364	show_face	unfamiliar_face	first_show	13	u015.bmp
-212.3716363636	n/a	53092.9091	left_press	n/a	n/a	256	n/a
-212.6361818182	n/a	53159.0455	show_circle	n/a	n/a	0	circle.bmp
-214.3361818182	n/a	53584.0455	show_cross	n/a	n/a	n/a	cross.bmp
-214.8470909091	n/a	53711.7727	show_face	unfamiliar_face	immediate_repeat	14	u015.bmp
-215.3661818182	n/a	53841.5455	left_press	n/a	n/a	256	n/a
-215.8625454545	n/a	53965.6364	show_circle	n/a	n/a	0	circle.bmp
-217.5625454545	n/a	54390.6364	show_cross	n/a	n/a	n/a	cross.bmp
-218.1707272727	n/a	54542.6818	show_face	scrambled_face	delayed_repeat	19	s096.bmp
-218.8398181818	n/a	54709.9545	left_press	n/a	n/a	256	n/a
-219.0307272727	n/a	54757.6818	show_circle	n/a	n/a	0	circle.bmp
-220.7307272727	n/a	55182.6818	show_cross	n/a	n/a	n/a	cross.bmp
-221.3116363636	n/a	55327.9091	show_face	famous_face	first_show	5	f042.bmp
-222.1398181818	n/a	55534.9545	right_press	n/a	n/a	4096	n/a
-222.2961818182	n/a	55574.0455	show_circle	n/a	n/a	0	circle.bmp
-223.9961818182	n/a	55999.0455	show_cross	n/a	n/a	n/a	cross.bmp
-224.5861818182	n/a	56146.5455	show_face	famous_face	immediate_repeat	6	f042.bmp
-225.2407272727	n/a	56310.1818	right_press	n/a	n/a	4096	n/a
-225.4434545455	n/a	56360.8636	show_circle	n/a	n/a	0	circle.bmp
-227.1434545455	n/a	56785.8636	show_cross	n/a	n/a	n/a	cross.bmp
-227.7934545455	n/a	56948.3636	show_face	unfamiliar_face	first_show	13	u093.bmp
-228.4880000000	n/a	57122	left_press	n/a	n/a	256	n/a
-228.7025454545	n/a	57175.6364	show_circle	n/a	n/a	0	circle.bmp
-230.4025454545	n/a	57600.6364	show_cross	n/a	n/a	n/a	cross.bmp
-230.9834545455	n/a	57745.8636	show_face	famous_face	delayed_repeat	7	f100.bmp
-231.5589090909	n/a	57889.7273	right_press	n/a	n/a	4096	n/a
-231.8589090909	n/a	57964.7273	show_circle	n/a	n/a	0	circle.bmp
-233.5589090909	n/a	58389.7273	show_cross	n/a	n/a	n/a	cross.bmp
-234.1407272727	n/a	58535.1818	show_face	scrambled_face	first_show	17	s039.bmp
-234.9834545455	n/a	58745.8636	right_press	n/a	n/a	4096	n/a
-235.0325454545	n/a	58758.1364	show_circle	n/a	n/a	0	circle.bmp
-236.7325454545	n/a	59183.1364	show_cross	n/a	n/a	n/a	cross.bmp
-237.3652727273	n/a	59341.3182	show_face	unfamiliar_face	delayed_repeat	15	u030.bmp
-237.9989090909	n/a	59499.7273	left_press	n/a	n/a	256	n/a
-238.3798181818	n/a	59594.9545	show_circle	n/a	n/a	0	circle.bmp
-240.0798181818	n/a	60019.9545	show_cross	n/a	n/a	n/a	cross.bmp
-240.6398181818	n/a	60159.9545	show_face	scrambled_face	first_show	17	s059.bmp
-241.3734545455	n/a	60343.3636	left_press	n/a	n/a	256	n/a
-241.4934545455	n/a	60373.3636	show_circle	n/a	n/a	0	circle.bmp
-243.1934545455	n/a	60798.3636	show_cross	n/a	n/a	n/a	cross.bmp
-243.6634545455	n/a	60915.8636	show_face	scrambled_face	immediate_repeat	18	s059.bmp
-244.4125454545	n/a	61103.1364	left_press	n/a	n/a	256	n/a
-244.6198181818	n/a	61154.9545	show_circle	n/a	n/a	0	circle.bmp
-246.3198181818	n/a	61579.9545	show_cross	n/a	n/a	n/a	cross.bmp
-246.8034545455	n/a	61700.8636	show_face	scrambled_face	first_show	17	s050.bmp
-247.3707272727	n/a	61842.6818	left_press	n/a	n/a	256	n/a
-247.6834545455	n/a	61920.8636	show_circle	n/a	n/a	0	circle.bmp
-249.3834545455	n/a	62345.8636	show_cross	n/a	n/a	n/a	cross.bmp
-250.0107272727	n/a	62502.6818	show_face	scrambled_face	first_show	17	s089.bmp
-250.7516363636	n/a	62687.9091	left_press	n/a	n/a	256	n/a
-250.9307272727	n/a	62732.6818	show_circle	n/a	n/a	0	circle.bmp
-252.6307272727	n/a	63157.6818	show_cross	n/a	n/a	n/a	cross.bmp
-253.2516363636	n/a	63312.9091	show_face	famous_face	first_show	5	f130.bmp
-253.7843636364	n/a	63446.0909	right_press	n/a	n/a	4096	n/a
-254.2407272727	n/a	63560.1818	show_circle	n/a	n/a	0	circle.bmp
-255.9407272727	n/a	63985.1818	show_cross	n/a	n/a	n/a	cross.bmp
-256.4089090909	n/a	64102.2273	show_face	famous_face	immediate_repeat	6	f130.bmp
-256.9107272727	n/a	64227.6818	right_press	n/a	n/a	4096	n/a
-257.3007272727	n/a	64325.1818	show_circle	n/a	n/a	0	circle.bmp
-259.0007272727	n/a	64750.1818	show_cross	n/a	n/a	n/a	cross.bmp
-259.6161818182	n/a	64904.0455	show_face	unfamiliar_face	delayed_repeat	15	u093.bmp
-260.4861818182	n/a	65121.5455	left_press	n/a	n/a	256	n/a
-260.5207272727	n/a	65130.1818	show_circle	n/a	n/a	0	circle.bmp
-262.2207272727	n/a	65555.1818	show_cross	n/a	n/a	n/a	cross.bmp
-262.7907272727	n/a	65697.6818	show_face	unfamiliar_face	first_show	13	u042.bmp
-263.5189090909	n/a	65879.7273	right_press	n/a	n/a	4096	n/a
-263.6470909091	n/a	65911.7727	show_circle	n/a	n/a	0	circle.bmp
-265.3470909091	n/a	66336.7727	show_cross	n/a	n/a	n/a	cross.bmp
-265.9307272727	n/a	66482.6818	show_face	unfamiliar_face	immediate_repeat	14	u042.bmp
-266.5225454545	n/a	66630.6364	right_press	n/a	n/a	4096	n/a
-266.8580000000	n/a	66714.5	show_circle	n/a	n/a	0	circle.bmp
-268.5580000000	n/a	67139.5	show_cross	n/a	n/a	n/a	cross.bmp
-269.0552727273	n/a	67263.8182	show_face	scrambled_face	delayed_repeat	19	s039.bmp
-270.0489090909	n/a	67512.2273	show_circle	n/a	n/a	0	circle.bmp
-271.7489090909	n/a	67937.2273	show_cross	n/a	n/a	n/a	cross.bmp
-272.3961818182	n/a	68099.0455	show_face	scrambled_face	first_show	17	s145.bmp
-273.3125454545	n/a	68328.1364	show_circle	n/a	n/a	0	circle.bmp
-275.0125454545	n/a	68753.1364	show_cross	n/a	n/a	n/a	cross.bmp
-275.4861818182	n/a	68871.5455	show_face	unfamiliar_face	first_show	13	u094.bmp
-276.1389090909	n/a	69034.7273	right_press	n/a	n/a	4096	n/a
-276.3398181818	n/a	69084.9545	show_circle	n/a	n/a	0	circle.bmp
-278.0398181818	n/a	69509.9545	show_cross	n/a	n/a	n/a	cross.bmp
-278.5934545455	n/a	69648.3636	show_face	unfamiliar_face	immediate_repeat	14	u094.bmp
-279.0098181818	n/a	69752.4545	right_press	n/a	n/a	4096	n/a
-279.4534545455	n/a	69863.3636	show_circle	n/a	n/a	0	circle.bmp
-281.1534545455	n/a	70288.3636	show_cross	n/a	n/a	n/a	cross.bmp
-281.7843636364	n/a	70446.0909	show_face	scrambled_face	delayed_repeat	19	s050.bmp
-282.4889090909	n/a	70622.2273	left_press	n/a	n/a	256	n/a
-282.7234545455	n/a	70680.8636	show_circle	n/a	n/a	0	circle.bmp
-284.4234545455	n/a	71105.8636	show_cross	n/a	n/a	n/a	cross.bmp
-285.0752727273	n/a	71268.8182	show_face	unfamiliar_face	first_show	13	u131.bmp
-285.7898181818	n/a	71447.4545	left_press	n/a	n/a	256	n/a
-286.0907272727	n/a	71522.6818	show_circle	n/a	n/a	0	circle.bmp
-287.7907272727	n/a	71947.6818	show_cross	n/a	n/a	n/a	cross.bmp
-288.4325454545	n/a	72108.1364	show_face	scrambled_face	delayed_repeat	19	s089.bmp
-289.1998181818	n/a	72299.9545	right_press	n/a	n/a	4096	n/a
-289.3698181818	n/a	72342.4545	show_circle	n/a	n/a	0	circle.bmp
-291.0698181818	n/a	72767.4545	show_cross	n/a	n/a	n/a	cross.bmp
-291.6734545455	n/a	72918.3636	show_face	unfamiliar_face	first_show	13	u006.bmp
-292.5834545455	n/a	73145.8636	right_press	n/a	n/a	4096	n/a
-292.6416363636	n/a	73160.4091	show_circle	n/a	n/a	0	circle.bmp
-294.3416363636	n/a	73585.4091	show_cross	n/a	n/a	n/a	cross.bmp
-294.7980000000	n/a	73699.5	show_face	unfamiliar_face	immediate_repeat	14	u006.bmp
-295.2443636364	n/a	73811.0909	right_press	n/a	n/a	4096	n/a
-295.6407272727	n/a	73910.1818	show_circle	n/a	n/a	0	circle.bmp
-297.3407272727	n/a	74335.1818	show_cross	n/a	n/a	n/a	cross.bmp
-297.8543636364	n/a	74463.5909	show_face	famous_face	first_show	5	f002.bmp
-298.5570909091	n/a	74639.2727	right_press	n/a	n/a	4096	n/a
-298.8607272727	n/a	74715.1818	show_circle	n/a	n/a	0	circle.bmp
-300.5607272727	n/a	75140.1818	show_cross	n/a	n/a	n/a	cross.bmp
-301.1961818182	n/a	75299.0455	show_face	unfamiliar_face	first_show	13	u032.bmp
-301.8989090909	n/a	75474.7273	left_press	n/a	n/a	256	n/a
-302.1325454545	n/a	75533.1364	show_circle	n/a	n/a	0	circle.bmp
-303.8325454545	n/a	75958.1364	show_cross	n/a	n/a	n/a	cross.bmp
-304.4698181818	n/a	76117.4545	show_face	unfamiliar_face	immediate_repeat	14	u032.bmp
-304.8898181818	n/a	76222.4545	right_press	n/a	n/a	4096	n/a
-305.3298181818	n/a	76332.4545	show_circle	n/a	n/a	0	circle.bmp
-307.0298181818	n/a	76757.4545	show_cross	n/a	n/a	n/a	cross.bmp
-307.6607272727	n/a	76915.1818	show_face	scrambled_face	delayed_repeat	19	s145.bmp
-308.6352727273	n/a	77158.8182	show_circle	n/a	n/a	0	circle.bmp
-309.0598181818	n/a	77264.9545	right_press	n/a	n/a	4096	n/a
-310.3352727273	n/a	77583.8182	show_cross	n/a	n/a	n/a	cross.bmp
-310.9516363636	n/a	77737.9091	show_face	unfamiliar_face	first_show	13	u080.bmp
-311.6580000000	n/a	77914.5	right_press	n/a	n/a	4096	n/a
-311.8480000000	n/a	77962	show_circle	n/a	n/a	0	circle.bmp
-313.5480000000	n/a	78387	show_cross	n/a	n/a	n/a	cross.bmp
-314.0589090909	n/a	78514.7273	show_face	unfamiliar_face	immediate_repeat	14	u080.bmp
-314.7598181818	n/a	78689.9545	right_press	n/a	n/a	4096	n/a
-314.9170909091	n/a	78729.2727	show_circle	n/a	n/a	0	circle.bmp
-314.9180000000	n/a	78729.5	show_circle	n/a	n/a	0	circle.bmp
-316.6170909091	n/a	79154.2727	show_cross	n/a	n/a	n/a	cross.bmp
-316.6180000000	n/a	79154.5	show_cross	n/a	n/a	n/a	cross.bmp
-317.2161818182	n/a	79304.0455	show_face	scrambled_face	first_show	17	s073.bmp
-317.8098181818	n/a	79452.4545	left_press	n/a	n/a	256	n/a
-318.0716363636	n/a	79517.9091	show_circle	n/a	n/a	0	circle.bmp
-319.7716363636	n/a	79942.9091	show_cross	n/a	n/a	n/a	cross.bmp
-320.3398181818	n/a	80084.9545	show_face	unfamiliar_face	delayed_repeat	15	u131.bmp
-321.0943636364	n/a	80273.5909	left_press	n/a	n/a	256	n/a
-321.1807272727	n/a	80295.1818	show_circle	n/a	n/a	0	circle.bmp
-322.8807272727	n/a	80720.1818	show_cross	n/a	n/a	n/a	cross.bmp
-323.4970909091	n/a	80874.2727	show_face	famous_face	first_show	5	f103.bmp
-324.3261818182	n/a	81081.5455	show_circle	n/a	n/a	0	circle.bmp
-324.6361818182	n/a	81159.0455	right_press	n/a	n/a	4096	n/a
-326.0261818182	n/a	81506.5455	show_cross	n/a	n/a	n/a	cross.bmp
-326.6707272727	n/a	81667.6818	show_face	famous_face	first_show	5	f035.bmp
-327.4034545455	n/a	81850.8636	left_press	n/a	n/a	256	n/a
-327.6416363636	n/a	81910.4091	show_circle	n/a	n/a	0	circle.bmp
-329.3416363636	n/a	82335.4091	show_cross	n/a	n/a	n/a	cross.bmp
-329.8116363636	n/a	82452.9091	show_face	famous_face	delayed_repeat	7	f002.bmp
-330.7070909091	n/a	82676.7727	show_circle	n/a	n/a	0	circle.bmp
-330.7507272727	n/a	82687.6818	right_press	n/a	n/a	4096	n/a
-332.4070909091	n/a	83101.7727	show_cross	n/a	n/a	n/a	cross.bmp
-333.0025454545	n/a	83250.6364	show_face	scrambled_face	first_show	17	s097.bmp
-333.7216363636	n/a	83430.4091	right_press	n/a	n/a	4096	n/a
-333.9707272727	n/a	83492.6818	show_circle	n/a	n/a	0	circle.bmp
-335.6707272727	n/a	83917.6818	show_cross	n/a	n/a	n/a	cross.bmp
-336.1598181818	n/a	84039.9545	show_face	unfamiliar_face	first_show	13	u008.bmp
-336.8425454545	n/a	84210.6364	left_press	n/a	n/a	256	n/a
-337.1180000000	n/a	84279.5	show_circle	n/a	n/a	0	circle.bmp
-338.8180000000	n/a	84704.5	show_cross	n/a	n/a	n/a	cross.bmp
-339.3170909091	n/a	84829.2727	show_face	unfamiliar_face	first_show	13	u046.bmp
-339.9552727273	n/a	84988.8182	left_press	n/a	n/a	256	n/a
-340.1689090909	n/a	85042.2273	show_circle	n/a	n/a	0	circle.bmp
-341.8689090909	n/a	85467.2273	show_cross	n/a	n/a	n/a	cross.bmp
-342.3080000000	n/a	85577	show_face	scrambled_face	delayed_repeat	19	s073.bmp
-343.0698181818	n/a	85767.4545	left_press	n/a	n/a	256	n/a
-343.2043636364	n/a	85801.0909	show_circle	n/a	n/a	0	circle.bmp
-344.9043636364	n/a	86226.0909	show_cross	n/a	n/a	n/a	cross.bmp
-345.3643636364	n/a	86341.0909	show_face	famous_face	first_show	5	f049.bmp
-346.1816363636	n/a	86545.4091	show_circle	n/a	n/a	0	circle.bmp
-346.8961818182	n/a	86724.0455	right_press	n/a	n/a	4096	n/a
-347.8816363636	n/a	86970.4091	show_cross	n/a	n/a	n/a	cross.bmp
-348.5043636364	n/a	87126.0909	show_face	famous_face	immediate_repeat	6	f049.bmp
-349.4470909091	n/a	87361.7727	show_circle	n/a	n/a	0	circle.bmp
-349.5634545455	n/a	87390.8636	right_press	n/a	n/a	4096	n/a
-351.1470909091	n/a	87786.7727	show_cross	n/a	n/a	n/a	cross.bmp
-351.5952727273	n/a	87898.8182	show_face	famous_face	delayed_repeat	7	f103.bmp
-352.3352727273	n/a	88083.8182	right_press	n/a	n/a	4096	n/a
-352.6034545455	n/a	88150.8636	show_circle	n/a	n/a	0	circle.bmp
-354.3034545455	n/a	88575.8636	show_cross	n/a	n/a	n/a	cross.bmp
-354.8025454545	n/a	88700.6364	show_face	scrambled_face	first_show	17	s108.bmp
-355.6170909091	n/a	88904.2727	right_press	n/a	n/a	4096	n/a
-355.6725454545	n/a	88918.1364	show_circle	n/a	n/a	0	circle.bmp
-357.3725454545	n/a	89343.1364	show_cross	n/a	n/a	n/a	cross.bmp
-357.9761818182	n/a	89494.0455	show_face	scrambled_face	immediate_repeat	18	s108.bmp
-358.5516363636	n/a	89637.9091	right_press	n/a	n/a	4096	n/a
-358.8280000000	n/a	89707	show_circle	n/a	n/a	0	circle.bmp
-360.5280000000	n/a	90132	show_cross	n/a	n/a	n/a	cross.bmp
-361.0670909091	n/a	90266.7727	show_face	famous_face	delayed_repeat	7	f035.bmp
-361.7670909091	n/a	90441.7727	left_press	n/a	n/a	256	n/a
-362.0161818182	n/a	90504.0455	show_circle	n/a	n/a	0	circle.bmp
-363.7161818182	n/a	90929.0455	show_cross	n/a	n/a	n/a	cross.bmp
-364.3243636364	n/a	91081.0909	show_face	famous_face	first_show	5	f096.bmp
-365.2916363636	n/a	91322.9091	right_press	n/a	n/a	4096	n/a
-365.3034545455	n/a	91325.8636	show_circle	n/a	n/a	0	circle.bmp
-367.0034545455	n/a	91750.8636	show_cross	n/a	n/a	n/a	cross.bmp
-367.4652727273	n/a	91866.3182	show_face	famous_face	immediate_repeat	6	f096.bmp
-368.1043636364	n/a	92026.0909	right_press	n/a	n/a	4096	n/a
-368.4243636364	n/a	92106.0909	show_circle	n/a	n/a	0	circle.bmp
-370.1243636364	n/a	92531.0909	show_cross	n/a	n/a	n/a	cross.bmp
-370.6225454545	n/a	92655.6364	show_face	scrambled_face	delayed_repeat	19	s097.bmp
-371.4798181818	n/a	92869.9545	show_circle	n/a	n/a	0	circle.bmp
-371.6716363636	n/a	92917.9091	left_press	n/a	n/a	256	n/a
-373.1798181818	n/a	93294.9545	show_cross	n/a	n/a	n/a	cross.bmp
-373.7125454545	n/a	93428.1364	show_face	famous_face	first_show	5	f014.bmp
-374.5680000000	n/a	93642	show_circle	n/a	n/a	0	circle.bmp
-374.6389090909	n/a	93659.7273	right_press	n/a	n/a	4096	n/a
-376.2680000000	n/a	94067	show_cross	n/a	n/a	n/a	cross.bmp
-376.8698181818	n/a	94217.4545	show_face	unfamiliar_face	delayed_repeat	15	u008.bmp
-377.4252727273	n/a	94356.3182	left_press	n/a	n/a	256	n/a
-377.7343636364	n/a	94433.5909	show_circle	n/a	n/a	0	circle.bmp
-379.4343636364	n/a	94858.5909	show_cross	n/a	n/a	n/a	cross.bmp
-380.0270909091	n/a	95006.7727	show_face	unfamiliar_face	first_show	13	u109.bmp
-381.0380000000	n/a	95259.5	show_circle	n/a	n/a	0	circle.bmp
-381.2125454545	n/a	95303.1364	left_press	n/a	n/a	256	n/a
-382.7380000000	n/a	95684.5	show_cross	n/a	n/a	n/a	cross.bmp
-383.3689090909	n/a	95842.2273	show_face	unfamiliar_face	immediate_repeat	14	u109.bmp
-384.0343636364	n/a	96008.5909	left_press	n/a	n/a	256	n/a
-384.3161818182	n/a	96079.0455	show_circle	n/a	n/a	0	circle.bmp
-386.0161818182	n/a	96504.0455	show_cross	n/a	n/a	n/a	cross.bmp
-386.6425454545	n/a	96660.6364	show_face	unfamiliar_face	delayed_repeat	15	u046.bmp
-387.2580000000	n/a	96814.5	left_press	n/a	n/a	256	n/a
-387.5489090909	n/a	96887.2273	show_circle	n/a	n/a	0	circle.bmp
-389.2489090909	n/a	97312.2273	show_cross	n/a	n/a	n/a	cross.bmp
-389.7161818182	n/a	97429.0455	show_face	unfamiliar_face	first_show	13	u043.bmp
-390.5170909091	n/a	97629.2727	left_press	n/a	n/a	256	n/a
-390.5534545455	n/a	97638.3636	show_circle	n/a	n/a	0	circle.bmp
-392.2534545455	n/a	98063.3636	show_cross	n/a	n/a	n/a	cross.bmp
-392.7398181818	n/a	98184.9545	show_face	unfamiliar_face	immediate_repeat	14	u043.bmp
-393.3107272727	n/a	98327.6818	left_press	n/a	n/a	256	n/a
-393.5707272727	n/a	98392.6818	show_circle	n/a	n/a	0	circle.bmp
-395.2707272727	n/a	98817.6818	show_cross	n/a	n/a	n/a	cross.bmp
-395.7634545455	n/a	98940.8636	show_face	unfamiliar_face	first_show	13	u026.bmp
-396.4798181818	n/a	99119.9545	left_press	n/a	n/a	256	n/a
-396.6470909091	n/a	99161.7727	show_circle	n/a	n/a	0	circle.bmp
-398.3470909091	n/a	99586.7727	show_cross	n/a	n/a	n/a	cross.bmp
-398.9707272727	n/a	99742.6818	show_face	unfamiliar_face	first_show	13	u133.bmp
-399.7543636364	n/a	99938.5909	left_press	n/a	n/a	256	n/a
-399.8980000000	n/a	99974.5	show_circle	n/a	n/a	0	circle.bmp
-401.5980000000	n/a	100399.5	show_cross	n/a	n/a	n/a	cross.bmp
-402.1116363636	n/a	100527.9091	show_face	unfamiliar_face	immediate_repeat	14	u133.bmp
-402.9789090909	n/a	100744.7273	show_circle	n/a	n/a	0	circle.bmp
-404.6789090909	n/a	101169.7273	show_cross	n/a	n/a	n/a	cross.bmp
-405.2852727273	n/a	101321.3182	show_face	famous_face	first_show	5	f044.bmp
-406.2470909091	n/a	101561.7727	show_circle	n/a	n/a	0	circle.bmp
-407.9470909091	n/a	101986.7727	show_cross	n/a	n/a	n/a	cross.bmp
-408.4425454545	n/a	102110.6364	show_face	famous_face	immediate_repeat	6	f044.bmp
-409.2952727273	n/a	102323.8182	right_press	n/a	n/a	4096	n/a
-409.3361818182	n/a	102334.0455	show_circle	n/a	n/a	0	circle.bmp
-411.0361818182	n/a	102759.0455	show_cross	n/a	n/a	n/a	cross.bmp
-411.4998181818	n/a	102874.9545	show_face	famous_face	delayed_repeat	7	f014.bmp
-412.3398181818	n/a	103084.9545	right_press	n/a	n/a	4096	n/a
-412.3952727273	n/a	103098.8182	show_circle	n/a	n/a	0	circle.bmp
-414.0952727273	n/a	103523.8182	show_cross	n/a	n/a	n/a	cross.bmp
-414.6407272727	n/a	103660.1818	show_face	famous_face	first_show	5	f085.bmp
-415.3334545455	n/a	103833.3636	right_press	n/a	n/a	4096	n/a
-415.4780000000	n/a	103869.5	show_circle	n/a	n/a	0	circle.bmp
-417.1780000000	n/a	104294.5	show_cross	n/a	n/a	n/a	cross.bmp
-417.7807272727	n/a	104445.1818	show_face	famous_face	first_show	5	f123.bmp
-418.2861818182	n/a	104571.5455	right_press	n/a	n/a	4096	n/a
-418.6043636364	n/a	104651.0909	show_circle	n/a	n/a	0	circle.bmp
-420.3043636364	n/a	105076.0909	show_cross	n/a	n/a	n/a	cross.bmp
-420.7552727273	n/a	105188.8182	show_face	famous_face	immediate_repeat	6	f123.bmp
-421.2707272727	n/a	105317.6818	right_press	n/a	n/a	4096	n/a
-421.6689090909	n/a	105417.2273	show_circle	n/a	n/a	0	circle.bmp
-423.3689090909	n/a	105842.2273	show_cross	n/a	n/a	n/a	cross.bmp
-423.9116363636	n/a	105977.9091	show_face	unfamiliar_face	first_show	13	u115.bmp
-424.7589090909	n/a	106189.7273	right_press	n/a	n/a	4096	n/a
-424.8898181818	n/a	106222.4545	show_circle	n/a	n/a	0	circle.bmp
-426.5898181818	n/a	106647.4545	show_cross	n/a	n/a	n/a	cross.bmp
-427.1698181818	n/a	106792.4545	show_face	unfamiliar_face	immediate_repeat	14	u115.bmp
-427.8270909091	n/a	106956.7727	right_press	n/a	n/a	4096	n/a
-428.1425454545	n/a	107035.6364	show_circle	n/a	n/a	0	circle.bmp
-429.8425454545	n/a	107460.6364	show_cross	n/a	n/a	n/a	cross.bmp
-430.3598181818	n/a	107589.9545	show_face	unfamiliar_face	delayed_repeat	15	u026.bmp
-431.2470909091	n/a	107811.7727	left_press	n/a	n/a	256	n/a
-431.2507272727	n/a	107812.6818	show_circle	n/a	n/a	0	circle.bmp
-432.9507272727	n/a	108237.6818	show_cross	n/a	n/a	n/a	cross.bmp
-433.4843636364	n/a	108371.0909	show_face	unfamiliar_face	first_show	13	u119.bmp
-434.0934545455	n/a	108523.3636	right_press	n/a	n/a	4096	n/a
-434.4807272727	n/a	108620.1818	show_circle	n/a	n/a	0	circle.bmp
-436.1807272727	n/a	109045.1818	show_cross	n/a	n/a	n/a	cross.bmp
-436.6416363636	n/a	109160.4091	show_face	famous_face	first_show	5	f057.bmp
-437.3252727273	n/a	109331.3182	right_press	n/a	n/a	4096	n/a
-437.5289090909	n/a	109382.2273	show_circle	n/a	n/a	0	circle.bmp
-439.2289090909	n/a	109807.2273	show_cross	n/a	n/a	n/a	cross.bmp
-439.7152727273	n/a	109928.8182	show_face	scrambled_face	first_show	17	s023.bmp
-440.3316363636	n/a	110082.9091	left_press	n/a	n/a	256	n/a
-440.5334545455	n/a	110133.3636	show_circle	n/a	n/a	0	circle.bmp
-442.2334545455	n/a	110558.3636	show_cross	n/a	n/a	n/a	cross.bmp
-442.8225454545	n/a	110705.6364	show_face	famous_face	delayed_repeat	7	f085.bmp
-443.6189090909	n/a	110904.7273	right_press	n/a	n/a	4096	n/a
-443.6452727273	n/a	110911.3182	show_circle	n/a	n/a	0	circle.bmp
-445.3452727273	n/a	111336.3182	show_cross	n/a	n/a	n/a	cross.bmp
-445.9298181818	n/a	111482.4545	show_face	scrambled_face	first_show	17	s140.bmp
-446.5261818182	n/a	111631.5455	right_press	n/a	n/a	4096	n/a
-446.8125454545	n/a	111703.1364	show_circle	n/a	n/a	0	circle.bmp
-448.5125454545	n/a	112128.1364	show_cross	n/a	n/a	n/a	cross.bmp
-449.0870909091	n/a	112271.7727	show_face	unfamiliar_face	first_show	13	u114.bmp
-449.8443636364	n/a	112461.0909	right_press	n/a	n/a	4096	n/a
-450.0007272727	n/a	112500.1818	show_circle	n/a	n/a	0	circle.bmp
-451.7007272727	n/a	112925.1818	show_cross	n/a	n/a	n/a	cross.bmp
-452.3107272727	n/a	113077.6818	show_face	unfamiliar_face	immediate_repeat	14	u114.bmp
-452.8780000000	n/a	113219.5	right_press	n/a	n/a	4096	n/a
-453.1652727273	n/a	113291.3182	show_circle	n/a	n/a	0	circle.bmp
-454.8652727273	n/a	113716.3182	show_cross	n/a	n/a	n/a	cross.bmp
-455.4516363636	n/a	113862.9091	show_face	famous_face	first_show	5	f062.bmp
-456.1716363636	n/a	114042.9091	left_press	n/a	n/a	256	n/a
-456.2898181818	n/a	114072.4545	show_circle	n/a	n/a	0	circle.bmp
-457.9898181818	n/a	114497.4545	show_cross	n/a	n/a	n/a	cross.bmp
-458.5589090909	n/a	114639.7273	show_face	famous_face	immediate_repeat	6	f062.bmp
-459.4280000000	n/a	114857	left_press	n/a	n/a	256	n/a
-459.4561818182	n/a	114864.0455	show_circle	n/a	n/a	0	circle.bmp
-461.1561818182	n/a	115289.0455	show_cross	n/a	n/a	n/a	cross.bmp
-461.7325454545	n/a	115433.1364	show_face	unfamiliar_face	delayed_repeat	15	u119.bmp
-462.3489090909	n/a	115587.2273	right_press	n/a	n/a	4096	n/a
-462.6970909091	n/a	115674.2727	show_circle	n/a	n/a	0	circle.bmp
-464.3970909091	n/a	116099.2727	show_cross	n/a	n/a	n/a	cross.bmp
-465.0398181818	n/a	116259.9545	show_face	famous_face	first_show	5	f092.bmp
-465.6852727273	n/a	116421.3182	right_press	n/a	n/a	4096	n/a
-466.0107272727	n/a	116502.6818	show_circle	n/a	n/a	0	circle.bmp
-467.7107272727	n/a	116927.6818	show_cross	n/a	n/a	n/a	cross.bmp
-468.2643636364	n/a	117066.0909	show_face	famous_face	immediate_repeat	6	f092.bmp
-469.1670909091	n/a	117291.7727	show_circle	n/a	n/a	0	circle.bmp
-470.8670909091	n/a	117716.7727	show_cross	n/a	n/a	n/a	cross.bmp
-471.4552727273	n/a	117863.8182	show_face	famous_face	delayed_repeat	7	f057.bmp
-472.0234545455	n/a	118005.8636	right_press	n/a	n/a	4096	n/a
-472.4125454545	n/a	118103.1364	show_circle	n/a	n/a	0	circle.bmp
-474.1125454545	n/a	118528.1364	show_cross	n/a	n/a	n/a	cross.bmp
-474.6952727273	n/a	118673.8182	show_face	scrambled_face	first_show	17	s083.bmp
-475.4843636364	n/a	118871.0909	right_press	n/a	n/a	4096	n/a
-475.5970909091	n/a	118899.2727	show_circle	n/a	n/a	0	circle.bmp
-477.2970909091	n/a	119324.2727	show_cross	n/a	n/a	n/a	cross.bmp
-477.8198181818	n/a	119454.9545	show_face	scrambled_face	delayed_repeat	19	s023.bmp
-478.6089090909	n/a	119652.2273	left_press	n/a	n/a	256	n/a
-478.7916363636	n/a	119697.9091	show_circle	n/a	n/a	0	circle.bmp
-480.4916363636	n/a	120122.9091	show_cross	n/a	n/a	n/a	cross.bmp
-481.0434545455	n/a	120260.8636	show_face	famous_face	first_show	5	f045.bmp
-481.9680000000	n/a	120492	show_circle	n/a	n/a	0	circle.bmp
-482.5580000000	n/a	120639.5	right_press	n/a	n/a	4096	n/a
-483.6680000000	n/a	120917	show_cross	n/a	n/a	n/a	cross.bmp
-484.2680000000	n/a	121067	show_face	scrambled_face	delayed_repeat	19	s140.bmp
-485.0316363636	n/a	121257.9091	right_press	n/a	n/a	4096	n/a
-485.2307272727	n/a	121307.6818	show_circle	n/a	n/a	0	circle.bmp
-486.9307272727	n/a	121732.6818	show_cross	n/a	n/a	n/a	cross.bmp
-487.5089090909	n/a	121877.2273	show_face	scrambled_face	first_show	17	s147.bmp
-488.0970909091	n/a	122024.2727	left_press	n/a	n/a	256	n/a
-488.3770909091	n/a	122094.2727	show_circle	n/a	n/a	0	circle.bmp
-490.0770909091	n/a	122519.2727	show_cross	n/a	n/a	n/a	cross.bmp
+onset	duration	sample	event_type	face_type	repetition_type	trial	trial_lag	trigger	stim_file
+0.004	n/a	1.0	setup	n/a	n/a	n/a	n/a	n/a	n/a
+0.004	n/a	1.0	right_sym	n/a	n/a	n/a	n/a	n/a	n/a
+24.791636363600002	n/a	6197.9091	show_face	unfamiliar_face	first_show	1	n/a	13	u025.bmp
+25.343454545500002	n/a	6335.8636	left_press	n/a	n/a	1	n/a	256	n/a
+25.7798181818	n/a	6444.9545	show_circle	n/a	n/a	1	n/a	0	circle.bmp
+27.4798181818	n/a	6869.9545	show_cross	n/a	n/a	2	n/a	n/a	cross.bmp
+27.9825454545	n/a	6995.6364	show_face	unfamiliar_face	immediate_repeat	2	1	14	u025.bmp
+28.5261818182	n/a	7131.5455	left_press	n/a	n/a	2	n/a	256	n/a
+28.896181818200002	n/a	7224.0455	show_circle	n/a	n/a	2	n/a	0	circle.bmp
+30.5961818182	n/a	7649.0455	show_cross	n/a	n/a	3	n/a	n/a	cross.bmp
+31.1734545455	n/a	7793.3636	show_face	scrambled_face	first_show	3	n/a	17	s146.bmp
+31.768	n/a	7942.0	left_press	n/a	n/a	3	n/a	256	n/a
+32.1525454545	n/a	8038.1364	show_circle	n/a	n/a	3	n/a	0	circle.bmp
+33.852545454499996	n/a	8463.1364	show_cross	n/a	n/a	4	n/a	n/a	cross.bmp
+34.363454545500005	n/a	8590.8636	show_face	scrambled_face	immediate_repeat	4	1	18	s146.bmp
+34.796181818200004	n/a	8699.0455	left_press	n/a	n/a	4	n/a	256	n/a
+35.2752727273	n/a	8818.8182	show_circle	n/a	n/a	4	n/a	0	circle.bmp
+36.9752727273	n/a	9243.8182	show_cross	n/a	n/a	5	n/a	n/a	cross.bmp
+37.4707272727	n/a	9367.6818	show_face	scrambled_face	first_show	5	n/a	17	s143.bmp
+38.0307272727	n/a	9507.6818	right_press	n/a	n/a	5	n/a	4096	n/a
+38.4870909091	n/a	9621.7727	show_circle	n/a	n/a	5	n/a	0	circle.bmp
+40.1870909091	n/a	10046.7727	show_cross	n/a	n/a	6	n/a	n/a	cross.bmp
+40.761636363600005	n/a	10190.4091	show_face	scrambled_face	immediate_repeat	6	1	18	s143.bmp
+41.1507272727	n/a	10287.6818	right_press	n/a	n/a	6	n/a	4096	n/a
+41.688909090900005	n/a	10422.2273	show_circle	n/a	n/a	6	n/a	0	circle.bmp
+43.3889090909	n/a	10847.2273	show_cross	n/a	n/a	7	n/a	n/a	cross.bmp
+44.0034545455	n/a	11000.8636	show_face	scrambled_face	first_show	7	n/a	17	s087.bmp
+44.6343636364	n/a	11158.5909	left_press	n/a	n/a	7	n/a	256	n/a
+44.8361818182	n/a	11209.0455	show_circle	n/a	n/a	7	n/a	0	circle.bmp
+46.5361818182	n/a	11634.0455	show_cross	n/a	n/a	8	n/a	n/a	cross.bmp
+46.9934545455	n/a	11748.3636	show_face	scrambled_face	first_show	8	n/a	17	s114.bmp
+47.6734545455	n/a	11918.3636	left_press	n/a	n/a	8	n/a	256	n/a
+47.998	n/a	11999.5	show_circle	n/a	n/a	8	n/a	0	circle.bmp
+49.698	n/a	12424.5	show_cross	n/a	n/a	9	n/a	n/a	cross.bmp
+50.3007272727	n/a	12575.1818	show_face	famous_face	first_show	9	n/a	5	f098.bmp
+50.946181818199996	n/a	12736.5455	left_press	n/a	n/a	9	n/a	256	n/a
+51.199818181800005	n/a	12799.9545	show_circle	n/a	n/a	9	n/a	0	circle.bmp
+52.8998181818	n/a	13224.9545	show_cross	n/a	n/a	10	n/a	n/a	cross.bmp
+53.475272727299995	n/a	13368.8182	show_face	scrambled_face	first_show	10	n/a	17	s090.bmp
+54.0661818182	n/a	13516.5455	left_press	n/a	n/a	10	n/a	256	n/a
+54.3561818182	n/a	13589.0455	show_circle	n/a	n/a	10	n/a	0	circle.bmp
+56.056181818199995	n/a	14014.0455	show_cross	n/a	n/a	11	n/a	n/a	cross.bmp
+56.6489090909	n/a	14162.2273	show_face	scrambled_face	first_show	11	n/a	17	s068.bmp
+57.4361818182	n/a	14359.0455	left_press	n/a	n/a	11	n/a	256	n/a
+57.601636363599994	n/a	14400.4091	show_circle	n/a	n/a	11	n/a	0	circle.bmp
+59.3016363636	n/a	14825.4091	show_cross	n/a	n/a	12	n/a	n/a	cross.bmp
+59.8725454545	n/a	14968.1364	show_face	famous_face	first_show	12	n/a	5	f070.bmp
+60.52072727270001	n/a	15130.1818	right_press	n/a	n/a	12	n/a	4096	n/a
+60.7461818182	n/a	15186.5455	show_circle	n/a	n/a	12	n/a	0	circle.bmp
+62.446181818199996	n/a	15611.5455	show_cross	n/a	n/a	13	n/a	n/a	cross.bmp
+63.0470909091	n/a	15761.7727	show_face	famous_face	immediate_repeat	13	1	6	f070.bmp
+63.596181818199994	n/a	15899.0455	right_press	n/a	n/a	13	n/a	4096	n/a
+63.9470909091	n/a	15986.7727	show_circle	n/a	n/a	13	n/a	0	circle.bmp
+65.6470909091	n/a	16411.7727	show_cross	n/a	n/a	14	n/a	n/a	cross.bmp
+66.2043636364	n/a	16551.0909	show_face	scrambled_face	delayed_repeat	14	7	19	s087.bmp
+66.9525454545	n/a	16738.1364	left_press	n/a	n/a	14	n/a	256	n/a
+67.0370909091	n/a	16759.2727	show_circle	n/a	n/a	14	n/a	0	circle.bmp
+68.7370909091	n/a	17184.2727	show_cross	n/a	n/a	15	n/a	n/a	cross.bmp
+69.228	n/a	17307.0	show_face	scrambled_face	first_show	15	n/a	17	s124.bmp
+69.90709090909999	n/a	17476.7727	left_press	n/a	n/a	15	n/a	256	n/a
+70.24527272729999	n/a	17561.3182	show_circle	n/a	n/a	15	n/a	0	circle.bmp
+71.9452727273	n/a	17986.3182	show_cross	n/a	n/a	16	n/a	n/a	cross.bmp
+72.468	n/a	18117.0	show_face	scrambled_face	immediate_repeat	16	1	18	s124.bmp
+72.97618181819999	n/a	18244.0455	left_press	n/a	n/a	16	n/a	256	n/a
+73.358	n/a	18339.5	show_circle	n/a	n/a	16	n/a	0	circle.bmp
+75.058	n/a	18764.5	show_cross	n/a	n/a	17	n/a	n/a	cross.bmp
+75.5589090909	n/a	18889.7273	show_face	scrambled_face	delayed_repeat	17	9	19	s114.bmp
+76.4025454545	n/a	19100.6364	show_circle	n/a	n/a	17	n/a	0	circle.bmp
+76.8434545455	n/a	19210.8636	left_press	n/a	n/a	17	n/a	256	n/a
+78.1025454545	n/a	19525.6364	show_cross	n/a	n/a	18	n/a	n/a	cross.bmp
+78.7661818182	n/a	19691.5455	show_face	famous_face	first_show	18	n/a	5	f134.bmp
+79.2952727273	n/a	19823.8182	right_press	n/a	n/a	18	n/a	4096	n/a
+79.6134545455	n/a	19903.3636	show_circle	n/a	n/a	18	n/a	0	circle.bmp
+81.31345454550001	n/a	20328.3636	show_cross	n/a	n/a	19	n/a	n/a	cross.bmp
+81.8234545455	n/a	20455.8636	show_face	famous_face	immediate_repeat	19	1	6	f134.bmp
+82.3389090909	n/a	20584.7273	right_press	n/a	n/a	19	n/a	4096	n/a
+82.708	n/a	20677.0	show_circle	n/a	n/a	19	n/a	0	circle.bmp
+84.408	n/a	21102.0	show_cross	n/a	n/a	20	n/a	n/a	cross.bmp
+84.98072727270001	n/a	21245.1818	show_face	famous_face	delayed_repeat	20	11	7	f098.bmp
+85.8807272727	n/a	21470.1818	show_circle	n/a	n/a	20	n/a	0	circle.bmp
+86.0498181818	n/a	21512.4545	right_press	n/a	n/a	20	n/a	4096	n/a
+87.5807272727	n/a	21895.1818	show_cross	n/a	n/a	21	n/a	n/a	cross.bmp
+88.07072727270001	n/a	22017.6818	show_face	scrambled_face	first_show	21	n/a	17	s148.bmp
+88.8570909091	n/a	22214.2727	right_press	n/a	n/a	21	n/a	4096	n/a
+88.95890909090001	n/a	22239.7273	show_circle	n/a	n/a	21	n/a	0	circle.bmp
+90.6589090909	n/a	22664.7273	show_cross	n/a	n/a	22	n/a	n/a	cross.bmp
+91.14436363639999	n/a	22786.0909	show_face	scrambled_face	delayed_repeat	22	12	19	s090.bmp
+92.0552727273	n/a	23013.8182	left_press	n/a	n/a	22	n/a	256	n/a
+92.0634545455	n/a	23015.8636	show_circle	n/a	n/a	22	n/a	0	circle.bmp
+93.7634545455	n/a	23440.8636	show_cross	n/a	n/a	23	n/a	n/a	cross.bmp
+94.2352727273	n/a	23558.8182	show_face	unfamiliar_face	first_show	23	n/a	13	u136.bmp
+94.9252727273	n/a	23731.3182	right_press	n/a	n/a	23	n/a	4096	n/a
+95.1189090909	n/a	23779.7273	show_circle	n/a	n/a	23	n/a	0	circle.bmp
+96.81890909090001	n/a	24204.7273	show_cross	n/a	n/a	24	n/a	n/a	cross.bmp
+97.4598181818	n/a	24364.9545	show_face	scrambled_face	delayed_repeat	24	13	19	s068.bmp
+98.1989090909	n/a	24549.7273	left_press	n/a	n/a	24	n/a	256	n/a
+98.28436363639999	n/a	24571.0909	show_circle	n/a	n/a	24	n/a	0	circle.bmp
+99.98436363639999	n/a	24996.0909	show_cross	n/a	n/a	25	n/a	n/a	cross.bmp
+100.53345454549999	n/a	25133.3636	show_face	unfamiliar_face	first_show	25	n/a	13	u053.bmp
+101.3070909091	n/a	25326.7727	right_press	n/a	n/a	25	n/a	4096	n/a
+101.3889090909	n/a	25347.2273	show_circle	n/a	n/a	25	n/a	0	circle.bmp
+103.0889090909	n/a	25772.2273	show_cross	n/a	n/a	26	n/a	n/a	cross.bmp
+103.6734545455	n/a	25918.3636	show_face	scrambled_face	first_show	26	n/a	17	s082.bmp
+104.4361818182	n/a	26109.0455	right_press	n/a	n/a	26	n/a	4096	n/a
+104.688	n/a	26172.0	show_circle	n/a	n/a	26	n/a	0	circle.bmp
+106.388	n/a	26597.0	show_cross	n/a	n/a	27	n/a	n/a	cross.bmp
+107.01436363639999	n/a	26753.5909	show_face	scrambled_face	immediate_repeat	27	1	18	s082.bmp
+107.74527272729999	n/a	26936.3182	left_press	n/a	n/a	27	n/a	256	n/a
+107.8761818182	n/a	26969.0455	show_circle	n/a	n/a	27	n/a	0	circle.bmp
+109.5761818182	n/a	27394.0455	show_cross	n/a	n/a	28	n/a	n/a	cross.bmp
+110.1552727273	n/a	27538.8182	show_face	unfamiliar_face	first_show	28	n/a	13	u002.bmp
+110.7816363636	n/a	27695.4091	right_press	n/a	n/a	28	n/a	4096	n/a
+111.0698181818	n/a	27767.4545	show_circle	n/a	n/a	28	n/a	0	circle.bmp
+112.7698181818	n/a	28192.4545	show_cross	n/a	n/a	29	n/a	n/a	cross.bmp
+113.26254545450001	n/a	28315.6364	show_face	unfamiliar_face	immediate_repeat	29	1	14	u002.bmp
+113.8698181818	n/a	28467.4545	right_press	n/a	n/a	29	n/a	4096	n/a
+114.1716363636	n/a	28542.9091	show_circle	n/a	n/a	29	n/a	0	circle.bmp
+115.8716363636	n/a	28967.9091	show_cross	n/a	n/a	30	n/a	n/a	cross.bmp
+116.3861818182	n/a	29096.5455	show_face	unfamiliar_face	first_show	30	n/a	13	u058.bmp
+117.1889090909	n/a	29297.2273	right_press	n/a	n/a	30	n/a	4096	n/a
+117.258	n/a	29314.5	show_circle	n/a	n/a	30	n/a	0	circle.bmp
+118.958	n/a	29739.5	show_cross	n/a	n/a	31	n/a	n/a	cross.bmp
+119.44345454549999	n/a	29860.8636	show_face	scrambled_face	delayed_repeat	31	10	19	s148.bmp
+120.2852727273	n/a	30071.3182	right_press	n/a	n/a	31	n/a	4096	n/a
+120.408	n/a	30102.0	show_circle	n/a	n/a	31	n/a	0	circle.bmp
+122.108	n/a	30527.0	show_cross	n/a	n/a	32	n/a	n/a	cross.bmp
+122.5670909091	n/a	30641.7727	show_face	unfamiliar_face	first_show	32	n/a	13	u013.bmp
+123.1843636364	n/a	30796.0909	right_press	n/a	n/a	32	n/a	4096	n/a
+123.5170909091	n/a	30879.2727	show_circle	n/a	n/a	32	n/a	0	circle.bmp
+125.2170909091	n/a	31304.2727	show_cross	n/a	n/a	33	n/a	n/a	cross.bmp
+125.808	n/a	31452.0	show_face	unfamiliar_face	delayed_repeat	33	10	15	u136.bmp
+126.38527272729999	n/a	31596.3182	right_press	n/a	n/a	33	n/a	4096	n/a
+126.7361818182	n/a	31684.0455	show_circle	n/a	n/a	33	n/a	0	circle.bmp
+128.4361818182	n/a	32109.0455	show_cross	n/a	n/a	34	n/a	n/a	cross.bmp
+128.9489090909	n/a	32237.2273	show_face	famous_face	first_show	34	n/a	5	f003.bmp
+129.6707272727	n/a	32417.6818	left_press	n/a	n/a	34	n/a	256	n/a
+129.80072727270002	n/a	32450.1818	show_circle	n/a	n/a	34	n/a	0	circle.bmp
+131.5007272727	n/a	32875.1818	show_cross	n/a	n/a	35	n/a	n/a	cross.bmp
+132.07254545450002	n/a	33018.1364	show_face	unfamiliar_face	delayed_repeat	35	10	15	u053.bmp
+132.9625454545	n/a	33240.6364	show_circle	n/a	n/a	35	n/a	0	circle.bmp
+133.1043636364	n/a	33276.0909	right_press	n/a	n/a	35	n/a	4096	n/a
+134.66254545450002	n/a	33665.6364	show_cross	n/a	n/a	36	n/a	n/a	cross.bmp
+135.2461818182	n/a	33811.5455	show_face	scrambled_face	first_show	36	n/a	17	s086.bmp
+136.1189090909	n/a	34029.7273	left_press	n/a	n/a	36	n/a	256	n/a
+136.2589090909	n/a	34064.7273	show_circle	n/a	n/a	36	n/a	0	circle.bmp
+137.9589090909	n/a	34489.7273	show_cross	n/a	n/a	37	n/a	n/a	cross.bmp
+138.4870909091	n/a	34621.7727	show_face	famous_face	first_show	37	n/a	5	f043.bmp
+139.0307272727	n/a	34757.6818	right_press	n/a	n/a	37	n/a	4096	n/a
+139.4798181818	n/a	34869.9545	show_circle	n/a	n/a	37	n/a	0	circle.bmp
+141.17981818180002	n/a	35294.9545	show_cross	n/a	n/a	38	n/a	n/a	cross.bmp
+141.828	n/a	35457.0	show_face	famous_face	immediate_repeat	38	1	6	f043.bmp
+142.29254545450002	n/a	35573.1364	right_press	n/a	n/a	38	n/a	4096	n/a
+142.6989090909	n/a	35674.7273	show_circle	n/a	n/a	38	n/a	0	circle.bmp
+144.3989090909	n/a	36099.7273	show_cross	n/a	n/a	39	n/a	n/a	cross.bmp
+144.8689090909	n/a	36217.2273	show_face	unfamiliar_face	first_show	39	n/a	13	u014.bmp
+145.80436363639998	n/a	36451.0909	show_circle	n/a	n/a	39	n/a	0	circle.bmp
+145.9652727273	n/a	36491.3182	left_press	n/a	n/a	39	n/a	256	n/a
+147.5043636364	n/a	36876.0909	show_cross	n/a	n/a	40	n/a	n/a	cross.bmp
+148.1425454545	n/a	37035.6364	show_face	unfamiliar_face	delayed_repeat	40	10	15	u058.bmp
+149.0734545455	n/a	37268.3636	show_circle	n/a	n/a	40	n/a	0	circle.bmp
+149.238	n/a	37309.5	left_press	n/a	n/a	40	n/a	256	n/a
+150.7734545455	n/a	37693.3636	show_cross	n/a	n/a	41	n/a	n/a	cross.bmp
+151.3170909091	n/a	37829.2727	show_face	famous_face	first_show	41	n/a	5	f110.bmp
+152.138	n/a	38034.5	show_circle	n/a	n/a	41	n/a	0	circle.bmp
+152.24436363639998	n/a	38061.0909	right_press	n/a	n/a	41	n/a	4096	n/a
+153.838	n/a	38459.5	show_cross	n/a	n/a	42	n/a	n/a	cross.bmp
+154.4743636364	n/a	38618.5909	show_face	famous_face	immediate_repeat	42	1	6	f110.bmp
+155.2389090909	n/a	38809.7273	right_press	n/a	n/a	42	n/a	4096	n/a
+155.31345454549998	n/a	38828.3636	show_circle	n/a	n/a	42	n/a	0	circle.bmp
+157.0134545455	n/a	39253.3636	show_cross	n/a	n/a	43	n/a	n/a	cross.bmp
+157.5816363636	n/a	39395.4091	show_face	unfamiliar_face	delayed_repeat	43	11	15	u013.bmp
+158.4916363636	n/a	39622.9091	show_circle	n/a	n/a	43	n/a	0	circle.bmp
+158.8516363636	n/a	39712.9091	left_press	n/a	n/a	43	n/a	256	n/a
+160.1916363636	n/a	40047.9091	show_cross	n/a	n/a	44	n/a	n/a	cross.bmp
+160.6889090909	n/a	40172.2273	show_face	scrambled_face	first_show	44	n/a	17	s032.bmp
+161.5570909091	n/a	40389.2727	right_press	n/a	n/a	44	n/a	4096	n/a
+161.6052727273	n/a	40401.3182	show_circle	n/a	n/a	44	n/a	0	circle.bmp
+163.3052727273	n/a	40826.3182	show_cross	n/a	n/a	45	n/a	n/a	cross.bmp
+163.7952727273	n/a	40948.8182	show_face	scrambled_face	immediate_repeat	45	1	18	s032.bmp
+164.2398181818	n/a	41059.9545	right_press	n/a	n/a	45	n/a	4096	n/a
+164.808	n/a	41202.0	show_circle	n/a	n/a	45	n/a	0	circle.bmp
+166.508	n/a	41627.0	show_cross	n/a	n/a	46	n/a	n/a	cross.bmp
+167.0361818182	n/a	41759.0455	show_face	famous_face	delayed_repeat	46	12	7	f003.bmp
+167.7598181818	n/a	41939.9545	right_press	n/a	n/a	46	n/a	4096	n/a
+168.0189090909	n/a	42004.7273	show_circle	n/a	n/a	46	n/a	0	circle.bmp
+169.7189090909	n/a	42429.7273	show_cross	n/a	n/a	47	n/a	n/a	cross.bmp
+170.2107272727	n/a	42552.6818	show_face	famous_face	first_show	47	n/a	5	f030.bmp
+170.8698181818	n/a	42717.4545	right_press	n/a	n/a	47	n/a	4096	n/a
+171.20981818180002	n/a	42802.4545	show_circle	n/a	n/a	47	n/a	0	circle.bmp
+172.9098181818	n/a	43227.4545	show_cross	n/a	n/a	48	n/a	n/a	cross.bmp
+173.5016363636	n/a	43375.4091	show_face	famous_face	immediate_repeat	48	1	6	f030.bmp
+174.1289090909	n/a	43532.2273	right_press	n/a	n/a	48	n/a	4096	n/a
+174.4652727273	n/a	43616.3182	show_circle	n/a	n/a	48	n/a	0	circle.bmp
+176.1652727273	n/a	44041.3182	show_cross	n/a	n/a	49	n/a	n/a	cross.bmp
+176.7252727273	n/a	44181.3182	show_face	scrambled_face	delayed_repeat	49	13	19	s086.bmp
+177.4107272727	n/a	44352.6818	left_press	n/a	n/a	49	n/a	256	n/a
+177.6443636364	n/a	44411.0909	show_circle	n/a	n/a	49	n/a	0	circle.bmp
+179.3443636364	n/a	44836.0909	show_cross	n/a	n/a	50	n/a	n/a	cross.bmp
+179.8325454545	n/a	44958.1364	show_face	scrambled_face	first_show	50	n/a	17	s069.bmp
+180.428	n/a	45107.0	left_press	n/a	n/a	50	n/a	256	n/a
+180.7589090909	n/a	45189.7273	show_circle	n/a	n/a	50	n/a	0	circle.bmp
+182.4589090909	n/a	45614.7273	show_cross	n/a	n/a	51	n/a	n/a	cross.bmp
+182.9734545455	n/a	45743.3636	show_face	scrambled_face	immediate_repeat	51	1	18	s069.bmp
+183.98163636360002	n/a	45995.4091	show_circle	n/a	n/a	51	n/a	0	circle.bmp
+184.0825454545	n/a	46020.6364	right_press	n/a	n/a	51	n/a	4096	n/a
+185.6816363636	n/a	46420.4091	show_cross	n/a	n/a	52	n/a	n/a	cross.bmp
+186.33072727270002	n/a	46582.6818	show_face	scrambled_face	first_show	52	n/a	17	s096.bmp
+187.07254545450002	n/a	46768.1364	left_press	n/a	n/a	52	n/a	256	n/a
+187.3234545455	n/a	46830.8636	show_circle	n/a	n/a	52	n/a	0	circle.bmp
+189.0234545455	n/a	47255.8636	show_cross	n/a	n/a	53	n/a	n/a	cross.bmp
+189.47254545450002	n/a	47368.1364	show_face	unfamiliar_face	delayed_repeat	53	14	15	u014.bmp
+190.2198181818	n/a	47554.9545	left_press	n/a	n/a	53	n/a	256	n/a
+190.3361818182	n/a	47584.0455	show_circle	n/a	n/a	53	n/a	0	circle.bmp
+192.0361818182	n/a	48009.0455	show_cross	n/a	n/a	54	n/a	n/a	cross.bmp
+192.5452727273	n/a	48136.3182	show_face	famous_face	first_show	54	n/a	5	f009.bmp
+193.3334545455	n/a	48333.3636	right_press	n/a	n/a	54	n/a	4096	n/a
+193.5161818182	n/a	48379.0455	show_circle	n/a	n/a	54	n/a	0	circle.bmp
+195.2161818182	n/a	48804.0455	show_cross	n/a	n/a	55	n/a	n/a	cross.bmp
+195.6525454545	n/a	48913.1364	show_face	famous_face	immediate_repeat	55	1	6	f009.bmp
+196.1398181818	n/a	49034.9545	right_press	n/a	n/a	55	n/a	4096	n/a
+196.65345454549998	n/a	49163.3636	show_circle	n/a	n/a	55	n/a	0	circle.bmp
+198.3534545455	n/a	49588.3636	show_cross	n/a	n/a	56	n/a	n/a	cross.bmp
+198.97709090909999	n/a	49744.2727	show_face	famous_face	first_show	56	n/a	5	f100.bmp
+199.7307272727	n/a	49932.6818	right_press	n/a	n/a	56	n/a	4096	n/a
+199.9707272727	n/a	49992.6818	show_circle	n/a	n/a	56	n/a	0	circle.bmp
+201.6707272727	n/a	50417.6818	show_cross	n/a	n/a	57	n/a	n/a	cross.bmp
+202.318	n/a	50579.5	show_face	unfamiliar_face	first_show	57	n/a	13	u030.bmp
+203.308	n/a	50827.0	show_circle	n/a	n/a	57	n/a	0	circle.bmp
+203.7234545455	n/a	50930.8636	left_press	n/a	n/a	57	n/a	256	n/a
+205.008	n/a	51252.0	show_cross	n/a	n/a	58	n/a	n/a	cross.bmp
+205.54163636360002	n/a	51385.4091	show_face	famous_face	first_show	58	n/a	5	f111.bmp
+206.2670909091	n/a	51566.7727	right_press	n/a	n/a	58	n/a	4096	n/a
+206.4043636364	n/a	51601.0909	show_circle	n/a	n/a	58	n/a	0	circle.bmp
+208.1043636364	n/a	52026.0909	show_cross	n/a	n/a	59	n/a	n/a	cross.bmp
+208.6661818182	n/a	52166.5455	show_face	famous_face	immediate_repeat	59	1	6	f111.bmp
+209.1443636364	n/a	52286.0909	right_press	n/a	n/a	59	n/a	4096	n/a
+209.5389090909	n/a	52384.7273	show_circle	n/a	n/a	59	n/a	0	circle.bmp
+211.2389090909	n/a	52809.7273	show_cross	n/a	n/a	60	n/a	n/a	cross.bmp
+211.72254545450002	n/a	52930.6364	show_face	unfamiliar_face	first_show	60	n/a	13	u015.bmp
+212.3716363636	n/a	53092.9091	left_press	n/a	n/a	60	n/a	256	n/a
+212.6361818182	n/a	53159.0455	show_circle	n/a	n/a	60	n/a	0	circle.bmp
+214.3361818182	n/a	53584.0455	show_cross	n/a	n/a	61	n/a	n/a	cross.bmp
+214.8470909091	n/a	53711.7727	show_face	unfamiliar_face	immediate_repeat	61	1	14	u015.bmp
+215.3661818182	n/a	53841.5455	left_press	n/a	n/a	61	n/a	256	n/a
+215.8625454545	n/a	53965.6364	show_circle	n/a	n/a	61	n/a	0	circle.bmp
+217.5625454545	n/a	54390.6364	show_cross	n/a	n/a	62	n/a	n/a	cross.bmp
+218.1707272727	n/a	54542.6818	show_face	scrambled_face	delayed_repeat	62	10	19	s096.bmp
+218.8398181818	n/a	54709.9545	left_press	n/a	n/a	62	n/a	256	n/a
+219.0307272727	n/a	54757.6818	show_circle	n/a	n/a	62	n/a	0	circle.bmp
+220.7307272727	n/a	55182.6818	show_cross	n/a	n/a	63	n/a	n/a	cross.bmp
+221.3116363636	n/a	55327.9091	show_face	famous_face	first_show	63	n/a	5	f042.bmp
+222.1398181818	n/a	55534.9545	right_press	n/a	n/a	63	n/a	4096	n/a
+222.29618181819998	n/a	55574.0455	show_circle	n/a	n/a	63	n/a	0	circle.bmp
+223.9961818182	n/a	55999.0455	show_cross	n/a	n/a	64	n/a	n/a	cross.bmp
+224.5861818182	n/a	56146.5455	show_face	famous_face	immediate_repeat	64	1	6	f042.bmp
+225.2407272727	n/a	56310.1818	right_press	n/a	n/a	64	n/a	4096	n/a
+225.4434545455	n/a	56360.8636	show_circle	n/a	n/a	64	n/a	0	circle.bmp
+227.1434545455	n/a	56785.8636	show_cross	n/a	n/a	65	n/a	n/a	cross.bmp
+227.7934545455	n/a	56948.3636	show_face	unfamiliar_face	first_show	65	n/a	13	u093.bmp
+228.488	n/a	57122.0	left_press	n/a	n/a	65	n/a	256	n/a
+228.7025454545	n/a	57175.6364	show_circle	n/a	n/a	65	n/a	0	circle.bmp
+230.4025454545	n/a	57600.6364	show_cross	n/a	n/a	66	n/a	n/a	cross.bmp
+230.9834545455	n/a	57745.8636	show_face	famous_face	delayed_repeat	66	10	7	f100.bmp
+231.5589090909	n/a	57889.7273	right_press	n/a	n/a	66	n/a	4096	n/a
+231.8589090909	n/a	57964.7273	show_circle	n/a	n/a	66	n/a	0	circle.bmp
+233.5589090909	n/a	58389.7273	show_cross	n/a	n/a	67	n/a	n/a	cross.bmp
+234.1407272727	n/a	58535.1818	show_face	scrambled_face	first_show	67	n/a	17	s039.bmp
+234.9834545455	n/a	58745.8636	right_press	n/a	n/a	67	n/a	4096	n/a
+235.0325454545	n/a	58758.1364	show_circle	n/a	n/a	67	n/a	0	circle.bmp
+236.7325454545	n/a	59183.1364	show_cross	n/a	n/a	68	n/a	n/a	cross.bmp
+237.3652727273	n/a	59341.3182	show_face	unfamiliar_face	delayed_repeat	68	11	15	u030.bmp
+237.9989090909	n/a	59499.7273	left_press	n/a	n/a	68	n/a	256	n/a
+238.3798181818	n/a	59594.9545	show_circle	n/a	n/a	68	n/a	0	circle.bmp
+240.0798181818	n/a	60019.9545	show_cross	n/a	n/a	69	n/a	n/a	cross.bmp
+240.6398181818	n/a	60159.9545	show_face	scrambled_face	first_show	69	n/a	17	s059.bmp
+241.37345454549998	n/a	60343.3636	left_press	n/a	n/a	69	n/a	256	n/a
+241.4934545455	n/a	60373.3636	show_circle	n/a	n/a	69	n/a	0	circle.bmp
+243.1934545455	n/a	60798.3636	show_cross	n/a	n/a	70	n/a	n/a	cross.bmp
+243.6634545455	n/a	60915.8636	show_face	scrambled_face	immediate_repeat	70	1	18	s059.bmp
+244.41254545450002	n/a	61103.1364	left_press	n/a	n/a	70	n/a	256	n/a
+244.6198181818	n/a	61154.9545	show_circle	n/a	n/a	70	n/a	0	circle.bmp
+246.3198181818	n/a	61579.9545	show_cross	n/a	n/a	71	n/a	n/a	cross.bmp
+246.8034545455	n/a	61700.8636	show_face	scrambled_face	first_show	71	n/a	17	s050.bmp
+247.3707272727	n/a	61842.6818	left_press	n/a	n/a	71	n/a	256	n/a
+247.68345454549998	n/a	61920.8636	show_circle	n/a	n/a	71	n/a	0	circle.bmp
+249.3834545455	n/a	62345.8636	show_cross	n/a	n/a	72	n/a	n/a	cross.bmp
+250.0107272727	n/a	62502.6818	show_face	scrambled_face	first_show	72	n/a	17	s089.bmp
+250.7516363636	n/a	62687.9091	left_press	n/a	n/a	72	n/a	256	n/a
+250.9307272727	n/a	62732.6818	show_circle	n/a	n/a	72	n/a	0	circle.bmp
+252.6307272727	n/a	63157.6818	show_cross	n/a	n/a	73	n/a	n/a	cross.bmp
+253.2516363636	n/a	63312.9091	show_face	famous_face	first_show	73	n/a	5	f130.bmp
+253.7843636364	n/a	63446.0909	right_press	n/a	n/a	73	n/a	4096	n/a
+254.2407272727	n/a	63560.1818	show_circle	n/a	n/a	73	n/a	0	circle.bmp
+255.9407272727	n/a	63985.1818	show_cross	n/a	n/a	74	n/a	n/a	cross.bmp
+256.4089090909	n/a	64102.2273	show_face	famous_face	immediate_repeat	74	1	6	f130.bmp
+256.9107272727	n/a	64227.6818	right_press	n/a	n/a	74	n/a	4096	n/a
+257.3007272727	n/a	64325.1818	show_circle	n/a	n/a	74	n/a	0	circle.bmp
+259.00072727270003	n/a	64750.1818	show_cross	n/a	n/a	75	n/a	n/a	cross.bmp
+259.6161818182	n/a	64904.0455	show_face	unfamiliar_face	delayed_repeat	75	10	15	u093.bmp
+260.4861818182	n/a	65121.5455	left_press	n/a	n/a	75	n/a	256	n/a
+260.5207272727	n/a	65130.1818	show_circle	n/a	n/a	75	n/a	0	circle.bmp
+262.2207272727	n/a	65555.1818	show_cross	n/a	n/a	76	n/a	n/a	cross.bmp
+262.7907272727	n/a	65697.6818	show_face	unfamiliar_face	first_show	76	n/a	13	u042.bmp
+263.5189090909	n/a	65879.7273	right_press	n/a	n/a	76	n/a	4096	n/a
+263.6470909091	n/a	65911.7727	show_circle	n/a	n/a	76	n/a	0	circle.bmp
+265.3470909091	n/a	66336.7727	show_cross	n/a	n/a	77	n/a	n/a	cross.bmp
+265.9307272727	n/a	66482.6818	show_face	unfamiliar_face	immediate_repeat	77	1	14	u042.bmp
+266.5225454545	n/a	66630.6364	right_press	n/a	n/a	77	n/a	4096	n/a
+266.858	n/a	66714.5	show_circle	n/a	n/a	77	n/a	0	circle.bmp
+268.558	n/a	67139.5	show_cross	n/a	n/a	78	n/a	n/a	cross.bmp
+269.0552727273	n/a	67263.8182	show_face	scrambled_face	delayed_repeat	78	11	19	s039.bmp
+270.0489090909	n/a	67512.2273	show_circle	n/a	n/a	78	n/a	0	circle.bmp
+271.7489090909	n/a	67937.2273	show_cross	n/a	n/a	79	n/a	n/a	cross.bmp
+272.3961818182	n/a	68099.0455	show_face	scrambled_face	first_show	79	n/a	17	s145.bmp
+273.3125454545	n/a	68328.1364	show_circle	n/a	n/a	79	n/a	0	circle.bmp
+275.0125454545	n/a	68753.1364	show_cross	n/a	n/a	80	n/a	n/a	cross.bmp
+275.4861818182	n/a	68871.5455	show_face	unfamiliar_face	first_show	80	n/a	13	u094.bmp
+276.13890909090003	n/a	69034.7273	right_press	n/a	n/a	80	n/a	4096	n/a
+276.3398181818	n/a	69084.9545	show_circle	n/a	n/a	80	n/a	0	circle.bmp
+278.0398181818	n/a	69509.9545	show_cross	n/a	n/a	81	n/a	n/a	cross.bmp
+278.5934545455	n/a	69648.3636	show_face	unfamiliar_face	immediate_repeat	81	1	14	u094.bmp
+279.00981818180003	n/a	69752.4545	right_press	n/a	n/a	81	n/a	4096	n/a
+279.4534545455	n/a	69863.3636	show_circle	n/a	n/a	81	n/a	0	circle.bmp
+281.1534545455	n/a	70288.3636	show_cross	n/a	n/a	82	n/a	n/a	cross.bmp
+281.7843636364	n/a	70446.0909	show_face	scrambled_face	delayed_repeat	82	11	19	s050.bmp
+282.4889090909	n/a	70622.2273	left_press	n/a	n/a	82	n/a	256	n/a
+282.7234545455	n/a	70680.8636	show_circle	n/a	n/a	82	n/a	0	circle.bmp
+284.42345454549996	n/a	71105.8636	show_cross	n/a	n/a	83	n/a	n/a	cross.bmp
+285.0752727273	n/a	71268.8182	show_face	unfamiliar_face	first_show	83	n/a	13	u131.bmp
+285.7898181818	n/a	71447.4545	left_press	n/a	n/a	83	n/a	256	n/a
+286.0907272727	n/a	71522.6818	show_circle	n/a	n/a	83	n/a	0	circle.bmp
+287.7907272727	n/a	71947.6818	show_cross	n/a	n/a	84	n/a	n/a	cross.bmp
+288.43254545450003	n/a	72108.1364	show_face	scrambled_face	delayed_repeat	84	12	19	s089.bmp
+289.1998181818	n/a	72299.9545	right_press	n/a	n/a	84	n/a	4096	n/a
+289.3698181818	n/a	72342.4545	show_circle	n/a	n/a	84	n/a	0	circle.bmp
+291.06981818180003	n/a	72767.4545	show_cross	n/a	n/a	85	n/a	n/a	cross.bmp
+291.67345454549996	n/a	72918.3636	show_face	unfamiliar_face	first_show	85	n/a	13	u006.bmp
+292.5834545455	n/a	73145.8636	right_press	n/a	n/a	85	n/a	4096	n/a
+292.6416363636	n/a	73160.4091	show_circle	n/a	n/a	85	n/a	0	circle.bmp
+294.3416363636	n/a	73585.4091	show_cross	n/a	n/a	86	n/a	n/a	cross.bmp
+294.798	n/a	73699.5	show_face	unfamiliar_face	immediate_repeat	86	1	14	u006.bmp
+295.2443636364	n/a	73811.0909	right_press	n/a	n/a	86	n/a	4096	n/a
+295.6407272727	n/a	73910.1818	show_circle	n/a	n/a	86	n/a	0	circle.bmp
+297.3407272727	n/a	74335.1818	show_cross	n/a	n/a	87	n/a	n/a	cross.bmp
+297.85436363639997	n/a	74463.5909	show_face	famous_face	first_show	87	n/a	5	f002.bmp
+298.5570909091	n/a	74639.2727	right_press	n/a	n/a	87	n/a	4096	n/a
+298.8607272727	n/a	74715.1818	show_circle	n/a	n/a	87	n/a	0	circle.bmp
+300.5607272727	n/a	75140.1818	show_cross	n/a	n/a	88	n/a	n/a	cross.bmp
+301.1961818182	n/a	75299.0455	show_face	unfamiliar_face	first_show	88	n/a	13	u032.bmp
+301.8989090909	n/a	75474.7273	left_press	n/a	n/a	88	n/a	256	n/a
+302.1325454545	n/a	75533.1364	show_circle	n/a	n/a	88	n/a	0	circle.bmp
+303.8325454545	n/a	75958.1364	show_cross	n/a	n/a	89	n/a	n/a	cross.bmp
+304.4698181818	n/a	76117.4545	show_face	unfamiliar_face	immediate_repeat	89	1	14	u032.bmp
+304.8898181818	n/a	76222.4545	right_press	n/a	n/a	89	n/a	4096	n/a
+305.3298181818	n/a	76332.4545	show_circle	n/a	n/a	89	n/a	0	circle.bmp
+307.0298181818	n/a	76757.4545	show_cross	n/a	n/a	90	n/a	n/a	cross.bmp
+307.6607272727	n/a	76915.1818	show_face	scrambled_face	delayed_repeat	90	11	19	s145.bmp
+308.6352727273	n/a	77158.8182	show_circle	n/a	n/a	90	n/a	0	circle.bmp
+309.0598181818	n/a	77264.9545	right_press	n/a	n/a	90	n/a	4096	n/a
+310.3352727273	n/a	77583.8182	show_cross	n/a	n/a	91	n/a	n/a	cross.bmp
+310.9516363636	n/a	77737.9091	show_face	unfamiliar_face	first_show	91	n/a	13	u080.bmp
+311.658	n/a	77914.5	right_press	n/a	n/a	91	n/a	4096	n/a
+311.848	n/a	77962.0	show_circle	n/a	n/a	91	n/a	0	circle.bmp
+313.548	n/a	78387.0	show_cross	n/a	n/a	92	n/a	n/a	cross.bmp
+314.0589090909	n/a	78514.7273	show_face	unfamiliar_face	immediate_repeat	92	1	14	u080.bmp
+314.75981818180003	n/a	78689.9545	right_press	n/a	n/a	92	n/a	4096	n/a
+314.9170909091	n/a	78729.2727	show_circle	n/a	n/a	92	n/a	0	circle.bmp
+314.918	n/a	78729.5	show_circle	n/a	n/a	92	n/a	0	circle.bmp
+316.6170909091	n/a	79154.2727	show_cross	n/a	n/a	93	n/a	n/a	cross.bmp
+316.618	n/a	79154.5	show_cross	n/a	n/a	94	n/a	n/a	cross.bmp
+317.21618181819997	n/a	79304.0455	show_face	scrambled_face	first_show	94	n/a	17	s073.bmp
+317.8098181818	n/a	79452.4545	left_press	n/a	n/a	94	n/a	256	n/a
+318.0716363636	n/a	79517.9091	show_circle	n/a	n/a	94	n/a	0	circle.bmp
+319.7716363636	n/a	79942.9091	show_cross	n/a	n/a	95	n/a	n/a	cross.bmp
+320.3398181818	n/a	80084.9545	show_face	unfamiliar_face	delayed_repeat	95	12	15	u131.bmp
+321.0943636364	n/a	80273.5909	left_press	n/a	n/a	95	n/a	256	n/a
+321.1807272727	n/a	80295.1818	show_circle	n/a	n/a	95	n/a	0	circle.bmp
+322.8807272727	n/a	80720.1818	show_cross	n/a	n/a	96	n/a	n/a	cross.bmp
+323.4970909091	n/a	80874.2727	show_face	famous_face	first_show	96	n/a	5	f103.bmp
+324.3261818182	n/a	81081.5455	show_circle	n/a	n/a	96	n/a	0	circle.bmp
+324.6361818182	n/a	81159.0455	right_press	n/a	n/a	96	n/a	4096	n/a
+326.0261818182	n/a	81506.5455	show_cross	n/a	n/a	97	n/a	n/a	cross.bmp
+326.6707272727	n/a	81667.6818	show_face	famous_face	first_show	97	n/a	5	f035.bmp
+327.4034545455	n/a	81850.8636	left_press	n/a	n/a	97	n/a	256	n/a
+327.6416363636	n/a	81910.4091	show_circle	n/a	n/a	97	n/a	0	circle.bmp
+329.3416363636	n/a	82335.4091	show_cross	n/a	n/a	98	n/a	n/a	cross.bmp
+329.81163636360003	n/a	82452.9091	show_face	famous_face	delayed_repeat	98	11	7	f002.bmp
+330.7070909091	n/a	82676.7727	show_circle	n/a	n/a	98	n/a	0	circle.bmp
+330.75072727270003	n/a	82687.6818	right_press	n/a	n/a	98	n/a	4096	n/a
+332.4070909091	n/a	83101.7727	show_cross	n/a	n/a	99	n/a	n/a	cross.bmp
+333.0025454545	n/a	83250.6364	show_face	scrambled_face	first_show	99	n/a	17	s097.bmp
+333.7216363636	n/a	83430.4091	right_press	n/a	n/a	99	n/a	4096	n/a
+333.9707272727	n/a	83492.6818	show_circle	n/a	n/a	99	n/a	0	circle.bmp
+335.6707272727	n/a	83917.6818	show_cross	n/a	n/a	100	n/a	n/a	cross.bmp
+336.1598181818	n/a	84039.9545	show_face	unfamiliar_face	first_show	100	n/a	13	u008.bmp
+336.8425454545	n/a	84210.6364	left_press	n/a	n/a	100	n/a	256	n/a
+337.118	n/a	84279.5	show_circle	n/a	n/a	100	n/a	0	circle.bmp
+338.818	n/a	84704.5	show_cross	n/a	n/a	101	n/a	n/a	cross.bmp
+339.3170909091	n/a	84829.2727	show_face	unfamiliar_face	first_show	101	n/a	13	u046.bmp
+339.9552727273	n/a	84988.8182	left_press	n/a	n/a	101	n/a	256	n/a
+340.1689090909	n/a	85042.2273	show_circle	n/a	n/a	101	n/a	0	circle.bmp
+341.8689090909	n/a	85467.2273	show_cross	n/a	n/a	102	n/a	n/a	cross.bmp
+342.308	n/a	85577.0	show_face	scrambled_face	delayed_repeat	102	8	19	s073.bmp
+343.06981818180003	n/a	85767.4545	left_press	n/a	n/a	102	n/a	256	n/a
+343.2043636364	n/a	85801.0909	show_circle	n/a	n/a	102	n/a	0	circle.bmp
+344.9043636364	n/a	86226.0909	show_cross	n/a	n/a	103	n/a	n/a	cross.bmp
+345.3643636364	n/a	86341.0909	show_face	famous_face	first_show	103	n/a	5	f049.bmp
+346.1816363636	n/a	86545.4091	show_circle	n/a	n/a	103	n/a	0	circle.bmp
+346.8961818182	n/a	86724.0455	right_press	n/a	n/a	103	n/a	4096	n/a
+347.8816363636	n/a	86970.4091	show_cross	n/a	n/a	104	n/a	n/a	cross.bmp
+348.5043636364	n/a	87126.0909	show_face	famous_face	immediate_repeat	104	1	6	f049.bmp
+349.44709090910004	n/a	87361.7727	show_circle	n/a	n/a	104	n/a	0	circle.bmp
+349.5634545455	n/a	87390.8636	right_press	n/a	n/a	104	n/a	4096	n/a
+351.14709090910003	n/a	87786.7727	show_cross	n/a	n/a	105	n/a	n/a	cross.bmp
+351.5952727273	n/a	87898.8182	show_face	famous_face	delayed_repeat	105	9	7	f103.bmp
+352.33527272730004	n/a	88083.8182	right_press	n/a	n/a	105	n/a	4096	n/a
+352.6034545455	n/a	88150.8636	show_circle	n/a	n/a	105	n/a	0	circle.bmp
+354.3034545455	n/a	88575.8636	show_cross	n/a	n/a	106	n/a	n/a	cross.bmp
+354.8025454545	n/a	88700.6364	show_face	scrambled_face	first_show	106	n/a	17	s108.bmp
+355.61709090910006	n/a	88904.2727	right_press	n/a	n/a	106	n/a	4096	n/a
+355.6725454545	n/a	88918.1364	show_circle	n/a	n/a	106	n/a	0	circle.bmp
+357.37254545449997	n/a	89343.1364	show_cross	n/a	n/a	107	n/a	n/a	cross.bmp
+357.9761818182	n/a	89494.0455	show_face	scrambled_face	immediate_repeat	107	1	18	s108.bmp
+358.5516363636	n/a	89637.9091	right_press	n/a	n/a	107	n/a	4096	n/a
+358.828	n/a	89707.0	show_circle	n/a	n/a	107	n/a	0	circle.bmp
+360.528	n/a	90132.0	show_cross	n/a	n/a	108	n/a	n/a	cross.bmp
+361.06709090910005	n/a	90266.7727	show_face	famous_face	delayed_repeat	108	11	7	f035.bmp
+361.76709090910003	n/a	90441.7727	left_press	n/a	n/a	108	n/a	256	n/a
+362.0161818182	n/a	90504.0455	show_circle	n/a	n/a	108	n/a	0	circle.bmp
+363.71618181819997	n/a	90929.0455	show_cross	n/a	n/a	109	n/a	n/a	cross.bmp
+364.3243636364	n/a	91081.0909	show_face	famous_face	first_show	109	n/a	5	f096.bmp
+365.2916363636	n/a	91322.9091	right_press	n/a	n/a	109	n/a	4096	n/a
+365.3034545455	n/a	91325.8636	show_circle	n/a	n/a	109	n/a	0	circle.bmp
+367.0034545455	n/a	91750.8636	show_cross	n/a	n/a	110	n/a	n/a	cross.bmp
+367.46527272730003	n/a	91866.3182	show_face	famous_face	immediate_repeat	110	1	6	f096.bmp
+368.10436363639997	n/a	92026.0909	right_press	n/a	n/a	110	n/a	4096	n/a
+368.4243636364	n/a	92106.0909	show_circle	n/a	n/a	110	n/a	0	circle.bmp
+370.1243636364	n/a	92531.0909	show_cross	n/a	n/a	111	n/a	n/a	cross.bmp
+370.62254545449997	n/a	92655.6364	show_face	scrambled_face	delayed_repeat	111	12	19	s097.bmp
+371.4798181818	n/a	92869.9545	show_circle	n/a	n/a	111	n/a	0	circle.bmp
+371.6716363636	n/a	92917.9091	left_press	n/a	n/a	111	n/a	256	n/a
+373.1798181818	n/a	93294.9545	show_cross	n/a	n/a	112	n/a	n/a	cross.bmp
+373.71254545449995	n/a	93428.1364	show_face	famous_face	first_show	112	n/a	5	f014.bmp
+374.568	n/a	93642.0	show_circle	n/a	n/a	112	n/a	0	circle.bmp
+374.6389090909	n/a	93659.7273	right_press	n/a	n/a	112	n/a	4096	n/a
+376.268	n/a	94067.0	show_cross	n/a	n/a	113	n/a	n/a	cross.bmp
+376.8698181818	n/a	94217.4545	show_face	unfamiliar_face	delayed_repeat	113	13	15	u008.bmp
+377.4252727273	n/a	94356.3182	left_press	n/a	n/a	113	n/a	256	n/a
+377.7343636364	n/a	94433.5909	show_circle	n/a	n/a	113	n/a	0	circle.bmp
+379.4343636364	n/a	94858.5909	show_cross	n/a	n/a	114	n/a	n/a	cross.bmp
+380.0270909091	n/a	95006.7727	show_face	unfamiliar_face	first_show	114	n/a	13	u109.bmp
+381.038	n/a	95259.5	show_circle	n/a	n/a	114	n/a	0	circle.bmp
+381.21254545449995	n/a	95303.1364	left_press	n/a	n/a	114	n/a	256	n/a
+382.738	n/a	95684.5	show_cross	n/a	n/a	115	n/a	n/a	cross.bmp
+383.3689090909	n/a	95842.2273	show_face	unfamiliar_face	immediate_repeat	115	1	14	u109.bmp
+384.0343636364	n/a	96008.5909	left_press	n/a	n/a	115	n/a	256	n/a
+384.3161818182	n/a	96079.0455	show_circle	n/a	n/a	115	n/a	0	circle.bmp
+386.0161818182	n/a	96504.0455	show_cross	n/a	n/a	116	n/a	n/a	cross.bmp
+386.64254545449995	n/a	96660.6364	show_face	unfamiliar_face	delayed_repeat	116	15	15	u046.bmp
+387.258	n/a	96814.5	left_press	n/a	n/a	116	n/a	256	n/a
+387.54890909089994	n/a	96887.2273	show_circle	n/a	n/a	116	n/a	0	circle.bmp
+389.2489090909	n/a	97312.2273	show_cross	n/a	n/a	117	n/a	n/a	cross.bmp
+389.71618181819997	n/a	97429.0455	show_face	unfamiliar_face	first_show	117	n/a	13	u043.bmp
+390.51709090910003	n/a	97629.2727	left_press	n/a	n/a	117	n/a	256	n/a
+390.5534545455	n/a	97638.3636	show_circle	n/a	n/a	117	n/a	0	circle.bmp
+392.2534545455	n/a	98063.3636	show_cross	n/a	n/a	118	n/a	n/a	cross.bmp
+392.7398181818	n/a	98184.9545	show_face	unfamiliar_face	immediate_repeat	118	1	14	u043.bmp
+393.3107272727	n/a	98327.6818	left_press	n/a	n/a	118	n/a	256	n/a
+393.57072727269997	n/a	98392.6818	show_circle	n/a	n/a	118	n/a	0	circle.bmp
+395.27072727269996	n/a	98817.6818	show_cross	n/a	n/a	119	n/a	n/a	cross.bmp
+395.76345454550005	n/a	98940.8636	show_face	unfamiliar_face	first_show	119	n/a	13	u026.bmp
+396.4798181818	n/a	99119.9545	left_press	n/a	n/a	119	n/a	256	n/a
+396.64709090910003	n/a	99161.7727	show_circle	n/a	n/a	119	n/a	0	circle.bmp
+398.3470909091	n/a	99586.7727	show_cross	n/a	n/a	120	n/a	n/a	cross.bmp
+398.97072727269995	n/a	99742.6818	show_face	unfamiliar_face	first_show	120	n/a	13	u133.bmp
+399.7543636364	n/a	99938.5909	left_press	n/a	n/a	120	n/a	256	n/a
+399.898	n/a	99974.5	show_circle	n/a	n/a	120	n/a	0	circle.bmp
+401.598	n/a	100399.5	show_cross	n/a	n/a	121	n/a	n/a	cross.bmp
+402.1116363636	n/a	100527.9091	show_face	unfamiliar_face	immediate_repeat	121	1	14	u133.bmp
+402.97890909089995	n/a	100744.7273	show_circle	n/a	n/a	121	n/a	0	circle.bmp
+404.67890909089994	n/a	101169.7273	show_cross	n/a	n/a	122	n/a	n/a	cross.bmp
+405.2852727273	n/a	101321.3182	show_face	famous_face	first_show	122	n/a	5	f044.bmp
+406.24709090910005	n/a	101561.7727	show_circle	n/a	n/a	122	n/a	0	circle.bmp
+407.94709090910004	n/a	101986.7727	show_cross	n/a	n/a	123	n/a	n/a	cross.bmp
+408.44254545449996	n/a	102110.6364	show_face	famous_face	immediate_repeat	123	1	6	f044.bmp
+409.2952727273	n/a	102323.8182	right_press	n/a	n/a	123	n/a	4096	n/a
+409.3361818182	n/a	102334.0455	show_circle	n/a	n/a	123	n/a	0	circle.bmp
+411.0361818182	n/a	102759.0455	show_cross	n/a	n/a	124	n/a	n/a	cross.bmp
+411.4998181818	n/a	102874.9545	show_face	famous_face	delayed_repeat	124	12	7	f014.bmp
+412.3398181818	n/a	103084.9545	right_press	n/a	n/a	124	n/a	4096	n/a
+412.39527272730004	n/a	103098.8182	show_circle	n/a	n/a	124	n/a	0	circle.bmp
+414.0952727273	n/a	103523.8182	show_cross	n/a	n/a	125	n/a	n/a	cross.bmp
+414.64072727269996	n/a	103660.1818	show_face	famous_face	first_show	125	n/a	5	f085.bmp
+415.33345454550005	n/a	103833.3636	right_press	n/a	n/a	125	n/a	4096	n/a
+415.478	n/a	103869.5	show_circle	n/a	n/a	125	n/a	0	circle.bmp
+417.178	n/a	104294.5	show_cross	n/a	n/a	126	n/a	n/a	cross.bmp
+417.78072727269995	n/a	104445.1818	show_face	famous_face	first_show	126	n/a	5	f123.bmp
+418.2861818182	n/a	104571.5455	right_press	n/a	n/a	126	n/a	4096	n/a
+418.60436363639997	n/a	104651.0909	show_circle	n/a	n/a	126	n/a	0	circle.bmp
+420.3043636364	n/a	105076.0909	show_cross	n/a	n/a	127	n/a	n/a	cross.bmp
+420.75527272730005	n/a	105188.8182	show_face	famous_face	immediate_repeat	127	1	6	f123.bmp
+421.27072727269996	n/a	105317.6818	right_press	n/a	n/a	127	n/a	4096	n/a
+421.66890909089994	n/a	105417.2273	show_circle	n/a	n/a	127	n/a	0	circle.bmp
+423.3689090909	n/a	105842.2273	show_cross	n/a	n/a	128	n/a	n/a	cross.bmp
+423.9116363636	n/a	105977.9091	show_face	unfamiliar_face	first_show	128	n/a	13	u115.bmp
+424.7589090909	n/a	106189.7273	right_press	n/a	n/a	128	n/a	4096	n/a
+424.8898181818	n/a	106222.4545	show_circle	n/a	n/a	128	n/a	0	circle.bmp
+426.5898181818	n/a	106647.4545	show_cross	n/a	n/a	129	n/a	n/a	cross.bmp
+427.1698181818	n/a	106792.4545	show_face	unfamiliar_face	immediate_repeat	129	1	14	u115.bmp
+427.82709090910004	n/a	106956.7727	right_press	n/a	n/a	129	n/a	4096	n/a
+428.14254545449995	n/a	107035.6364	show_circle	n/a	n/a	129	n/a	0	circle.bmp
+429.84254545449994	n/a	107460.6364	show_cross	n/a	n/a	130	n/a	n/a	cross.bmp
+430.3598181818	n/a	107589.9545	show_face	unfamiliar_face	delayed_repeat	130	11	15	u026.bmp
+431.24709090910005	n/a	107811.7727	left_press	n/a	n/a	130	n/a	256	n/a
+431.2507272727	n/a	107812.6818	show_circle	n/a	n/a	130	n/a	0	circle.bmp
+432.95072727269996	n/a	108237.6818	show_cross	n/a	n/a	131	n/a	n/a	cross.bmp
+433.4843636364	n/a	108371.0909	show_face	unfamiliar_face	first_show	131	n/a	13	u119.bmp
+434.09345454550004	n/a	108523.3636	right_press	n/a	n/a	131	n/a	4096	n/a
+434.4807272727	n/a	108620.1818	show_circle	n/a	n/a	131	n/a	0	circle.bmp
+436.1807272727	n/a	109045.1818	show_cross	n/a	n/a	132	n/a	n/a	cross.bmp
+436.6416363636	n/a	109160.4091	show_face	famous_face	first_show	132	n/a	5	f057.bmp
+437.32527272730005	n/a	109331.3182	right_press	n/a	n/a	132	n/a	4096	n/a
+437.52890909089996	n/a	109382.2273	show_circle	n/a	n/a	132	n/a	0	circle.bmp
+439.22890909089995	n/a	109807.2273	show_cross	n/a	n/a	133	n/a	n/a	cross.bmp
+439.71527272730003	n/a	109928.8182	show_face	scrambled_face	first_show	133	n/a	17	s023.bmp
+440.3316363636	n/a	110082.9091	left_press	n/a	n/a	133	n/a	256	n/a
+440.53345454550004	n/a	110133.3636	show_circle	n/a	n/a	133	n/a	0	circle.bmp
+442.2334545455	n/a	110558.3636	show_cross	n/a	n/a	134	n/a	n/a	cross.bmp
+442.82254545449996	n/a	110705.6364	show_face	famous_face	delayed_repeat	134	9	7	f085.bmp
+443.6189090909	n/a	110904.7273	right_press	n/a	n/a	134	n/a	4096	n/a
+443.64527272730004	n/a	110911.3182	show_circle	n/a	n/a	134	n/a	0	circle.bmp
+445.3452727273	n/a	111336.3182	show_cross	n/a	n/a	135	n/a	n/a	cross.bmp
+445.9298181818	n/a	111482.4545	show_face	scrambled_face	first_show	135	n/a	17	s140.bmp
+446.5261818182	n/a	111631.5455	right_press	n/a	n/a	135	n/a	4096	n/a
+446.81254545449997	n/a	111703.1364	show_circle	n/a	n/a	135	n/a	0	circle.bmp
+448.51254545449996	n/a	112128.1364	show_cross	n/a	n/a	136	n/a	n/a	cross.bmp
+449.0870909091	n/a	112271.7727	show_face	unfamiliar_face	first_show	136	n/a	13	u114.bmp
+449.8443636364	n/a	112461.0909	right_press	n/a	n/a	136	n/a	4096	n/a
+450.0007272727	n/a	112500.1818	show_circle	n/a	n/a	136	n/a	0	circle.bmp
+451.70072727269996	n/a	112925.1818	show_cross	n/a	n/a	137	n/a	n/a	cross.bmp
+452.3107272727	n/a	113077.6818	show_face	unfamiliar_face	immediate_repeat	137	1	14	u114.bmp
+452.878	n/a	113219.5	right_press	n/a	n/a	137	n/a	4096	n/a
+453.1652727273	n/a	113291.3182	show_circle	n/a	n/a	137	n/a	0	circle.bmp
+454.8652727273	n/a	113716.3182	show_cross	n/a	n/a	138	n/a	n/a	cross.bmp
+455.4516363636	n/a	113862.9091	show_face	famous_face	first_show	138	n/a	5	f062.bmp
+456.1716363636	n/a	114042.9091	left_press	n/a	n/a	138	n/a	256	n/a
+456.2898181818	n/a	114072.4545	show_circle	n/a	n/a	138	n/a	0	circle.bmp
+457.9898181818	n/a	114497.4545	show_cross	n/a	n/a	139	n/a	n/a	cross.bmp
+458.5589090909	n/a	114639.7273	show_face	famous_face	immediate_repeat	139	1	6	f062.bmp
+459.428	n/a	114857.0	left_press	n/a	n/a	139	n/a	256	n/a
+459.4561818182	n/a	114864.0455	show_circle	n/a	n/a	139	n/a	0	circle.bmp
+461.1561818182	n/a	115289.0455	show_cross	n/a	n/a	140	n/a	n/a	cross.bmp
+461.7325454545	n/a	115433.1364	show_face	unfamiliar_face	delayed_repeat	140	9	15	u119.bmp
+462.34890909089995	n/a	115587.2273	right_press	n/a	n/a	140	n/a	4096	n/a
+462.69709090910004	n/a	115674.2727	show_circle	n/a	n/a	140	n/a	0	circle.bmp
+464.39709090910003	n/a	116099.2727	show_cross	n/a	n/a	141	n/a	n/a	cross.bmp
+465.0398181818	n/a	116259.9545	show_face	famous_face	first_show	141	n/a	5	f092.bmp
+465.68527272730006	n/a	116421.3182	right_press	n/a	n/a	141	n/a	4096	n/a
+466.01072727269997	n/a	116502.6818	show_circle	n/a	n/a	141	n/a	0	circle.bmp
+467.71072727269996	n/a	116927.6818	show_cross	n/a	n/a	142	n/a	n/a	cross.bmp
+468.2643636364	n/a	117066.0909	show_face	famous_face	immediate_repeat	142	1	6	f092.bmp
+469.1670909091	n/a	117291.7727	show_circle	n/a	n/a	142	n/a	0	circle.bmp
+470.86709090910006	n/a	117716.7727	show_cross	n/a	n/a	143	n/a	n/a	cross.bmp
+471.45527272730004	n/a	117863.8182	show_face	famous_face	delayed_repeat	143	11	7	f057.bmp
+472.02345454550004	n/a	118005.8636	right_press	n/a	n/a	143	n/a	4096	n/a
+472.4125454545	n/a	118103.1364	show_circle	n/a	n/a	143	n/a	0	circle.bmp
+474.1125454545	n/a	118528.1364	show_cross	n/a	n/a	144	n/a	n/a	cross.bmp
+474.69527272730005	n/a	118673.8182	show_face	scrambled_face	first_show	144	n/a	17	s083.bmp
+475.4843636364	n/a	118871.0909	right_press	n/a	n/a	144	n/a	4096	n/a
+475.5970909091	n/a	118899.2727	show_circle	n/a	n/a	144	n/a	0	circle.bmp
+477.29709090910006	n/a	119324.2727	show_cross	n/a	n/a	145	n/a	n/a	cross.bmp
+477.81981818180003	n/a	119454.9545	show_face	scrambled_face	delayed_repeat	145	12	19	s023.bmp
+478.60890909089994	n/a	119652.2273	left_press	n/a	n/a	145	n/a	256	n/a
+478.7916363636	n/a	119697.9091	show_circle	n/a	n/a	145	n/a	0	circle.bmp
+480.4916363636	n/a	120122.9091	show_cross	n/a	n/a	146	n/a	n/a	cross.bmp
+481.0434545455	n/a	120260.8636	show_face	famous_face	first_show	146	n/a	5	f045.bmp
+481.968	n/a	120492.0	show_circle	n/a	n/a	146	n/a	0	circle.bmp
+482.558	n/a	120639.5	right_press	n/a	n/a	146	n/a	4096	n/a
+483.668	n/a	120917.0	show_cross	n/a	n/a	147	n/a	n/a	cross.bmp
+484.268	n/a	121067.0	show_face	scrambled_face	delayed_repeat	147	12	19	s140.bmp
+485.0316363636	n/a	121257.9091	right_press	n/a	n/a	147	n/a	4096	n/a
+485.2307272727	n/a	121307.6818	show_circle	n/a	n/a	147	n/a	0	circle.bmp
+486.9307272727	n/a	121732.6818	show_cross	n/a	n/a	148	n/a	n/a	cross.bmp
+487.5089090909	n/a	121877.2273	show_face	scrambled_face	first_show	148	n/a	17	s147.bmp
+488.0970909091	n/a	122024.2727	left_press	n/a	n/a	148	n/a	256	n/a
+488.37709090910005	n/a	122094.2727	show_circle	n/a	n/a	148	n/a	0	circle.bmp
+490.07709090910004	n/a	122519.2727	show_cross	n/a	n/a	149	n/a	n/a	cross.bmp

--- a/eeg_hed_small/sub-003/eeg/sub-003_task-FacePerception_run-5_events.tsv
+++ b/eeg_hed_small/sub-003/eeg/sub-003_task-FacePerception_run-5_events.tsv
@@ -1,581 +1,581 @@
-onset	duration	sample	event_type	face_type	repetition_type	trigger	stim_file
-0.0040000000	n/a	1	setup	n/a	n/a	n/a	n/a
-0.0040000000	n/a	1	right_sym	n/a	n/a	n/a	n/a
-25.0307272727	n/a	6257.6818	show_face	unfamiliar_face	first_show	13	u142.bmp
-25.8189090909	n/a	6454.7273	right_press	n/a	n/a	4096	n/a
-25.9616363636	n/a	6490.4091	show_circle	n/a	n/a	0	circle.bmp
-27.6616363636	n/a	6915.4091	show_cross	n/a	n/a	n/a	cross.bmp
-28.1707272727	n/a	7042.6818	show_face	scrambled_face	first_show	17	s007.bmp
-28.8207272727	n/a	7205.1818	left_press	n/a	n/a	256	n/a
-29.1116363636	n/a	7277.9091	show_circle	n/a	n/a	0	circle.bmp
-30.8116363636	n/a	7702.9091	show_cross	n/a	n/a	n/a	cross.bmp
-31.2780000000	n/a	7819.5	show_face	scrambled_face	first_show	17	s004.bmp
-31.7961818182	n/a	7949.0455	left_press	n/a	n/a	256	n/a
-32.1225454545	n/a	8030.6364	show_circle	n/a	n/a	0	circle.bmp
-33.8225454545	n/a	8455.6364	show_cross	n/a	n/a	n/a	cross.bmp
-34.3016363636	n/a	8575.4091	show_face	famous_face	first_show	5	f086.bmp
-34.9652727273	n/a	8741.3182	right_press	n/a	n/a	4096	n/a
-35.1698181818	n/a	8792.4545	show_circle	n/a	n/a	0	circle.bmp
-36.8698181818	n/a	9217.4545	show_cross	n/a	n/a	n/a	cross.bmp
-37.3752727273	n/a	9343.8182	show_face	scrambled_face	first_show	17	s054.bmp
-37.8943636364	n/a	9473.5909	left_press	n/a	n/a	256	n/a
-38.3789090909	n/a	9594.7273	show_circle	n/a	n/a	0	circle.bmp
-40.0789090909	n/a	10019.7273	show_cross	n/a	n/a	n/a	cross.bmp
-40.6661818182	n/a	10166.5455	show_face	scrambled_face	immediate_repeat	18	s054.bmp
-41.1598181818	n/a	10289.9545	left_press	n/a	n/a	256	n/a
-41.4861818182	n/a	10371.5455	show_circle	n/a	n/a	0	circle.bmp
-43.1861818182	n/a	10796.5455	show_cross	n/a	n/a	n/a	cross.bmp
-43.6570909091	n/a	10914.2727	show_face	famous_face	first_show	5	f047.bmp
-44.4952727273	n/a	11123.8182	show_circle	n/a	n/a	0	circle.bmp
-44.8952727273	n/a	11223.8182	right_press	n/a	n/a	4096	n/a
-46.1952727273	n/a	11548.8182	show_cross	n/a	n/a	n/a	cross.bmp
-46.7470909091	n/a	11686.7727	show_face	famous_face	immediate_repeat	6	f047.bmp
-47.1843636364	n/a	11796.0909	right_press	n/a	n/a	4096	n/a
-47.7498181818	n/a	11937.4545	show_circle	n/a	n/a	0	circle.bmp
-49.4498181818	n/a	12362.4545	show_cross	n/a	n/a	n/a	cross.bmp
-49.9380000000	n/a	12484.5	show_face	unfamiliar_face	delayed_repeat	15	u142.bmp
-50.7652727273	n/a	12691.3182	show_circle	n/a	n/a	0	circle.bmp
-51.3452727273	n/a	12836.3182	left_press	n/a	n/a	256	n/a
-52.4652727273	n/a	13116.3182	show_cross	n/a	n/a	n/a	cross.bmp
-53.0452727273	n/a	13261.3182	show_face	famous_face	first_show	5	f055.bmp
-53.6316363636	n/a	13407.9091	right_press	n/a	n/a	4096	n/a
-53.8716363636	n/a	13467.9091	show_circle	n/a	n/a	0	circle.bmp
-55.5716363636	n/a	13892.9091	show_cross	n/a	n/a	n/a	cross.bmp
-56.0852727273	n/a	14021.3182	show_face	famous_face	immediate_repeat	6	f055.bmp
-56.6243636364	n/a	14156.0909	right_press	n/a	n/a	4096	n/a
-57.0452727273	n/a	14261.3182	show_circle	n/a	n/a	0	circle.bmp
-58.7452727273	n/a	14686.3182	show_cross	n/a	n/a	n/a	cross.bmp
-59.2261818182	n/a	14806.5455	show_face	scrambled_face	delayed_repeat	19	s007.bmp
-59.7943636364	n/a	14948.5909	left_press	n/a	n/a	256	n/a
-60.1461818182	n/a	15036.5455	show_circle	n/a	n/a	0	circle.bmp
-61.8461818182	n/a	15461.5455	show_cross	n/a	n/a	n/a	cross.bmp
-62.4670909091	n/a	15616.7727	show_face	famous_face	first_show	5	f097.bmp
-63.2325454545	n/a	15808.1364	left_press	n/a	n/a	256	n/a
-63.4561818182	n/a	15864.0455	show_circle	n/a	n/a	0	circle.bmp
-65.1561818182	n/a	16289.0455	show_cross	n/a	n/a	n/a	cross.bmp
-65.7407272727	n/a	16435.1818	show_face	famous_face	immediate_repeat	6	f097.bmp
-66.1943636364	n/a	16548.5909	left_press	n/a	n/a	256	n/a
-66.7107272727	n/a	16677.6818	show_circle	n/a	n/a	0	circle.bmp
-68.4107272727	n/a	17102.6818	show_cross	n/a	n/a	n/a	cross.bmp
-69.0316363636	n/a	17257.9091	show_face	scrambled_face	delayed_repeat	19	s004.bmp
-69.8061818182	n/a	17451.5455	left_press	n/a	n/a	256	n/a
-69.9134545455	n/a	17478.3636	show_circle	n/a	n/a	0	circle.bmp
-71.6134545455	n/a	17903.3636	show_cross	n/a	n/a	n/a	cross.bmp
-72.1561818182	n/a	18039.0455	show_face	unfamiliar_face	first_show	13	u051.bmp
-72.8025454545	n/a	18200.6364	right_press	n/a	n/a	4096	n/a
-73.0361818182	n/a	18259.0455	show_circle	n/a	n/a	0	circle.bmp
-74.7361818182	n/a	18684.0455	show_cross	n/a	n/a	n/a	cross.bmp
-75.3134545455	n/a	18828.3636	show_face	unfamiliar_face	immediate_repeat	14	u051.bmp
-75.7680000000	n/a	18942	right_press	n/a	n/a	4096	n/a
-76.2880000000	n/a	19072	show_circle	n/a	n/a	0	circle.bmp
-77.9880000000	n/a	19497	show_cross	n/a	n/a	n/a	cross.bmp
-78.4534545455	n/a	19613.3636	show_face	famous_face	delayed_repeat	7	f086.bmp
-79.1398181818	n/a	19784.9545	right_press	n/a	n/a	4096	n/a
-79.4698181818	n/a	19867.4545	show_circle	n/a	n/a	0	circle.bmp
-81.1698181818	n/a	20292.4545	show_cross	n/a	n/a	n/a	cross.bmp
-81.6443636364	n/a	20411.0909	show_face	famous_face	first_show	5	f001.bmp
-82.3107272727	n/a	20577.6818	right_press	n/a	n/a	4096	n/a
-82.5225454545	n/a	20630.6364	show_circle	n/a	n/a	0	circle.bmp
-84.2225454545	n/a	21055.6364	show_cross	n/a	n/a	n/a	cross.bmp
-84.7516363636	n/a	21187.9091	show_face	famous_face	immediate_repeat	6	f001.bmp
-85.4616363636	n/a	21365.4091	right_press	n/a	n/a	4096	n/a
-85.6070909091	n/a	21401.7727	show_circle	n/a	n/a	0	circle.bmp
-87.3070909091	n/a	21826.7727	show_cross	n/a	n/a	n/a	cross.bmp
-87.8425454545	n/a	21960.6364	show_face	famous_face	first_show	5	f148.bmp
-88.8352727273	n/a	22208.8182	show_circle	n/a	n/a	0	circle.bmp
-89.1198181818	n/a	22279.9545	right_press	n/a	n/a	4096	n/a
-90.5352727273	n/a	22633.8182	show_cross	n/a	n/a	n/a	cross.bmp
-91.1661818182	n/a	22791.5455	show_face	famous_face	immediate_repeat	6	f148.bmp
-91.6316363636	n/a	22907.9091	right_press	n/a	n/a	4096	n/a
-92.0034545455	n/a	23000.8636	show_circle	n/a	n/a	0	circle.bmp
-93.7034545455	n/a	23425.8636	show_cross	n/a	n/a	n/a	cross.bmp
-94.2398181818	n/a	23559.9545	show_face	scrambled_face	first_show	17	s079.bmp
-94.8380000000	n/a	23709.5	left_press	n/a	n/a	256	n/a
-95.0943636364	n/a	23773.5909	show_circle	n/a	n/a	0	circle.bmp
-96.7943636364	n/a	24198.5909	show_cross	n/a	n/a	n/a	cross.bmp
-97.4470909091	n/a	24361.7727	show_face	unfamiliar_face	first_show	13	u012.bmp
-98.2489090909	n/a	24562.2273	right_press	n/a	n/a	4096	n/a
-98.3470909091	n/a	24586.7727	show_circle	n/a	n/a	0	circle.bmp
-100.0470909091	n/a	25011.7727	show_cross	n/a	n/a	n/a	cross.bmp
-100.6716363636	n/a	25167.9091	show_face	unfamiliar_face	immediate_repeat	14	u012.bmp
-101.2343636364	n/a	25308.5909	right_press	n/a	n/a	4096	n/a
-101.5525454545	n/a	25388.1364	show_circle	n/a	n/a	0	circle.bmp
-103.2525454545	n/a	25813.1364	show_cross	n/a	n/a	n/a	cross.bmp
-103.8116363636	n/a	25952.9091	show_face	famous_face	first_show	5	f114.bmp
-104.5361818182	n/a	26134.0455	left_press	n/a	n/a	256	n/a
-104.6998181818	n/a	26174.9545	show_circle	n/a	n/a	0	circle.bmp
-106.3998181818	n/a	26599.9545	show_cross	n/a	n/a	n/a	cross.bmp
-107.0025454545	n/a	26750.6364	show_face	famous_face	immediate_repeat	6	f114.bmp
-107.5325454545	n/a	26883.1364	left_press	n/a	n/a	256	n/a
-107.8252727273	n/a	26956.3182	show_circle	n/a	n/a	0	circle.bmp
-109.5252727273	n/a	27381.3182	show_cross	n/a	n/a	n/a	cross.bmp
-110.1934545455	n/a	27548.3636	show_face	unfamiliar_face	first_show	13	u095.bmp
-110.7852727273	n/a	27696.3182	right_press	n/a	n/a	4096	n/a
-111.1643636364	n/a	27791.0909	show_circle	n/a	n/a	0	circle.bmp
-112.8643636364	n/a	28216.0909	show_cross	n/a	n/a	n/a	cross.bmp
-113.4007272727	n/a	28350.1818	show_face	unfamiliar_face	immediate_repeat	14	u095.bmp
-113.8970909091	n/a	28474.2727	right_press	n/a	n/a	4096	n/a
-114.3834545455	n/a	28595.8636	show_circle	n/a	n/a	0	circle.bmp
-116.0834545455	n/a	29020.8636	show_cross	n/a	n/a	n/a	cross.bmp
-116.6916363636	n/a	29172.9091	show_face	unfamiliar_face	first_show	13	u102.bmp
-117.3689090909	n/a	29342.2273	right_press	n/a	n/a	4096	n/a
-117.7034545455	n/a	29425.8636	show_circle	n/a	n/a	0	circle.bmp
-119.4034545455	n/a	29850.8636	show_cross	n/a	n/a	n/a	cross.bmp
-120.0161818182	n/a	30004.0455	show_face	unfamiliar_face	immediate_repeat	14	u102.bmp
-120.7780000000	n/a	30194.5	right_press	n/a	n/a	4096	n/a
-120.9216363636	n/a	30230.4091	show_circle	n/a	n/a	0	circle.bmp
-122.6216363636	n/a	30655.4091	show_cross	n/a	n/a	n/a	cross.bmp
-123.2570909091	n/a	30814.2727	show_face	scrambled_face	first_show	17	s020.bmp
-123.9661818182	n/a	30991.5455	left_press	n/a	n/a	256	n/a
-124.1652727273	n/a	31041.3182	show_circle	n/a	n/a	0	circle.bmp
-125.8652727273	n/a	31466.3182	show_cross	n/a	n/a	n/a	cross.bmp
-126.4980000000	n/a	31624.5	show_face	scrambled_face	delayed_repeat	19	s079.bmp
-127.1134545455	n/a	31778.3636	left_press	n/a	n/a	256	n/a
-127.4843636364	n/a	31871.0909	show_circle	n/a	n/a	0	circle.bmp
-129.1843636364	n/a	32296.0909	show_cross	n/a	n/a	n/a	cross.bmp
-129.7552727273	n/a	32438.8182	show_face	scrambled_face	first_show	17	s111.bmp
-130.6852727273	n/a	32671.3182	show_circle	n/a	n/a	0	circle.bmp
-131.0670909091	n/a	32766.7727	left_press	n/a	n/a	256	n/a
-132.3852727273	n/a	33096.3182	show_cross	n/a	n/a	n/a	cross.bmp
-133.0125454545	n/a	33253.1364	show_face	scrambled_face	first_show	17	s075.bmp
-133.8243636364	n/a	33456.0909	left_press	n/a	n/a	256	n/a
-134.0116363636	n/a	33502.9091	show_circle	n/a	n/a	0	circle.bmp
-135.7116363636	n/a	33927.9091	show_cross	n/a	n/a	n/a	cross.bmp
-136.2698181818	n/a	34067.4545	show_face	scrambled_face	first_show	17	s118.bmp
-137.0380000000	n/a	34259.5	left_press	n/a	n/a	256	n/a
-137.1243636364	n/a	34281.0909	show_circle	n/a	n/a	0	circle.bmp
-138.8243636364	n/a	34706.0909	show_cross	n/a	n/a	n/a	cross.bmp
-139.3443636364	n/a	34836.0909	show_face	famous_face	first_show	5	f026.bmp
-139.9325454545	n/a	34983.1364	right_press	n/a	n/a	4096	n/a
-140.2180000000	n/a	35054.5	show_circle	n/a	n/a	0	circle.bmp
-141.9180000000	n/a	35479.5	show_cross	n/a	n/a	n/a	cross.bmp
-142.5016363636	n/a	35625.4091	show_face	famous_face	first_show	5	f143.bmp
-143.1225454545	n/a	35780.6364	right_press	n/a	n/a	4096	n/a
-143.3798181818	n/a	35844.9545	show_circle	n/a	n/a	0	circle.bmp
-145.0798181818	n/a	36269.9545	show_cross	n/a	n/a	n/a	cross.bmp
-145.6252727273	n/a	36406.3182	show_face	scrambled_face	delayed_repeat	19	s020.bmp
-146.4752727273	n/a	36618.8182	right_press	n/a	n/a	4096	n/a
-146.4843636364	n/a	36621.0909	show_circle	n/a	n/a	0	circle.bmp
-148.1843636364	n/a	37046.0909	show_cross	n/a	n/a	n/a	cross.bmp
-148.7652727273	n/a	37191.3182	show_face	scrambled_face	first_show	17	s116.bmp
-149.5134545455	n/a	37378.3636	left_press	n/a	n/a	256	n/a
-149.7343636364	n/a	37433.5909	show_circle	n/a	n/a	0	circle.bmp
-151.4343636364	n/a	37858.5909	show_cross	n/a	n/a	n/a	cross.bmp
-151.9898181818	n/a	37997.4545	show_face	scrambled_face	immediate_repeat	18	s116.bmp
-152.6461818182	n/a	38161.5455	left_press	n/a	n/a	256	n/a
-152.9670909091	n/a	38241.7727	show_circle	n/a	n/a	0	circle.bmp
-154.6670909091	n/a	38666.7727	show_cross	n/a	n/a	n/a	cross.bmp
-155.2807272727	n/a	38820.1818	show_face	scrambled_face	delayed_repeat	19	s111.bmp
-156.1516363636	n/a	39037.9091	show_circle	n/a	n/a	0	circle.bmp
-156.2970909091	n/a	39074.2727	left_press	n/a	n/a	256	n/a
-157.8516363636	n/a	39462.9091	show_cross	n/a	n/a	n/a	cross.bmp
-158.3207272727	n/a	39580.1818	show_face	famous_face	first_show	5	f029.bmp
-158.9289090909	n/a	39732.2273	right_press	n/a	n/a	4096	n/a
-159.3280000000	n/a	39832	show_circle	n/a	n/a	0	circle.bmp
-161.0280000000	n/a	40257	show_cross	n/a	n/a	n/a	cross.bmp
-161.5116363636	n/a	40377.9091	show_face	scrambled_face	delayed_repeat	19	s075.bmp
-162.3661818182	n/a	40591.5455	left_press	n/a	n/a	256	n/a
-162.5107272727	n/a	40627.6818	show_circle	n/a	n/a	0	circle.bmp
-164.2107272727	n/a	41052.6818	show_cross	n/a	n/a	n/a	cross.bmp
-164.6689090909	n/a	41167.2273	show_face	scrambled_face	first_show	17	s005.bmp
-165.2670909091	n/a	41316.7727	right_press	n/a	n/a	4096	n/a
-165.5989090909	n/a	41399.7273	show_circle	n/a	n/a	0	circle.bmp
-167.2989090909	n/a	41824.7273	show_cross	n/a	n/a	n/a	cross.bmp
-167.8098181818	n/a	41952.4545	show_face	scrambled_face	delayed_repeat	19	s118.bmp
-168.5480000000	n/a	42137	left_press	n/a	n/a	256	n/a
-168.7252727273	n/a	42181.3182	show_circle	n/a	n/a	0	circle.bmp
-170.4252727273	n/a	42606.3182	show_cross	n/a	n/a	n/a	cross.bmp
-170.9834545455	n/a	42745.8636	show_face	scrambled_face	first_show	17	s139.bmp
-171.6870909091	n/a	42921.7727	left_press	n/a	n/a	256	n/a
-171.8180000000	n/a	42954.5	show_circle	n/a	n/a	0	circle.bmp
-173.5180000000	n/a	43379.5	show_cross	n/a	n/a	n/a	cross.bmp
-174.1407272727	n/a	43535.1818	show_face	scrambled_face	immediate_repeat	18	s139.bmp
-174.9661818182	n/a	43741.5455	show_circle	n/a	n/a	0	circle.bmp
-175.1661818182	n/a	43791.5455	left_press	n/a	n/a	256	n/a
-176.6661818182	n/a	44166.5455	show_cross	n/a	n/a	n/a	cross.bmp
-177.1816363636	n/a	44295.4091	show_face	famous_face	delayed_repeat	7	f026.bmp
-177.7752727273	n/a	44443.8182	right_press	n/a	n/a	4096	n/a
-178.1743636364	n/a	44543.5909	show_circle	n/a	n/a	0	circle.bmp
-179.8743636364	n/a	44968.5909	show_cross	n/a	n/a	n/a	cross.bmp
-180.4889090909	n/a	45122.2273	show_face	unfamiliar_face	first_show	13	u001.bmp
-181.0852727273	n/a	45271.3182	left_press	n/a	n/a	256	n/a
-181.4816363636	n/a	45370.4091	show_circle	n/a	n/a	0	circle.bmp
-183.1816363636	n/a	45795.4091	show_cross	n/a	n/a	n/a	cross.bmp
-183.6625454545	n/a	45915.6364	show_face	famous_face	delayed_repeat	7	f143.bmp
-184.3807272727	n/a	46095.1818	right_press	n/a	n/a	4096	n/a
-184.5443636364	n/a	46136.0909	show_circle	n/a	n/a	0	circle.bmp
-186.2443636364	n/a	46561.0909	show_cross	n/a	n/a	n/a	cross.bmp
-186.9034545455	n/a	46725.8636	show_face	unfamiliar_face	first_show	13	u062.bmp
-187.8080000000	n/a	46952	left_press	n/a	n/a	256	n/a
-187.9216363636	n/a	46980.4091	show_circle	n/a	n/a	0	circle.bmp
-189.6216363636	n/a	47405.4091	show_cross	n/a	n/a	n/a	cross.bmp
-190.1616363636	n/a	47540.4091	show_face	unfamiliar_face	immediate_repeat	14	u062.bmp
-190.8680000000	n/a	47717	left_press	n/a	n/a	256	n/a
-191.1389090909	n/a	47784.7273	show_circle	n/a	n/a	0	circle.bmp
-192.8389090909	n/a	48209.7273	show_cross	n/a	n/a	n/a	cross.bmp
-193.3852727273	n/a	48346.3182	show_face	unfamiliar_face	first_show	13	u125.bmp
-194.3289090909	n/a	48582.2273	left_press	n/a	n/a	256	n/a
-194.3361818182	n/a	48584.0455	show_circle	n/a	n/a	0	circle.bmp
-196.0361818182	n/a	49009.0455	show_cross	n/a	n/a	n/a	cross.bmp
-196.5261818182	n/a	49131.5455	show_face	unfamiliar_face	immediate_repeat	14	u125.bmp
-197.3680000000	n/a	49342	show_circle	n/a	n/a	0	circle.bmp
-199.0680000000	n/a	49767	show_cross	n/a	n/a	n/a	cross.bmp
-199.5661818182	n/a	49891.5455	show_face	famous_face	delayed_repeat	7	f029.bmp
-200.5034545455	n/a	50125.8636	right_press	n/a	n/a	4096	n/a
-200.5589090909	n/a	50139.7273	show_circle	n/a	n/a	0	circle.bmp
-202.2589090909	n/a	50564.7273	show_cross	n/a	n/a	n/a	cross.bmp
-202.7398181818	n/a	50684.9545	show_face	scrambled_face	first_show	17	s078.bmp
-203.5461818182	n/a	50886.5455	left_press	n/a	n/a	256	n/a
-203.5607272727	n/a	50890.1818	show_circle	n/a	n/a	0	circle.bmp
-205.2607272727	n/a	51315.1818	show_cross	n/a	n/a	n/a	cross.bmp
-205.7807272727	n/a	51445.1818	show_face	scrambled_face	delayed_repeat	19	s005.bmp
-206.3325454545	n/a	51583.1364	right_press	n/a	n/a	4096	n/a
-206.6007272727	n/a	51650.1818	show_circle	n/a	n/a	0	circle.bmp
-208.3007272727	n/a	52075.1818	show_cross	n/a	n/a	n/a	cross.bmp
-208.8707272727	n/a	52217.6818	show_face	famous_face	first_show	5	f031.bmp
-209.7470909091	n/a	52436.7727	show_circle	n/a	n/a	0	circle.bmp
-210.3161818182	n/a	52579.0455	left_press	n/a	n/a	256	n/a
-211.4470909091	n/a	52861.7727	show_cross	n/a	n/a	n/a	cross.bmp
-212.0780000000	n/a	53019.5	show_face	famous_face	first_show	5	f107.bmp
-213.0780000000	n/a	53269.5	show_circle	n/a	n/a	0	circle.bmp
-213.1861818182	n/a	53296.5455	left_press	n/a	n/a	256	n/a
-214.7780000000	n/a	53694.5	show_cross	n/a	n/a	n/a	cross.bmp
-215.2689090909	n/a	53817.2273	show_face	famous_face	immediate_repeat	6	f107.bmp
-215.8089090909	n/a	53952.2273	left_press	n/a	n/a	256	n/a
-216.1398181818	n/a	54034.9545	show_circle	n/a	n/a	0	circle.bmp
-217.8398181818	n/a	54459.9545	show_cross	n/a	n/a	n/a	cross.bmp
-218.4761818182	n/a	54619.0455	show_face	unfamiliar_face	delayed_repeat	15	u001.bmp
-219.2507272727	n/a	54812.6818	left_press	n/a	n/a	256	n/a
-219.3707272727	n/a	54842.6818	show_circle	n/a	n/a	0	circle.bmp
-221.0707272727	n/a	55267.6818	show_cross	n/a	n/a	n/a	cross.bmp
-221.6170909091	n/a	55404.2727	show_face	famous_face	first_show	5	f116.bmp
-222.6243636364	n/a	55656.0909	show_circle	n/a	n/a	0	circle.bmp
-222.7298181818	n/a	55682.4545	right_press	n/a	n/a	4096	n/a
-224.3243636364	n/a	56081.0909	show_cross	n/a	n/a	n/a	cross.bmp
-224.8589090909	n/a	56214.7273	show_face	famous_face	first_show	5	f016.bmp
-225.4561818182	n/a	56364.0455	right_press	n/a	n/a	4096	n/a
-225.7443636364	n/a	56436.0909	show_circle	n/a	n/a	0	circle.bmp
-227.4443636364	n/a	56861.0909	show_cross	n/a	n/a	n/a	cross.bmp
-227.9316363636	n/a	56982.9091	show_face	famous_face	immediate_repeat	6	f016.bmp
-228.8170909091	n/a	57204.2727	show_circle	n/a	n/a	0	circle.bmp
-229.4607272727	n/a	57365.1818	right_press	n/a	n/a	4096	n/a
-230.5170909091	n/a	57629.2727	show_cross	n/a	n/a	n/a	cross.bmp
-230.9716363636	n/a	57742.9091	show_face	famous_face	first_show	5	f083.bmp
-231.7252727273	n/a	57931.3182	right_press	n/a	n/a	4096	n/a
-231.8998181818	n/a	57974.9545	show_circle	n/a	n/a	0	circle.bmp
-233.5998181818	n/a	58399.9545	show_cross	n/a	n/a	n/a	cross.bmp
-234.1789090909	n/a	58544.7273	show_face	famous_face	immediate_repeat	6	f083.bmp
-235.1570909091	n/a	58789.2727	show_circle	n/a	n/a	0	circle.bmp
-236.8570909091	n/a	59214.2727	show_cross	n/a	n/a	n/a	cross.bmp
-237.4370909091	n/a	59359.2727	show_face	scrambled_face	delayed_repeat	19	s078.bmp
-238.1680000000	n/a	59542	left_press	n/a	n/a	256	n/a
-238.2670909091	n/a	59566.7727	show_circle	n/a	n/a	0	circle.bmp
-239.9670909091	n/a	59991.7727	show_cross	n/a	n/a	n/a	cross.bmp
-240.4434545455	n/a	60110.8636	show_face	unfamiliar_face	first_show	13	u010.bmp
-241.1516363636	n/a	60287.9091	right_press	n/a	n/a	4096	n/a
-241.3807272727	n/a	60345.1818	show_circle	n/a	n/a	0	circle.bmp
-243.0807272727	n/a	60770.1818	show_cross	n/a	n/a	n/a	cross.bmp
-243.6843636364	n/a	60921.0909	show_face	famous_face	delayed_repeat	7	f031.bmp
-244.5898181818	n/a	61147.4545	left_press	n/a	n/a	256	n/a
-244.6298181818	n/a	61157.4545	show_circle	n/a	n/a	0	circle.bmp
-246.3298181818	n/a	61582.4545	show_cross	n/a	n/a	n/a	cross.bmp
-246.8752727273	n/a	61718.8182	show_face	unfamiliar_face	first_show	13	u059.bmp
-247.8107272727	n/a	61952.6818	left_press	n/a	n/a	256	n/a
-247.8643636364	n/a	61966.0909	show_circle	n/a	n/a	0	circle.bmp
-249.5643636364	n/a	62391.0909	show_cross	n/a	n/a	n/a	cross.bmp
-250.0489090909	n/a	62512.2273	show_face	scrambled_face	first_show	17	s042.bmp
-250.8952727273	n/a	62723.8182	right_press	n/a	n/a	4096	n/a
-250.9270909091	n/a	62731.7727	show_circle	n/a	n/a	0	circle.bmp
-252.6270909091	n/a	63156.7727	show_cross	n/a	n/a	n/a	cross.bmp
-253.1561818182	n/a	63289.0455	show_face	scrambled_face	immediate_repeat	18	s042.bmp
-254.0934545455	n/a	63523.3636	show_circle	n/a	n/a	0	circle.bmp
-254.1752727273	n/a	63543.8182	left_press	n/a	n/a	256	n/a
-255.7934545455	n/a	63948.3636	show_cross	n/a	n/a	n/a	cross.bmp
-256.3307272727	n/a	64082.6818	show_face	famous_face	delayed_repeat	7	f116.bmp
-257.0661818182	n/a	64266.5455	right_press	n/a	n/a	4096	n/a
-257.1480000000	n/a	64287	show_circle	n/a	n/a	0	circle.bmp
-258.8480000000	n/a	64712	show_cross	n/a	n/a	n/a	cross.bmp
-259.4043636364	n/a	64851.0909	show_face	scrambled_face	first_show	17	s014.bmp
-260.3316363636	n/a	65082.9091	show_circle	n/a	n/a	0	circle.bmp
-262.0316363636	n/a	65507.9091	show_cross	n/a	n/a	n/a	cross.bmp
-262.5616363636	n/a	65640.4091	show_face	scrambled_face	immediate_repeat	18	s014.bmp
-263.2580000000	n/a	65814.5	left_press	n/a	n/a	256	n/a
-263.3961818182	n/a	65849.0455	show_circle	n/a	n/a	0	circle.bmp
-265.0961818182	n/a	66274.0455	show_cross	n/a	n/a	n/a	cross.bmp
-265.5852727273	n/a	66396.3182	show_face	unfamiliar_face	first_show	13	u082.bmp
-266.2570909091	n/a	66564.2727	left_press	n/a	n/a	256	n/a
-266.4343636364	n/a	66608.5909	show_circle	n/a	n/a	0	circle.bmp
-268.1343636364	n/a	67033.5909	show_cross	n/a	n/a	n/a	cross.bmp
-268.7252727273	n/a	67181.3182	show_face	unfamiliar_face	immediate_repeat	14	u082.bmp
-269.3107272727	n/a	67327.6818	left_press	n/a	n/a	256	n/a
-269.6116363636	n/a	67402.9091	show_circle	n/a	n/a	0	circle.bmp
-271.3116363636	n/a	67827.9091	show_cross	n/a	n/a	n/a	cross.bmp
-271.8325454545	n/a	67958.1364	show_face	famous_face	first_show	5	f023.bmp
-272.7407272727	n/a	68185.1818	right_press	n/a	n/a	4096	n/a
-272.7980000000	n/a	68199.5	show_circle	n/a	n/a	0	circle.bmp
-274.4980000000	n/a	68624.5	show_cross	n/a	n/a	n/a	cross.bmp
-275.0734545455	n/a	68768.3636	show_face	unfamiliar_face	delayed_repeat	15	u010.bmp
-275.7016363636	n/a	68925.4091	right_press	n/a	n/a	4096	n/a
-275.9925454545	n/a	68998.1364	show_circle	n/a	n/a	0	circle.bmp
-277.6925454545	n/a	69423.1364	show_cross	n/a	n/a	n/a	cross.bmp
-278.2143636364	n/a	69553.5909	show_face	famous_face	first_show	5	f118.bmp
-279.0925454545	n/a	69773.1364	right_press	n/a	n/a	4096	n/a
-279.1643636364	n/a	69791.0909	show_circle	n/a	n/a	0	circle.bmp
-280.8643636364	n/a	70216.0909	show_cross	n/a	n/a	n/a	cross.bmp
-281.4716363636	n/a	70367.9091	show_face	famous_face	immediate_repeat	6	f118.bmp
-282.3580000000	n/a	70589.5	show_circle	n/a	n/a	0	circle.bmp
-283.2216363636	n/a	70805.4091	right_press	n/a	n/a	4096	n/a
-284.0580000000	n/a	71014.5	show_cross	n/a	n/a	n/a	cross.bmp
-284.5616363636	n/a	71140.4091	show_face	unfamiliar_face	delayed_repeat	15	u059.bmp
-285.4061818182	n/a	71351.5455	show_circle	n/a	n/a	0	circle.bmp
-285.5416363636	n/a	71385.4091	right_press	n/a	n/a	4096	n/a
-287.1061818182	n/a	71776.5455	show_cross	n/a	n/a	n/a	cross.bmp
-287.5861818182	n/a	71896.5455	show_face	scrambled_face	first_show	17	s125.bmp
-288.5980000000	n/a	72149.5	show_circle	n/a	n/a	0	circle.bmp
-290.2980000000	n/a	72574.5	show_cross	n/a	n/a	n/a	cross.bmp
-290.8770909091	n/a	72719.2727	show_face	unfamiliar_face	first_show	13	u033.bmp
-291.7034545455	n/a	72925.8636	show_circle	n/a	n/a	0	circle.bmp
-291.9352727273	n/a	72983.8182	left_press	n/a	n/a	256	n/a
-293.4034545455	n/a	73350.8636	show_cross	n/a	n/a	n/a	cross.bmp
-293.9007272727	n/a	73475.1818	show_face	famous_face	first_show	5	f068.bmp
-294.5925454545	n/a	73648.1364	right_press	n/a	n/a	4096	n/a
-294.8761818182	n/a	73719.0455	show_circle	n/a	n/a	0	circle.bmp
-296.5761818182	n/a	74144.0455	show_cross	n/a	n/a	n/a	cross.bmp
-297.0907272727	n/a	74272.6818	show_face	unfamiliar_face	first_show	13	u038.bmp
-297.9107272727	n/a	74477.6818	right_press	n/a	n/a	4096	n/a
-297.9252727273	n/a	74481.3182	show_circle	n/a	n/a	0	circle.bmp
-299.6252727273	n/a	74906.3182	show_cross	n/a	n/a	n/a	cross.bmp
-300.1480000000	n/a	75037	show_face	unfamiliar_face	immediate_repeat	14	u038.bmp
-300.8143636364	n/a	75203.5909	left_press	n/a	n/a	256	n/a
-300.9970909091	n/a	75249.2727	show_circle	n/a	n/a	0	circle.bmp
-302.6970909091	n/a	75674.2727	show_cross	n/a	n/a	n/a	cross.bmp
-303.2216363636	n/a	75805.4091	show_face	famous_face	delayed_repeat	7	f023.bmp
-303.8261818182	n/a	75956.5455	right_press	n/a	n/a	4096	n/a
-304.0761818182	n/a	76019.0455	show_circle	n/a	n/a	0	circle.bmp
-305.7761818182	n/a	76444.0455	show_cross	n/a	n/a	n/a	cross.bmp
-306.3961818182	n/a	76599.0455	show_face	scrambled_face	first_show	17	s098.bmp
-307.0561818182	n/a	76764.0455	left_press	n/a	n/a	256	n/a
-307.3434545455	n/a	76835.8636	show_circle	n/a	n/a	0	circle.bmp
-309.0434545455	n/a	77260.8636	show_cross	n/a	n/a	n/a	cross.bmp
-309.6361818182	n/a	77409.0455	show_face	unfamiliar_face	first_show	13	u137.bmp
-310.3580000000	n/a	77589.5	left_press	n/a	n/a	256	n/a
-310.6361818182	n/a	77659.0455	show_circle	n/a	n/a	0	circle.bmp
-312.3361818182	n/a	78084.0455	show_cross	n/a	n/a	n/a	cross.bmp
-312.8270909091	n/a	78206.7727	show_face	unfamiliar_face	immediate_repeat	14	u137.bmp
-313.4943636364	n/a	78373.5909	left_press	n/a	n/a	256	n/a
-313.7798181818	n/a	78444.9545	show_circle	n/a	n/a	0	circle.bmp
-315.4798181818	n/a	78869.9545	show_cross	n/a	n/a	n/a	cross.bmp
-315.9343636364	n/a	78983.5909	show_face	scrambled_face	delayed_repeat	19	s125.bmp
-316.7607272727	n/a	79190.1818	show_circle	n/a	n/a	0	circle.bmp
-318.4607272727	n/a	79615.1818	show_cross	n/a	n/a	n/a	cross.bmp
-319.0252727273	n/a	79756.3182	show_face	scrambled_face	first_show	17	s008.bmp
-319.8625454545	n/a	79965.6364	show_circle	n/a	n/a	0	circle.bmp
-321.5625454545	n/a	80390.6364	show_cross	n/a	n/a	n/a	cross.bmp
-322.0489090909	n/a	80512.2273	show_face	unfamiliar_face	delayed_repeat	15	u033.bmp
-322.9398181818	n/a	80734.9545	right_press	n/a	n/a	4096	n/a
-322.9598181818	n/a	80739.9545	show_circle	n/a	n/a	0	circle.bmp
-324.6598181818	n/a	81164.9545	show_cross	n/a	n/a	n/a	cross.bmp
-325.1889090909	n/a	81297.2273	show_face	famous_face	first_show	5	f146.bmp
-325.9034545455	n/a	81475.8636	left_press	n/a	n/a	256	n/a
-326.1925454545	n/a	81548.1364	show_circle	n/a	n/a	0	circle.bmp
-327.8925454545	n/a	81973.1364	show_cross	n/a	n/a	n/a	cross.bmp
-328.3961818182	n/a	82099.0455	show_face	famous_face	delayed_repeat	7	f068.bmp
-329.1516363636	n/a	82287.9091	right_press	n/a	n/a	4096	n/a
-329.3270909091	n/a	82331.7727	show_circle	n/a	n/a	0	circle.bmp
-331.0270909091	n/a	82756.7727	show_cross	n/a	n/a	n/a	cross.bmp
-331.6034545455	n/a	82900.8636	show_face	famous_face	first_show	5	f061.bmp
-332.3098181818	n/a	83077.4545	right_press	n/a	n/a	4096	n/a
-332.5280000000	n/a	83132	show_circle	n/a	n/a	0	circle.bmp
-334.2280000000	n/a	83557	show_cross	n/a	n/a	n/a	cross.bmp
-334.8443636364	n/a	83711.0909	show_face	scrambled_face	first_show	17	s019.bmp
-335.4380000000	n/a	83859.5	left_press	n/a	n/a	256	n/a
-335.8034545455	n/a	83950.8636	show_circle	n/a	n/a	0	circle.bmp
-337.5034545455	n/a	84375.8636	show_cross	n/a	n/a	n/a	cross.bmp
-338.0189090909	n/a	84504.7273	show_face	scrambled_face	delayed_repeat	19	s098.bmp
-338.7707272727	n/a	84692.6818	left_press	n/a	n/a	256	n/a
-338.9734545455	n/a	84743.3636	show_circle	n/a	n/a	0	circle.bmp
-340.6734545455	n/a	85168.3636	show_cross	n/a	n/a	n/a	cross.bmp
-341.3098181818	n/a	85327.4545	show_face	unfamiliar_face	first_show	13	u116.bmp
-342.0389090909	n/a	85509.7273	right_press	n/a	n/a	4096	n/a
-342.3007272727	n/a	85575.1818	show_circle	n/a	n/a	0	circle.bmp
-344.0007272727	n/a	86000.1818	show_cross	n/a	n/a	n/a	cross.bmp
-344.4834545455	n/a	86120.8636	show_face	unfamiliar_face	first_show	13	u036.bmp
-345.4107272727	n/a	86352.6818	left_press	n/a	n/a	256	n/a
-345.4370909091	n/a	86359.2727	show_circle	n/a	n/a	0	circle.bmp
-347.1370909091	n/a	86784.2727	show_cross	n/a	n/a	n/a	cross.bmp
-347.7580000000	n/a	86939.5	show_face	scrambled_face	delayed_repeat	19	s008.bmp
-348.4725454545	n/a	87118.1364	left_press	n/a	n/a	256	n/a
-348.6516363636	n/a	87162.9091	show_circle	n/a	n/a	0	circle.bmp
-350.3516363636	n/a	87587.9091	show_cross	n/a	n/a	n/a	cross.bmp
-350.8480000000	n/a	87712	show_face	famous_face	first_show	5	f053.bmp
-351.5807272727	n/a	87895.1818	left_press	n/a	n/a	256	n/a
-351.6670909091	n/a	87916.7727	show_circle	n/a	n/a	0	circle.bmp
-353.3670909091	n/a	88341.7727	show_cross	n/a	n/a	n/a	cross.bmp
-353.8561818182	n/a	88464.0455	show_face	famous_face	delayed_repeat	7	f146.bmp
-354.7680000000	n/a	88692	show_circle	n/a	n/a	0	circle.bmp
-354.7770909091	n/a	88694.2727	left_press	n/a	n/a	256	n/a
-356.4680000000	n/a	89117	show_cross	n/a	n/a	n/a	cross.bmp
-357.1125454545	n/a	89278.1364	show_face	unfamiliar_face	first_show	13	u067.bmp
-357.9589090909	n/a	89489.7273	show_circle	n/a	n/a	0	circle.bmp
-357.9898181818	n/a	89497.4545	left_press	n/a	n/a	256	n/a
-359.6589090909	n/a	89914.7273	show_cross	n/a	n/a	n/a	cross.bmp
-360.2870909091	n/a	90071.7727	show_face	famous_face	delayed_repeat	7	f061.bmp
-361.2307272727	n/a	90307.6818	show_circle	n/a	n/a	0	circle.bmp
-361.6698181818	n/a	90417.4545	right_press	n/a	n/a	4096	n/a
-362.9307272727	n/a	90732.6818	show_cross	n/a	n/a	n/a	cross.bmp
-363.5607272727	n/a	90890.1818	show_face	famous_face	first_show	5	f125.bmp
-364.3880000000	n/a	91097	show_circle	n/a	n/a	0	circle.bmp
-364.4625454545	n/a	91115.6364	right_press	n/a	n/a	4096	n/a
-366.0880000000	n/a	91522	show_cross	n/a	n/a	n/a	cross.bmp
-366.5507272727	n/a	91637.6818	show_face	famous_face	immediate_repeat	6	f125.bmp
-367.4052727273	n/a	91851.3182	show_circle	n/a	n/a	0	circle.bmp
-369.1052727273	n/a	92276.3182	show_cross	n/a	n/a	n/a	cross.bmp
-369.2625454545	n/a	92315.6364	right_press	n/a	n/a	4096	n/a
-369.7080000000	n/a	92427	show_face	scrambled_face	delayed_repeat	19	s019.bmp
-370.5689090909	n/a	92642.2273	show_circle	n/a	n/a	0	circle.bmp
-371.2998181818	n/a	92824.9545	left_press	n/a	n/a	256	n/a
-372.2689090909	n/a	93067.2273	show_cross	n/a	n/a	n/a	cross.bmp
-372.8652727273	n/a	93216.3182	show_face	unfamiliar_face	first_show	13	u117.bmp
-373.8080000000	n/a	93452	show_circle	n/a	n/a	0	circle.bmp
-373.8107272727	n/a	93452.6818	right_press	n/a	n/a	4096	n/a
-375.5080000000	n/a	93877	show_cross	n/a	n/a	n/a	cross.bmp
-376.0898181818	n/a	94022.4545	show_face	unfamiliar_face	immediate_repeat	14	u117.bmp
-376.7343636364	n/a	94183.5909	right_press	n/a	n/a	4096	n/a
-376.9798181818	n/a	94244.9545	show_circle	n/a	n/a	0	circle.bmp
-378.6798181818	n/a	94669.9545	show_cross	n/a	n/a	n/a	cross.bmp
-379.3134545455	n/a	94828.3636	show_face	unfamiliar_face	delayed_repeat	15	u116.bmp
-380.0861818182	n/a	95021.5455	right_press	n/a	n/a	4096	n/a
-380.1352727273	n/a	95033.8182	show_circle	n/a	n/a	0	circle.bmp
-381.8352727273	n/a	95458.8182	show_cross	n/a	n/a	n/a	cross.bmp
-382.3043636364	n/a	95576.0909	show_face	scrambled_face	first_show	17	s134.bmp
-383.1643636364	n/a	95791.0909	right_press	n/a	n/a	4096	n/a
-383.2725454545	n/a	95818.1364	show_circle	n/a	n/a	0	circle.bmp
-384.9725454545	n/a	96243.1364	show_cross	n/a	n/a	n/a	cross.bmp
-385.4780000000	n/a	96369.5	show_face	scrambled_face	immediate_repeat	18	s134.bmp
-385.9607272727	n/a	96490.1818	right_press	n/a	n/a	4096	n/a
-386.4152727273	n/a	96603.8182	show_circle	n/a	n/a	0	circle.bmp
-388.1152727273	n/a	97028.8182	show_cross	n/a	n/a	n/a	cross.bmp
-388.6352727273	n/a	97158.8182	show_face	unfamiliar_face	delayed_repeat	15	u036.bmp
-389.4680000000	n/a	97367	show_circle	n/a	n/a	0	circle.bmp
-389.5534545455	n/a	97388.3636	left_press	n/a	n/a	256	n/a
-391.1680000000	n/a	97792	show_cross	n/a	n/a	n/a	cross.bmp
-391.6589090909	n/a	97914.7273	show_face	scrambled_face	first_show	17	s119.bmp
-392.2389090909	n/a	98059.7273	left_press	n/a	n/a	256	n/a
-392.5880000000	n/a	98147	show_circle	n/a	n/a	0	circle.bmp
-394.2880000000	n/a	98572	show_cross	n/a	n/a	n/a	cross.bmp
-394.7325454545	n/a	98683.1364	show_face	famous_face	delayed_repeat	7	f053.bmp
-395.4798181818	n/a	98869.9545	left_press	n/a	n/a	256	n/a
-395.5934545455	n/a	98898.3636	show_circle	n/a	n/a	0	circle.bmp
-397.2934545455	n/a	99323.3636	show_cross	n/a	n/a	n/a	cross.bmp
-397.7898181818	n/a	99447.4545	show_face	scrambled_face	first_show	17	s021.bmp
-398.6352727273	n/a	99658.8182	show_circle	n/a	n/a	0	circle.bmp
-400.3352727273	n/a	100083.8182	show_cross	n/a	n/a	n/a	cross.bmp
-400.9634545455	n/a	100240.8636	show_face	scrambled_face	immediate_repeat	18	s021.bmp
-401.8698181818	n/a	100467.4545	left_press	n/a	n/a	256	n/a
-401.9307272727	n/a	100482.6818	show_circle	n/a	n/a	0	circle.bmp
-403.6307272727	n/a	100907.6818	show_cross	n/a	n/a	n/a	cross.bmp
-404.2216363636	n/a	101055.4091	show_face	unfamiliar_face	delayed_repeat	15	u067.bmp
-405.0061818182	n/a	101251.5455	left_press	n/a	n/a	256	n/a
-405.1680000000	n/a	101292	show_circle	n/a	n/a	0	circle.bmp
-406.8680000000	n/a	101717	show_cross	n/a	n/a	n/a	cross.bmp
-407.3961818182	n/a	101849.0455	show_face	scrambled_face	first_show	17	s061.bmp
-408.3725454545	n/a	102093.1364	show_circle	n/a	n/a	0	circle.bmp
-410.0725454545	n/a	102518.1364	show_cross	n/a	n/a	n/a	cross.bmp
-410.7198181818	n/a	102679.9545	show_face	unfamiliar_face	first_show	13	u111.bmp
-411.3516363636	n/a	102837.9091	right_press	n/a	n/a	4096	n/a
-411.5852727273	n/a	102896.3182	show_circle	n/a	n/a	0	circle.bmp
-413.2852727273	n/a	103321.3182	show_cross	n/a	n/a	n/a	cross.bmp
-413.7770909091	n/a	103444.2727	show_face	unfamiliar_face	immediate_repeat	14	u111.bmp
-414.2780000000	n/a	103569.5	right_press	n/a	n/a	4096	n/a
-414.6807272727	n/a	103670.1818	show_circle	n/a	n/a	0	circle.bmp
-416.3807272727	n/a	104095.1818	show_cross	n/a	n/a	n/a	cross.bmp
-416.8670909091	n/a	104216.7727	show_face	unfamiliar_face	first_show	13	u004.bmp
-417.8380000000	n/a	104459.5	show_circle	n/a	n/a	0	circle.bmp
-418.0016363636	n/a	104500.4091	left_press	n/a	n/a	256	n/a
-419.5380000000	n/a	104884.5	show_cross	n/a	n/a	n/a	cross.bmp
-420.0580000000	n/a	105014.5	show_face	scrambled_face	first_show	17	s040.bmp
-420.9198181818	n/a	105229.9545	left_press	n/a	n/a	256	n/a
-421.0289090909	n/a	105257.2273	show_circle	n/a	n/a	0	circle.bmp
-422.7289090909	n/a	105682.2273	show_cross	n/a	n/a	n/a	cross.bmp
-423.1980000000	n/a	105799.5	show_face	scrambled_face	immediate_repeat	18	s040.bmp
-424.1507272727	n/a	106037.6818	show_circle	n/a	n/a	0	circle.bmp
-425.8507272727	n/a	106462.6818	show_cross	n/a	n/a	n/a	cross.bmp
-426.3725454545	n/a	106593.1364	show_face	scrambled_face	delayed_repeat	19	s119.bmp
-427.2543636364	n/a	106813.5909	show_circle	n/a	n/a	0	circle.bmp
-428.9543636364	n/a	107238.5909	show_cross	n/a	n/a	n/a	cross.bmp
-429.5970909091	n/a	107399.2727	show_face	famous_face	first_show	5	f006.bmp
-430.5280000000	n/a	107632	show_circle	n/a	n/a	0	circle.bmp
-432.2280000000	n/a	108057	show_cross	n/a	n/a	n/a	cross.bmp
-432.8370909091	n/a	108209.2727	show_face	famous_face	immediate_repeat	6	f006.bmp
-433.4970909091	n/a	108374.2727	right_press	n/a	n/a	4096	n/a
-433.8489090909	n/a	108462.2273	show_circle	n/a	n/a	0	circle.bmp
-435.5489090909	n/a	108887.2273	show_cross	n/a	n/a	n/a	cross.bmp
-436.1952727273	n/a	109048.8182	show_face	unfamiliar_face	first_show	13	u034.bmp
-436.8398181818	n/a	109209.9545	right_press	n/a	n/a	4096	n/a
-437.1043636364	n/a	109276.0909	show_circle	n/a	n/a	0	circle.bmp
-438.8043636364	n/a	109701.0909	show_cross	n/a	n/a	n/a	cross.bmp
-439.3852727273	n/a	109846.3182	show_face	unfamiliar_face	immediate_repeat	14	u034.bmp
-439.8234545455	n/a	109955.8636	right_press	n/a	n/a	4096	n/a
-440.3834545455	n/a	110095.8636	show_circle	n/a	n/a	0	circle.bmp
-442.0834545455	n/a	110520.8636	show_cross	n/a	n/a	n/a	cross.bmp
-442.6934545455	n/a	110673.3636	show_face	scrambled_face	delayed_repeat	19	s061.bmp
-443.6361818182	n/a	110909.0455	right_press	n/a	n/a	4096	n/a
-443.6716363636	n/a	110917.9091	show_circle	n/a	n/a	0	circle.bmp
-445.3716363636	n/a	111342.9091	show_cross	n/a	n/a	n/a	cross.bmp
-445.9170909091	n/a	111479.2727	show_face	unfamiliar_face	first_show	13	u075.bmp
-446.6943636364	n/a	111673.5909	left_press	n/a	n/a	256	n/a
-446.9280000000	n/a	111732	show_circle	n/a	n/a	0	circle.bmp
-448.6280000000	n/a	112157	show_cross	n/a	n/a	n/a	cross.bmp
-449.1080000000	n/a	112277	show_face	scrambled_face	first_show	17	s027.bmp
-449.9752727273	n/a	112493.8182	right_press	n/a	n/a	4096	n/a
-450.0698181818	n/a	112517.4545	show_circle	n/a	n/a	0	circle.bmp
-451.7698181818	n/a	112942.4545	show_cross	n/a	n/a	n/a	cross.bmp
-452.2816363636	n/a	113070.4091	show_face	unfamiliar_face	delayed_repeat	15	u004.bmp
-453.2407272727	n/a	113310.1818	left_press	n/a	n/a	256	n/a
-453.2561818182	n/a	113314.0455	show_circle	n/a	n/a	0	circle.bmp
-454.9561818182	n/a	113739.0455	show_cross	n/a	n/a	n/a	cross.bmp
-455.5898181818	n/a	113897.4545	show_face	famous_face	first_show	5	f024.bmp
-456.3480000000	n/a	114087	left_press	n/a	n/a	256	n/a
-456.5280000000	n/a	114132	show_circle	n/a	n/a	0	circle.bmp
-458.2280000000	n/a	114557	show_cross	n/a	n/a	n/a	cross.bmp
-458.8134545455	n/a	114703.3636	show_face	famous_face	immediate_repeat	6	f024.bmp
-459.8234545455	n/a	114955.8636	show_circle	n/a	n/a	0	circle.bmp
-461.5234545455	n/a	115380.8636	show_cross	n/a	n/a	n/a	cross.bmp
-462.0716363636	n/a	115517.9091	show_face	scrambled_face	first_show	17	s057.bmp
-463.0298181818	n/a	115757.4545	show_circle	n/a	n/a	0	circle.bmp
-463.1152727273	n/a	115778.8182	left_press	n/a	n/a	256	n/a
-464.7298181818	n/a	116182.4545	show_cross	n/a	n/a	n/a	cross.bmp
-465.2289090909	n/a	116307.2273	show_face	famous_face	first_show	5	f126.bmp
-466.1707272727	n/a	116542.6818	show_circle	n/a	n/a	0	circle.bmp
-467.8707272727	n/a	116967.6818	show_cross	n/a	n/a	n/a	cross.bmp
-468.3861818182	n/a	117096.5455	show_face	unfamiliar_face	first_show	13	u135.bmp
-469.2334545455	n/a	117308.3636	right_press	n/a	n/a	4096	n/a
-469.3252727273	n/a	117331.3182	show_circle	n/a	n/a	0	circle.bmp
-471.0252727273	n/a	117756.3182	show_cross	n/a	n/a	n/a	cross.bmp
-471.5261818182	n/a	117881.5455	show_face	unfamiliar_face	immediate_repeat	14	u135.bmp
-472.5361818182	n/a	118134.0455	show_circle	n/a	n/a	0	circle.bmp
-474.2361818182	n/a	118559.0455	show_cross	n/a	n/a	n/a	cross.bmp
-474.7507272727	n/a	118687.6818	show_face	unfamiliar_face	delayed_repeat	15	u075.bmp
-475.4425454545	n/a	118860.6364	left_press	n/a	n/a	256	n/a
-475.5734545455	n/a	118893.3636	show_circle	n/a	n/a	0	circle.bmp
-477.2734545455	n/a	119318.3636	show_cross	n/a	n/a	n/a	cross.bmp
-477.9080000000	n/a	119477	show_face	unfamiliar_face	first_show	13	u110.bmp
-478.8343636364	n/a	119708.5909	show_circle	n/a	n/a	0	circle.bmp
-479.0570909091	n/a	119764.2727	left_press	n/a	n/a	256	n/a
-480.5343636364	n/a	120133.5909	show_cross	n/a	n/a	n/a	cross.bmp
-481.1816363636	n/a	120295.4091	show_face	unfamiliar_face	immediate_repeat	14	u110.bmp
-481.6534545455	n/a	120413.3636	left_press	n/a	n/a	256	n/a
-482.1670909091	n/a	120541.7727	show_circle	n/a	n/a	0	circle.bmp
-483.8670909091	n/a	120966.7727	show_cross	n/a	n/a	n/a	cross.bmp
-484.3898181818	n/a	121097.4545	show_face	scrambled_face	delayed_repeat	19	s027.bmp
-484.9789090909	n/a	121244.7273	left_press	n/a	n/a	256	n/a
-485.2416363636	n/a	121310.4091	show_circle	n/a	n/a	0	circle.bmp
-486.9416363636	n/a	121735.4091	show_cross	n/a	n/a	n/a	cross.bmp
-487.5134545455	n/a	121878.3636	show_face	unfamiliar_face	first_show	13	u072.bmp
-488.1352727273	n/a	122033.8182	left_press	n/a	n/a	256	n/a
-488.3989090909	n/a	122099.7273	show_circle	n/a	n/a	0	circle.bmp
-490.0989090909	n/a	122524.7273	show_cross	n/a	n/a	n/a	cross.bmp
-490.7370909091	n/a	122684.2727	show_face	unfamiliar_face	immediate_repeat	14	u072.bmp
-491.1852727273	n/a	122796.3182	left_press	n/a	n/a	256	n/a
-491.5689090909	n/a	122892.2273	show_circle	n/a	n/a	0	circle.bmp
-493.2689090909	n/a	123317.2273	show_cross	n/a	n/a	n/a	cross.bmp
+onset	duration	sample	event_type	face_type	repetition_type	trial	trial_lag	trigger	stim_file
+0.004	n/a	1.0	setup	n/a	n/a	n/a	n/a	n/a	n/a
+0.004	n/a	1.0	right_sym	n/a	n/a	n/a	n/a	n/a	n/a
+25.0307272727	n/a	6257.6818	show_face	unfamiliar_face	first_show	1	n/a	13	u142.bmp
+25.8189090909	n/a	6454.7273	right_press	n/a	n/a	1	n/a	4096	n/a
+25.9616363636	n/a	6490.4091	show_circle	n/a	n/a	1	n/a	0	circle.bmp
+27.661636363600003	n/a	6915.4091	show_cross	n/a	n/a	2	n/a	n/a	cross.bmp
+28.1707272727	n/a	7042.6818	show_face	scrambled_face	first_show	2	n/a	17	s007.bmp
+28.8207272727	n/a	7205.1818	left_press	n/a	n/a	2	n/a	256	n/a
+29.111636363600002	n/a	7277.9091	show_circle	n/a	n/a	2	n/a	0	circle.bmp
+30.8116363636	n/a	7702.9091	show_cross	n/a	n/a	3	n/a	n/a	cross.bmp
+31.278	n/a	7819.5	show_face	scrambled_face	first_show	3	n/a	17	s004.bmp
+31.7961818182	n/a	7949.0455	left_press	n/a	n/a	3	n/a	256	n/a
+32.1225454545	n/a	8030.6364	show_circle	n/a	n/a	3	n/a	0	circle.bmp
+33.822545454499995	n/a	8455.6364	show_cross	n/a	n/a	4	n/a	n/a	cross.bmp
+34.301636363600004	n/a	8575.4091	show_face	famous_face	first_show	4	n/a	5	f086.bmp
+34.9652727273	n/a	8741.3182	right_press	n/a	n/a	4	n/a	4096	n/a
+35.1698181818	n/a	8792.4545	show_circle	n/a	n/a	4	n/a	0	circle.bmp
+36.8698181818	n/a	9217.4545	show_cross	n/a	n/a	5	n/a	n/a	cross.bmp
+37.3752727273	n/a	9343.8182	show_face	scrambled_face	first_show	5	n/a	17	s054.bmp
+37.8943636364	n/a	9473.5909	left_press	n/a	n/a	5	n/a	256	n/a
+38.3789090909	n/a	9594.7273	show_circle	n/a	n/a	5	n/a	0	circle.bmp
+40.0789090909	n/a	10019.7273	show_cross	n/a	n/a	6	n/a	n/a	cross.bmp
+40.6661818182	n/a	10166.5455	show_face	scrambled_face	immediate_repeat	6	1	18	s054.bmp
+41.1598181818	n/a	10289.9545	left_press	n/a	n/a	6	n/a	256	n/a
+41.4861818182	n/a	10371.5455	show_circle	n/a	n/a	6	n/a	0	circle.bmp
+43.1861818182	n/a	10796.5455	show_cross	n/a	n/a	7	n/a	n/a	cross.bmp
+43.6570909091	n/a	10914.2727	show_face	famous_face	first_show	7	n/a	5	f047.bmp
+44.4952727273	n/a	11123.8182	show_circle	n/a	n/a	7	n/a	0	circle.bmp
+44.8952727273	n/a	11223.8182	right_press	n/a	n/a	7	n/a	4096	n/a
+46.195272727299994	n/a	11548.8182	show_cross	n/a	n/a	8	n/a	n/a	cross.bmp
+46.747090909099995	n/a	11686.7727	show_face	famous_face	immediate_repeat	8	1	6	f047.bmp
+47.1843636364	n/a	11796.0909	right_press	n/a	n/a	8	n/a	4096	n/a
+47.7498181818	n/a	11937.4545	show_circle	n/a	n/a	8	n/a	0	circle.bmp
+49.449818181800005	n/a	12362.4545	show_cross	n/a	n/a	9	n/a	n/a	cross.bmp
+49.938	n/a	12484.5	show_face	unfamiliar_face	delayed_repeat	9	8	15	u142.bmp
+50.765272727299994	n/a	12691.3182	show_circle	n/a	n/a	9	n/a	0	circle.bmp
+51.34527272729999	n/a	12836.3182	left_press	n/a	n/a	9	n/a	256	n/a
+52.4652727273	n/a	13116.3182	show_cross	n/a	n/a	10	n/a	n/a	cross.bmp
+53.045272727299995	n/a	13261.3182	show_face	famous_face	first_show	10	n/a	5	f055.bmp
+53.631636363599995	n/a	13407.9091	right_press	n/a	n/a	10	n/a	4096	n/a
+53.8716363636	n/a	13467.9091	show_circle	n/a	n/a	10	n/a	0	circle.bmp
+55.5716363636	n/a	13892.9091	show_cross	n/a	n/a	11	n/a	n/a	cross.bmp
+56.085272727299994	n/a	14021.3182	show_face	famous_face	immediate_repeat	11	1	6	f055.bmp
+56.624363636400005	n/a	14156.0909	right_press	n/a	n/a	11	n/a	4096	n/a
+57.045272727299995	n/a	14261.3182	show_circle	n/a	n/a	11	n/a	0	circle.bmp
+58.7452727273	n/a	14686.3182	show_cross	n/a	n/a	12	n/a	n/a	cross.bmp
+59.2261818182	n/a	14806.5455	show_face	scrambled_face	delayed_repeat	12	10	19	s007.bmp
+59.7943636364	n/a	14948.5909	left_press	n/a	n/a	12	n/a	256	n/a
+60.1461818182	n/a	15036.5455	show_circle	n/a	n/a	12	n/a	0	circle.bmp
+61.846181818199994	n/a	15461.5455	show_cross	n/a	n/a	13	n/a	n/a	cross.bmp
+62.4670909091	n/a	15616.7727	show_face	famous_face	first_show	13	n/a	5	f097.bmp
+63.2325454545	n/a	15808.1364	left_press	n/a	n/a	13	n/a	256	n/a
+63.456181818199994	n/a	15864.0455	show_circle	n/a	n/a	13	n/a	0	circle.bmp
+65.1561818182	n/a	16289.0455	show_cross	n/a	n/a	14	n/a	n/a	cross.bmp
+65.7407272727	n/a	16435.1818	show_face	famous_face	immediate_repeat	14	1	6	f097.bmp
+66.1943636364	n/a	16548.5909	left_press	n/a	n/a	14	n/a	256	n/a
+66.7107272727	n/a	16677.6818	show_circle	n/a	n/a	14	n/a	0	circle.bmp
+68.4107272727	n/a	17102.6818	show_cross	n/a	n/a	15	n/a	n/a	cross.bmp
+69.0316363636	n/a	17257.9091	show_face	scrambled_face	delayed_repeat	15	12	19	s004.bmp
+69.8061818182	n/a	17451.5455	left_press	n/a	n/a	15	n/a	256	n/a
+69.9134545455	n/a	17478.3636	show_circle	n/a	n/a	15	n/a	0	circle.bmp
+71.6134545455	n/a	17903.3636	show_cross	n/a	n/a	16	n/a	n/a	cross.bmp
+72.1561818182	n/a	18039.0455	show_face	unfamiliar_face	first_show	16	n/a	13	u051.bmp
+72.80254545449999	n/a	18200.6364	right_press	n/a	n/a	16	n/a	4096	n/a
+73.03618181819999	n/a	18259.0455	show_circle	n/a	n/a	16	n/a	0	circle.bmp
+74.7361818182	n/a	18684.0455	show_cross	n/a	n/a	17	n/a	n/a	cross.bmp
+75.31345454550001	n/a	18828.3636	show_face	unfamiliar_face	immediate_repeat	17	1	14	u051.bmp
+75.768	n/a	18942.0	right_press	n/a	n/a	17	n/a	4096	n/a
+76.288	n/a	19072.0	show_circle	n/a	n/a	17	n/a	0	circle.bmp
+77.988	n/a	19497.0	show_cross	n/a	n/a	18	n/a	n/a	cross.bmp
+78.45345454550001	n/a	19613.3636	show_face	famous_face	delayed_repeat	18	14	7	f086.bmp
+79.13981818180001	n/a	19784.9545	right_press	n/a	n/a	18	n/a	4096	n/a
+79.46981818180001	n/a	19867.4545	show_circle	n/a	n/a	18	n/a	0	circle.bmp
+81.1698181818	n/a	20292.4545	show_cross	n/a	n/a	19	n/a	n/a	cross.bmp
+81.6443636364	n/a	20411.0909	show_face	famous_face	first_show	19	n/a	5	f001.bmp
+82.3107272727	n/a	20577.6818	right_press	n/a	n/a	19	n/a	4096	n/a
+82.5225454545	n/a	20630.6364	show_circle	n/a	n/a	19	n/a	0	circle.bmp
+84.2225454545	n/a	21055.6364	show_cross	n/a	n/a	20	n/a	n/a	cross.bmp
+84.7516363636	n/a	21187.9091	show_face	famous_face	immediate_repeat	20	1	6	f001.bmp
+85.4616363636	n/a	21365.4091	right_press	n/a	n/a	20	n/a	4096	n/a
+85.6070909091	n/a	21401.7727	show_circle	n/a	n/a	20	n/a	0	circle.bmp
+87.3070909091	n/a	21826.7727	show_cross	n/a	n/a	21	n/a	n/a	cross.bmp
+87.84254545450001	n/a	21960.6364	show_face	famous_face	first_show	21	n/a	5	f148.bmp
+88.8352727273	n/a	22208.8182	show_circle	n/a	n/a	21	n/a	0	circle.bmp
+89.1198181818	n/a	22279.9545	right_press	n/a	n/a	21	n/a	4096	n/a
+90.5352727273	n/a	22633.8182	show_cross	n/a	n/a	22	n/a	n/a	cross.bmp
+91.1661818182	n/a	22791.5455	show_face	famous_face	immediate_repeat	22	1	6	f148.bmp
+91.63163636360001	n/a	22907.9091	right_press	n/a	n/a	22	n/a	4096	n/a
+92.00345454549999	n/a	23000.8636	show_circle	n/a	n/a	22	n/a	0	circle.bmp
+93.7034545455	n/a	23425.8636	show_cross	n/a	n/a	23	n/a	n/a	cross.bmp
+94.2398181818	n/a	23559.9545	show_face	scrambled_face	first_show	23	n/a	17	s079.bmp
+94.838	n/a	23709.5	left_press	n/a	n/a	23	n/a	256	n/a
+95.09436363639999	n/a	23773.5909	show_circle	n/a	n/a	23	n/a	0	circle.bmp
+96.79436363639999	n/a	24198.5909	show_cross	n/a	n/a	24	n/a	n/a	cross.bmp
+97.4470909091	n/a	24361.7727	show_face	unfamiliar_face	first_show	24	n/a	13	u012.bmp
+98.2489090909	n/a	24562.2273	right_press	n/a	n/a	24	n/a	4096	n/a
+98.3470909091	n/a	24586.7727	show_circle	n/a	n/a	24	n/a	0	circle.bmp
+100.04709090909999	n/a	25011.7727	show_cross	n/a	n/a	25	n/a	n/a	cross.bmp
+100.6716363636	n/a	25167.9091	show_face	unfamiliar_face	immediate_repeat	25	1	14	u012.bmp
+101.23436363639999	n/a	25308.5909	right_press	n/a	n/a	25	n/a	4096	n/a
+101.5525454545	n/a	25388.1364	show_circle	n/a	n/a	25	n/a	0	circle.bmp
+103.25254545450001	n/a	25813.1364	show_cross	n/a	n/a	26	n/a	n/a	cross.bmp
+103.8116363636	n/a	25952.9091	show_face	famous_face	first_show	26	n/a	5	f114.bmp
+104.53618181819999	n/a	26134.0455	left_press	n/a	n/a	26	n/a	256	n/a
+104.6998181818	n/a	26174.9545	show_circle	n/a	n/a	26	n/a	0	circle.bmp
+106.3998181818	n/a	26599.9545	show_cross	n/a	n/a	27	n/a	n/a	cross.bmp
+107.00254545450001	n/a	26750.6364	show_face	famous_face	immediate_repeat	27	1	6	f114.bmp
+107.53254545450001	n/a	26883.1364	left_press	n/a	n/a	27	n/a	256	n/a
+107.82527272729999	n/a	26956.3182	show_circle	n/a	n/a	27	n/a	0	circle.bmp
+109.52527272729999	n/a	27381.3182	show_cross	n/a	n/a	28	n/a	n/a	cross.bmp
+110.19345454549999	n/a	27548.3636	show_face	unfamiliar_face	first_show	28	n/a	13	u095.bmp
+110.7852727273	n/a	27696.3182	right_press	n/a	n/a	28	n/a	4096	n/a
+111.1643636364	n/a	27791.0909	show_circle	n/a	n/a	28	n/a	0	circle.bmp
+112.8643636364	n/a	28216.0909	show_cross	n/a	n/a	29	n/a	n/a	cross.bmp
+113.40072727270001	n/a	28350.1818	show_face	unfamiliar_face	immediate_repeat	29	1	14	u095.bmp
+113.8970909091	n/a	28474.2727	right_press	n/a	n/a	29	n/a	4096	n/a
+114.38345454549999	n/a	28595.8636	show_circle	n/a	n/a	29	n/a	0	circle.bmp
+116.08345454549999	n/a	29020.8636	show_cross	n/a	n/a	30	n/a	n/a	cross.bmp
+116.69163636360001	n/a	29172.9091	show_face	unfamiliar_face	first_show	30	n/a	13	u102.bmp
+117.3689090909	n/a	29342.2273	right_press	n/a	n/a	30	n/a	4096	n/a
+117.7034545455	n/a	29425.8636	show_circle	n/a	n/a	30	n/a	0	circle.bmp
+119.4034545455	n/a	29850.8636	show_cross	n/a	n/a	31	n/a	n/a	cross.bmp
+120.0161818182	n/a	30004.0455	show_face	unfamiliar_face	immediate_repeat	31	1	14	u102.bmp
+120.778	n/a	30194.5	right_press	n/a	n/a	31	n/a	4096	n/a
+120.9216363636	n/a	30230.4091	show_circle	n/a	n/a	31	n/a	0	circle.bmp
+122.6216363636	n/a	30655.4091	show_cross	n/a	n/a	32	n/a	n/a	cross.bmp
+123.2570909091	n/a	30814.2727	show_face	scrambled_face	first_show	32	n/a	17	s020.bmp
+123.9661818182	n/a	30991.5455	left_press	n/a	n/a	32	n/a	256	n/a
+124.16527272729999	n/a	31041.3182	show_circle	n/a	n/a	32	n/a	0	circle.bmp
+125.8652727273	n/a	31466.3182	show_cross	n/a	n/a	33	n/a	n/a	cross.bmp
+126.498	n/a	31624.5	show_face	scrambled_face	delayed_repeat	33	10	19	s079.bmp
+127.11345454549999	n/a	31778.3636	left_press	n/a	n/a	33	n/a	256	n/a
+127.48436363639999	n/a	31871.0909	show_circle	n/a	n/a	33	n/a	0	circle.bmp
+129.1843636364	n/a	32296.0909	show_cross	n/a	n/a	34	n/a	n/a	cross.bmp
+129.7552727273	n/a	32438.8182	show_face	scrambled_face	first_show	34	n/a	17	s111.bmp
+130.6852727273	n/a	32671.3182	show_circle	n/a	n/a	34	n/a	0	circle.bmp
+131.0670909091	n/a	32766.7727	left_press	n/a	n/a	34	n/a	256	n/a
+132.3852727273	n/a	33096.3182	show_cross	n/a	n/a	35	n/a	n/a	cross.bmp
+133.0125454545	n/a	33253.1364	show_face	scrambled_face	first_show	35	n/a	17	s075.bmp
+133.8243636364	n/a	33456.0909	left_press	n/a	n/a	35	n/a	256	n/a
+134.01163636360002	n/a	33502.9091	show_circle	n/a	n/a	35	n/a	0	circle.bmp
+135.7116363636	n/a	33927.9091	show_cross	n/a	n/a	36	n/a	n/a	cross.bmp
+136.2698181818	n/a	34067.4545	show_face	scrambled_face	first_show	36	n/a	17	s118.bmp
+137.038	n/a	34259.5	left_press	n/a	n/a	36	n/a	256	n/a
+137.1243636364	n/a	34281.0909	show_circle	n/a	n/a	36	n/a	0	circle.bmp
+138.8243636364	n/a	34706.0909	show_cross	n/a	n/a	37	n/a	n/a	cross.bmp
+139.3443636364	n/a	34836.0909	show_face	famous_face	first_show	37	n/a	5	f026.bmp
+139.9325454545	n/a	34983.1364	right_press	n/a	n/a	37	n/a	4096	n/a
+140.218	n/a	35054.5	show_circle	n/a	n/a	37	n/a	0	circle.bmp
+141.918	n/a	35479.5	show_cross	n/a	n/a	38	n/a	n/a	cross.bmp
+142.5016363636	n/a	35625.4091	show_face	famous_face	first_show	38	n/a	5	f143.bmp
+143.1225454545	n/a	35780.6364	right_press	n/a	n/a	38	n/a	4096	n/a
+143.3798181818	n/a	35844.9545	show_circle	n/a	n/a	38	n/a	0	circle.bmp
+145.0798181818	n/a	36269.9545	show_cross	n/a	n/a	39	n/a	n/a	cross.bmp
+145.6252727273	n/a	36406.3182	show_face	scrambled_face	delayed_repeat	39	7	19	s020.bmp
+146.4752727273	n/a	36618.8182	right_press	n/a	n/a	39	n/a	4096	n/a
+146.4843636364	n/a	36621.0909	show_circle	n/a	n/a	39	n/a	0	circle.bmp
+148.1843636364	n/a	37046.0909	show_cross	n/a	n/a	40	n/a	n/a	cross.bmp
+148.7652727273	n/a	37191.3182	show_face	scrambled_face	first_show	40	n/a	17	s116.bmp
+149.5134545455	n/a	37378.3636	left_press	n/a	n/a	40	n/a	256	n/a
+149.7343636364	n/a	37433.5909	show_circle	n/a	n/a	40	n/a	0	circle.bmp
+151.4343636364	n/a	37858.5909	show_cross	n/a	n/a	41	n/a	n/a	cross.bmp
+151.9898181818	n/a	37997.4545	show_face	scrambled_face	immediate_repeat	41	1	18	s116.bmp
+152.6461818182	n/a	38161.5455	left_press	n/a	n/a	41	n/a	256	n/a
+152.9670909091	n/a	38241.7727	show_circle	n/a	n/a	41	n/a	0	circle.bmp
+154.6670909091	n/a	38666.7727	show_cross	n/a	n/a	42	n/a	n/a	cross.bmp
+155.2807272727	n/a	38820.1818	show_face	scrambled_face	delayed_repeat	42	8	19	s111.bmp
+156.1516363636	n/a	39037.9091	show_circle	n/a	n/a	42	n/a	0	circle.bmp
+156.2970909091	n/a	39074.2727	left_press	n/a	n/a	42	n/a	256	n/a
+157.8516363636	n/a	39462.9091	show_cross	n/a	n/a	43	n/a	n/a	cross.bmp
+158.3207272727	n/a	39580.1818	show_face	famous_face	first_show	43	n/a	5	f029.bmp
+158.9289090909	n/a	39732.2273	right_press	n/a	n/a	43	n/a	4096	n/a
+159.328	n/a	39832.0	show_circle	n/a	n/a	43	n/a	0	circle.bmp
+161.028	n/a	40257.0	show_cross	n/a	n/a	44	n/a	n/a	cross.bmp
+161.51163636360002	n/a	40377.9091	show_face	scrambled_face	delayed_repeat	44	9	19	s075.bmp
+162.3661818182	n/a	40591.5455	left_press	n/a	n/a	44	n/a	256	n/a
+162.5107272727	n/a	40627.6818	show_circle	n/a	n/a	44	n/a	0	circle.bmp
+164.2107272727	n/a	41052.6818	show_cross	n/a	n/a	45	n/a	n/a	cross.bmp
+164.6689090909	n/a	41167.2273	show_face	scrambled_face	first_show	45	n/a	17	s005.bmp
+165.2670909091	n/a	41316.7727	right_press	n/a	n/a	45	n/a	4096	n/a
+165.5989090909	n/a	41399.7273	show_circle	n/a	n/a	45	n/a	0	circle.bmp
+167.2989090909	n/a	41824.7273	show_cross	n/a	n/a	46	n/a	n/a	cross.bmp
+167.8098181818	n/a	41952.4545	show_face	scrambled_face	delayed_repeat	46	10	19	s118.bmp
+168.548	n/a	42137.0	left_press	n/a	n/a	46	n/a	256	n/a
+168.7252727273	n/a	42181.3182	show_circle	n/a	n/a	46	n/a	0	circle.bmp
+170.42527272729998	n/a	42606.3182	show_cross	n/a	n/a	47	n/a	n/a	cross.bmp
+170.9834545455	n/a	42745.8636	show_face	scrambled_face	first_show	47	n/a	17	s139.bmp
+171.6870909091	n/a	42921.7727	left_press	n/a	n/a	47	n/a	256	n/a
+171.818	n/a	42954.5	show_circle	n/a	n/a	47	n/a	0	circle.bmp
+173.518	n/a	43379.5	show_cross	n/a	n/a	48	n/a	n/a	cross.bmp
+174.1407272727	n/a	43535.1818	show_face	scrambled_face	immediate_repeat	48	1	18	s139.bmp
+174.9661818182	n/a	43741.5455	show_circle	n/a	n/a	48	n/a	0	circle.bmp
+175.1661818182	n/a	43791.5455	left_press	n/a	n/a	48	n/a	256	n/a
+176.6661818182	n/a	44166.5455	show_cross	n/a	n/a	49	n/a	n/a	cross.bmp
+177.1816363636	n/a	44295.4091	show_face	famous_face	delayed_repeat	49	12	7	f026.bmp
+177.7752727273	n/a	44443.8182	right_press	n/a	n/a	49	n/a	4096	n/a
+178.1743636364	n/a	44543.5909	show_circle	n/a	n/a	49	n/a	0	circle.bmp
+179.8743636364	n/a	44968.5909	show_cross	n/a	n/a	50	n/a	n/a	cross.bmp
+180.4889090909	n/a	45122.2273	show_face	unfamiliar_face	first_show	50	n/a	13	u001.bmp
+181.0852727273	n/a	45271.3182	left_press	n/a	n/a	50	n/a	256	n/a
+181.48163636360002	n/a	45370.4091	show_circle	n/a	n/a	50	n/a	0	circle.bmp
+183.1816363636	n/a	45795.4091	show_cross	n/a	n/a	51	n/a	n/a	cross.bmp
+183.66254545450002	n/a	45915.6364	show_face	famous_face	delayed_repeat	51	13	7	f143.bmp
+184.3807272727	n/a	46095.1818	right_press	n/a	n/a	51	n/a	4096	n/a
+184.5443636364	n/a	46136.0909	show_circle	n/a	n/a	51	n/a	0	circle.bmp
+186.24436363639998	n/a	46561.0909	show_cross	n/a	n/a	52	n/a	n/a	cross.bmp
+186.90345454549998	n/a	46725.8636	show_face	unfamiliar_face	first_show	52	n/a	13	u062.bmp
+187.808	n/a	46952.0	left_press	n/a	n/a	52	n/a	256	n/a
+187.92163636360002	n/a	46980.4091	show_circle	n/a	n/a	52	n/a	0	circle.bmp
+189.6216363636	n/a	47405.4091	show_cross	n/a	n/a	53	n/a	n/a	cross.bmp
+190.1616363636	n/a	47540.4091	show_face	unfamiliar_face	immediate_repeat	53	1	14	u062.bmp
+190.868	n/a	47717.0	left_press	n/a	n/a	53	n/a	256	n/a
+191.1389090909	n/a	47784.7273	show_circle	n/a	n/a	53	n/a	0	circle.bmp
+192.8389090909	n/a	48209.7273	show_cross	n/a	n/a	54	n/a	n/a	cross.bmp
+193.3852727273	n/a	48346.3182	show_face	unfamiliar_face	first_show	54	n/a	13	u125.bmp
+194.3289090909	n/a	48582.2273	left_press	n/a	n/a	54	n/a	256	n/a
+194.3361818182	n/a	48584.0455	show_circle	n/a	n/a	54	n/a	0	circle.bmp
+196.0361818182	n/a	49009.0455	show_cross	n/a	n/a	55	n/a	n/a	cross.bmp
+196.5261818182	n/a	49131.5455	show_face	unfamiliar_face	immediate_repeat	55	1	14	u125.bmp
+197.368	n/a	49342.0	show_circle	n/a	n/a	55	n/a	0	circle.bmp
+199.068	n/a	49767.0	show_cross	n/a	n/a	56	n/a	n/a	cross.bmp
+199.5661818182	n/a	49891.5455	show_face	famous_face	delayed_repeat	56	13	7	f029.bmp
+200.5034545455	n/a	50125.8636	right_press	n/a	n/a	56	n/a	4096	n/a
+200.5589090909	n/a	50139.7273	show_circle	n/a	n/a	56	n/a	0	circle.bmp
+202.2589090909	n/a	50564.7273	show_cross	n/a	n/a	57	n/a	n/a	cross.bmp
+202.7398181818	n/a	50684.9545	show_face	scrambled_face	first_show	57	n/a	17	s078.bmp
+203.54618181819998	n/a	50886.5455	left_press	n/a	n/a	57	n/a	256	n/a
+203.5607272727	n/a	50890.1818	show_circle	n/a	n/a	57	n/a	0	circle.bmp
+205.2607272727	n/a	51315.1818	show_cross	n/a	n/a	58	n/a	n/a	cross.bmp
+205.7807272727	n/a	51445.1818	show_face	scrambled_face	delayed_repeat	58	13	19	s005.bmp
+206.3325454545	n/a	51583.1364	right_press	n/a	n/a	58	n/a	4096	n/a
+206.6007272727	n/a	51650.1818	show_circle	n/a	n/a	58	n/a	0	circle.bmp
+208.30072727270002	n/a	52075.1818	show_cross	n/a	n/a	59	n/a	n/a	cross.bmp
+208.8707272727	n/a	52217.6818	show_face	famous_face	first_show	59	n/a	5	f031.bmp
+209.7470909091	n/a	52436.7727	show_circle	n/a	n/a	59	n/a	0	circle.bmp
+210.3161818182	n/a	52579.0455	left_press	n/a	n/a	59	n/a	256	n/a
+211.4470909091	n/a	52861.7727	show_cross	n/a	n/a	60	n/a	n/a	cross.bmp
+212.078	n/a	53019.5	show_face	famous_face	first_show	60	n/a	5	f107.bmp
+213.078	n/a	53269.5	show_circle	n/a	n/a	60	n/a	0	circle.bmp
+213.1861818182	n/a	53296.5455	left_press	n/a	n/a	60	n/a	256	n/a
+214.778	n/a	53694.5	show_cross	n/a	n/a	61	n/a	n/a	cross.bmp
+215.2689090909	n/a	53817.2273	show_face	famous_face	immediate_repeat	61	1	6	f107.bmp
+215.8089090909	n/a	53952.2273	left_press	n/a	n/a	61	n/a	256	n/a
+216.1398181818	n/a	54034.9545	show_circle	n/a	n/a	61	n/a	0	circle.bmp
+217.8398181818	n/a	54459.9545	show_cross	n/a	n/a	62	n/a	n/a	cross.bmp
+218.4761818182	n/a	54619.0455	show_face	unfamiliar_face	delayed_repeat	62	12	15	u001.bmp
+219.2507272727	n/a	54812.6818	left_press	n/a	n/a	62	n/a	256	n/a
+219.3707272727	n/a	54842.6818	show_circle	n/a	n/a	62	n/a	0	circle.bmp
+221.0707272727	n/a	55267.6818	show_cross	n/a	n/a	63	n/a	n/a	cross.bmp
+221.6170909091	n/a	55404.2727	show_face	famous_face	first_show	63	n/a	5	f116.bmp
+222.6243636364	n/a	55656.0909	show_circle	n/a	n/a	63	n/a	0	circle.bmp
+222.7298181818	n/a	55682.4545	right_press	n/a	n/a	63	n/a	4096	n/a
+224.3243636364	n/a	56081.0909	show_cross	n/a	n/a	64	n/a	n/a	cross.bmp
+224.8589090909	n/a	56214.7273	show_face	famous_face	first_show	64	n/a	5	f016.bmp
+225.4561818182	n/a	56364.0455	right_press	n/a	n/a	64	n/a	4096	n/a
+225.74436363639998	n/a	56436.0909	show_circle	n/a	n/a	64	n/a	0	circle.bmp
+227.4443636364	n/a	56861.0909	show_cross	n/a	n/a	65	n/a	n/a	cross.bmp
+227.9316363636	n/a	56982.9091	show_face	famous_face	immediate_repeat	65	1	6	f016.bmp
+228.8170909091	n/a	57204.2727	show_circle	n/a	n/a	65	n/a	0	circle.bmp
+229.4607272727	n/a	57365.1818	right_press	n/a	n/a	65	n/a	4096	n/a
+230.5170909091	n/a	57629.2727	show_cross	n/a	n/a	66	n/a	n/a	cross.bmp
+230.9716363636	n/a	57742.9091	show_face	famous_face	first_show	66	n/a	5	f083.bmp
+231.7252727273	n/a	57931.3182	right_press	n/a	n/a	66	n/a	4096	n/a
+231.89981818180001	n/a	57974.9545	show_circle	n/a	n/a	66	n/a	0	circle.bmp
+233.5998181818	n/a	58399.9545	show_cross	n/a	n/a	67	n/a	n/a	cross.bmp
+234.1789090909	n/a	58544.7273	show_face	famous_face	immediate_repeat	67	1	6	f083.bmp
+235.1570909091	n/a	58789.2727	show_circle	n/a	n/a	67	n/a	0	circle.bmp
+236.8570909091	n/a	59214.2727	show_cross	n/a	n/a	68	n/a	n/a	cross.bmp
+237.4370909091	n/a	59359.2727	show_face	scrambled_face	delayed_repeat	68	11	19	s078.bmp
+238.168	n/a	59542.0	left_press	n/a	n/a	68	n/a	256	n/a
+238.2670909091	n/a	59566.7727	show_circle	n/a	n/a	68	n/a	0	circle.bmp
+239.9670909091	n/a	59991.7727	show_cross	n/a	n/a	69	n/a	n/a	cross.bmp
+240.4434545455	n/a	60110.8636	show_face	unfamiliar_face	first_show	69	n/a	13	u010.bmp
+241.1516363636	n/a	60287.9091	right_press	n/a	n/a	69	n/a	4096	n/a
+241.3807272727	n/a	60345.1818	show_circle	n/a	n/a	69	n/a	0	circle.bmp
+243.08072727270002	n/a	60770.1818	show_cross	n/a	n/a	70	n/a	n/a	cross.bmp
+243.6843636364	n/a	60921.0909	show_face	famous_face	delayed_repeat	70	11	7	f031.bmp
+244.5898181818	n/a	61147.4545	left_press	n/a	n/a	70	n/a	256	n/a
+244.6298181818	n/a	61157.4545	show_circle	n/a	n/a	70	n/a	0	circle.bmp
+246.3298181818	n/a	61582.4545	show_cross	n/a	n/a	71	n/a	n/a	cross.bmp
+246.8752727273	n/a	61718.8182	show_face	unfamiliar_face	first_show	71	n/a	13	u059.bmp
+247.8107272727	n/a	61952.6818	left_press	n/a	n/a	71	n/a	256	n/a
+247.8643636364	n/a	61966.0909	show_circle	n/a	n/a	71	n/a	0	circle.bmp
+249.5643636364	n/a	62391.0909	show_cross	n/a	n/a	72	n/a	n/a	cross.bmp
+250.0489090909	n/a	62512.2273	show_face	scrambled_face	first_show	72	n/a	17	s042.bmp
+250.89527272729998	n/a	62723.8182	right_press	n/a	n/a	72	n/a	4096	n/a
+250.9270909091	n/a	62731.7727	show_circle	n/a	n/a	72	n/a	0	circle.bmp
+252.6270909091	n/a	63156.7727	show_cross	n/a	n/a	73	n/a	n/a	cross.bmp
+253.1561818182	n/a	63289.0455	show_face	scrambled_face	immediate_repeat	73	1	18	s042.bmp
+254.09345454549998	n/a	63523.3636	show_circle	n/a	n/a	73	n/a	0	circle.bmp
+254.17527272729998	n/a	63543.8182	left_press	n/a	n/a	73	n/a	256	n/a
+255.7934545455	n/a	63948.3636	show_cross	n/a	n/a	74	n/a	n/a	cross.bmp
+256.3307272727	n/a	64082.6818	show_face	famous_face	delayed_repeat	74	11	7	f116.bmp
+257.0661818182	n/a	64266.5455	right_press	n/a	n/a	74	n/a	4096	n/a
+257.148	n/a	64287.0	show_circle	n/a	n/a	74	n/a	0	circle.bmp
+258.848	n/a	64712.0	show_cross	n/a	n/a	75	n/a	n/a	cross.bmp
+259.4043636364	n/a	64851.0909	show_face	scrambled_face	first_show	75	n/a	17	s014.bmp
+260.3316363636	n/a	65082.9091	show_circle	n/a	n/a	75	n/a	0	circle.bmp
+262.0316363636	n/a	65507.9091	show_cross	n/a	n/a	76	n/a	n/a	cross.bmp
+262.56163636360003	n/a	65640.4091	show_face	scrambled_face	immediate_repeat	76	1	18	s014.bmp
+263.258	n/a	65814.5	left_press	n/a	n/a	76	n/a	256	n/a
+263.3961818182	n/a	65849.0455	show_circle	n/a	n/a	76	n/a	0	circle.bmp
+265.0961818182	n/a	66274.0455	show_cross	n/a	n/a	77	n/a	n/a	cross.bmp
+265.5852727273	n/a	66396.3182	show_face	unfamiliar_face	first_show	77	n/a	13	u082.bmp
+266.2570909091	n/a	66564.2727	left_press	n/a	n/a	77	n/a	256	n/a
+266.4343636364	n/a	66608.5909	show_circle	n/a	n/a	77	n/a	0	circle.bmp
+268.1343636364	n/a	67033.5909	show_cross	n/a	n/a	78	n/a	n/a	cross.bmp
+268.7252727273	n/a	67181.3182	show_face	unfamiliar_face	immediate_repeat	78	1	14	u082.bmp
+269.3107272727	n/a	67327.6818	left_press	n/a	n/a	78	n/a	256	n/a
+269.6116363636	n/a	67402.9091	show_circle	n/a	n/a	78	n/a	0	circle.bmp
+271.31163636360003	n/a	67827.9091	show_cross	n/a	n/a	79	n/a	n/a	cross.bmp
+271.8325454545	n/a	67958.1364	show_face	famous_face	first_show	79	n/a	5	f023.bmp
+272.7407272727	n/a	68185.1818	right_press	n/a	n/a	79	n/a	4096	n/a
+272.798	n/a	68199.5	show_circle	n/a	n/a	79	n/a	0	circle.bmp
+274.498	n/a	68624.5	show_cross	n/a	n/a	80	n/a	n/a	cross.bmp
+275.0734545455	n/a	68768.3636	show_face	unfamiliar_face	delayed_repeat	80	11	15	u010.bmp
+275.7016363636	n/a	68925.4091	right_press	n/a	n/a	80	n/a	4096	n/a
+275.99254545450003	n/a	68998.1364	show_circle	n/a	n/a	80	n/a	0	circle.bmp
+277.6925454545	n/a	69423.1364	show_cross	n/a	n/a	81	n/a	n/a	cross.bmp
+278.2143636364	n/a	69553.5909	show_face	famous_face	first_show	81	n/a	5	f118.bmp
+279.0925454545	n/a	69773.1364	right_press	n/a	n/a	81	n/a	4096	n/a
+279.16436363639997	n/a	69791.0909	show_circle	n/a	n/a	81	n/a	0	circle.bmp
+280.8643636364	n/a	70216.0909	show_cross	n/a	n/a	82	n/a	n/a	cross.bmp
+281.4716363636	n/a	70367.9091	show_face	famous_face	immediate_repeat	82	1	6	f118.bmp
+282.358	n/a	70589.5	show_circle	n/a	n/a	82	n/a	0	circle.bmp
+283.2216363636	n/a	70805.4091	right_press	n/a	n/a	82	n/a	4096	n/a
+284.058	n/a	71014.5	show_cross	n/a	n/a	83	n/a	n/a	cross.bmp
+284.56163636360003	n/a	71140.4091	show_face	unfamiliar_face	delayed_repeat	83	12	15	u059.bmp
+285.4061818182	n/a	71351.5455	show_circle	n/a	n/a	83	n/a	0	circle.bmp
+285.5416363636	n/a	71385.4091	right_press	n/a	n/a	83	n/a	4096	n/a
+287.1061818182	n/a	71776.5455	show_cross	n/a	n/a	84	n/a	n/a	cross.bmp
+287.5861818182	n/a	71896.5455	show_face	scrambled_face	first_show	84	n/a	17	s125.bmp
+288.598	n/a	72149.5	show_circle	n/a	n/a	84	n/a	0	circle.bmp
+290.298	n/a	72574.5	show_cross	n/a	n/a	85	n/a	n/a	cross.bmp
+290.8770909091	n/a	72719.2727	show_face	unfamiliar_face	first_show	85	n/a	13	u033.bmp
+291.7034545455	n/a	72925.8636	show_circle	n/a	n/a	85	n/a	0	circle.bmp
+291.9352727273	n/a	72983.8182	left_press	n/a	n/a	85	n/a	256	n/a
+293.4034545455	n/a	73350.8636	show_cross	n/a	n/a	86	n/a	n/a	cross.bmp
+293.9007272727	n/a	73475.1818	show_face	famous_face	first_show	86	n/a	5	f068.bmp
+294.5925454545	n/a	73648.1364	right_press	n/a	n/a	86	n/a	4096	n/a
+294.8761818182	n/a	73719.0455	show_circle	n/a	n/a	86	n/a	0	circle.bmp
+296.5761818182	n/a	74144.0455	show_cross	n/a	n/a	87	n/a	n/a	cross.bmp
+297.0907272727	n/a	74272.6818	show_face	unfamiliar_face	first_show	87	n/a	13	u038.bmp
+297.9107272727	n/a	74477.6818	right_press	n/a	n/a	87	n/a	4096	n/a
+297.9252727273	n/a	74481.3182	show_circle	n/a	n/a	87	n/a	0	circle.bmp
+299.6252727273	n/a	74906.3182	show_cross	n/a	n/a	88	n/a	n/a	cross.bmp
+300.148	n/a	75037.0	show_face	unfamiliar_face	immediate_repeat	88	1	14	u038.bmp
+300.8143636364	n/a	75203.5909	left_press	n/a	n/a	88	n/a	256	n/a
+300.9970909091	n/a	75249.2727	show_circle	n/a	n/a	88	n/a	0	circle.bmp
+302.6970909091	n/a	75674.2727	show_cross	n/a	n/a	89	n/a	n/a	cross.bmp
+303.2216363636	n/a	75805.4091	show_face	famous_face	delayed_repeat	89	10	7	f023.bmp
+303.8261818182	n/a	75956.5455	right_press	n/a	n/a	89	n/a	4096	n/a
+304.0761818182	n/a	76019.0455	show_circle	n/a	n/a	89	n/a	0	circle.bmp
+305.7761818182	n/a	76444.0455	show_cross	n/a	n/a	90	n/a	n/a	cross.bmp
+306.3961818182	n/a	76599.0455	show_face	scrambled_face	first_show	90	n/a	17	s098.bmp
+307.0561818182	n/a	76764.0455	left_press	n/a	n/a	90	n/a	256	n/a
+307.3434545455	n/a	76835.8636	show_circle	n/a	n/a	90	n/a	0	circle.bmp
+309.04345454549997	n/a	77260.8636	show_cross	n/a	n/a	91	n/a	n/a	cross.bmp
+309.6361818182	n/a	77409.0455	show_face	unfamiliar_face	first_show	91	n/a	13	u137.bmp
+310.358	n/a	77589.5	left_press	n/a	n/a	91	n/a	256	n/a
+310.6361818182	n/a	77659.0455	show_circle	n/a	n/a	91	n/a	0	circle.bmp
+312.3361818182	n/a	78084.0455	show_cross	n/a	n/a	92	n/a	n/a	cross.bmp
+312.8270909091	n/a	78206.7727	show_face	unfamiliar_face	immediate_repeat	92	1	14	u137.bmp
+313.4943636364	n/a	78373.5909	left_press	n/a	n/a	92	n/a	256	n/a
+313.7798181818	n/a	78444.9545	show_circle	n/a	n/a	92	n/a	0	circle.bmp
+315.4798181818	n/a	78869.9545	show_cross	n/a	n/a	93	n/a	n/a	cross.bmp
+315.9343636364	n/a	78983.5909	show_face	scrambled_face	delayed_repeat	93	9	19	s125.bmp
+316.7607272727	n/a	79190.1818	show_circle	n/a	n/a	93	n/a	0	circle.bmp
+318.4607272727	n/a	79615.1818	show_cross	n/a	n/a	94	n/a	n/a	cross.bmp
+319.0252727273	n/a	79756.3182	show_face	scrambled_face	first_show	94	n/a	17	s008.bmp
+319.8625454545	n/a	79965.6364	show_circle	n/a	n/a	94	n/a	0	circle.bmp
+321.5625454545	n/a	80390.6364	show_cross	n/a	n/a	95	n/a	n/a	cross.bmp
+322.0489090909	n/a	80512.2273	show_face	unfamiliar_face	delayed_repeat	95	10	15	u033.bmp
+322.9398181818	n/a	80734.9545	right_press	n/a	n/a	95	n/a	4096	n/a
+322.9598181818	n/a	80739.9545	show_circle	n/a	n/a	95	n/a	0	circle.bmp
+324.6598181818	n/a	81164.9545	show_cross	n/a	n/a	96	n/a	n/a	cross.bmp
+325.1889090909	n/a	81297.2273	show_face	famous_face	first_show	96	n/a	5	f146.bmp
+325.9034545455	n/a	81475.8636	left_press	n/a	n/a	96	n/a	256	n/a
+326.1925454545	n/a	81548.1364	show_circle	n/a	n/a	96	n/a	0	circle.bmp
+327.8925454545	n/a	81973.1364	show_cross	n/a	n/a	97	n/a	n/a	cross.bmp
+328.3961818182	n/a	82099.0455	show_face	famous_face	delayed_repeat	97	11	7	f068.bmp
+329.1516363636	n/a	82287.9091	right_press	n/a	n/a	97	n/a	4096	n/a
+329.3270909091	n/a	82331.7727	show_circle	n/a	n/a	97	n/a	0	circle.bmp
+331.0270909091	n/a	82756.7727	show_cross	n/a	n/a	98	n/a	n/a	cross.bmp
+331.60345454549997	n/a	82900.8636	show_face	famous_face	first_show	98	n/a	5	f061.bmp
+332.3098181818	n/a	83077.4545	right_press	n/a	n/a	98	n/a	4096	n/a
+332.528	n/a	83132.0	show_circle	n/a	n/a	98	n/a	0	circle.bmp
+334.228	n/a	83557.0	show_cross	n/a	n/a	99	n/a	n/a	cross.bmp
+334.8443636364	n/a	83711.0909	show_face	scrambled_face	first_show	99	n/a	17	s019.bmp
+335.438	n/a	83859.5	left_press	n/a	n/a	99	n/a	256	n/a
+335.8034545455	n/a	83950.8636	show_circle	n/a	n/a	99	n/a	0	circle.bmp
+337.5034545455	n/a	84375.8636	show_cross	n/a	n/a	100	n/a	n/a	cross.bmp
+338.0189090909	n/a	84504.7273	show_face	scrambled_face	delayed_repeat	100	10	19	s098.bmp
+338.7707272727	n/a	84692.6818	left_press	n/a	n/a	100	n/a	256	n/a
+338.9734545455	n/a	84743.3636	show_circle	n/a	n/a	100	n/a	0	circle.bmp
+340.67345454549996	n/a	85168.3636	show_cross	n/a	n/a	101	n/a	n/a	cross.bmp
+341.3098181818	n/a	85327.4545	show_face	unfamiliar_face	first_show	101	n/a	13	u116.bmp
+342.0389090909	n/a	85509.7273	right_press	n/a	n/a	101	n/a	4096	n/a
+342.3007272727	n/a	85575.1818	show_circle	n/a	n/a	101	n/a	0	circle.bmp
+344.0007272727	n/a	86000.1818	show_cross	n/a	n/a	102	n/a	n/a	cross.bmp
+344.4834545455	n/a	86120.8636	show_face	unfamiliar_face	first_show	102	n/a	13	u036.bmp
+345.41072727269994	n/a	86352.6818	left_press	n/a	n/a	102	n/a	256	n/a
+345.43709090910005	n/a	86359.2727	show_circle	n/a	n/a	102	n/a	0	circle.bmp
+347.13709090910004	n/a	86784.2727	show_cross	n/a	n/a	103	n/a	n/a	cross.bmp
+347.758	n/a	86939.5	show_face	scrambled_face	delayed_repeat	103	9	19	s008.bmp
+348.4725454545	n/a	87118.1364	left_press	n/a	n/a	103	n/a	256	n/a
+348.6516363636	n/a	87162.9091	show_circle	n/a	n/a	103	n/a	0	circle.bmp
+350.3516363636	n/a	87587.9091	show_cross	n/a	n/a	104	n/a	n/a	cross.bmp
+350.848	n/a	87712.0	show_face	famous_face	first_show	104	n/a	5	f053.bmp
+351.58072727269996	n/a	87895.1818	left_press	n/a	n/a	104	n/a	256	n/a
+351.6670909091	n/a	87916.7727	show_circle	n/a	n/a	104	n/a	0	circle.bmp
+353.36709090910006	n/a	88341.7727	show_cross	n/a	n/a	105	n/a	n/a	cross.bmp
+353.8561818182	n/a	88464.0455	show_face	famous_face	delayed_repeat	105	9	7	f146.bmp
+354.768	n/a	88692.0	show_circle	n/a	n/a	105	n/a	0	circle.bmp
+354.7770909091	n/a	88694.2727	left_press	n/a	n/a	105	n/a	256	n/a
+356.468	n/a	89117.0	show_cross	n/a	n/a	106	n/a	n/a	cross.bmp
+357.1125454545	n/a	89278.1364	show_face	unfamiliar_face	first_show	106	n/a	13	u067.bmp
+357.95890909089997	n/a	89489.7273	show_circle	n/a	n/a	106	n/a	0	circle.bmp
+357.9898181818	n/a	89497.4545	left_press	n/a	n/a	106	n/a	256	n/a
+359.65890909089995	n/a	89914.7273	show_cross	n/a	n/a	107	n/a	n/a	cross.bmp
+360.2870909091	n/a	90071.7727	show_face	famous_face	delayed_repeat	107	9	7	f061.bmp
+361.2307272727	n/a	90307.6818	show_circle	n/a	n/a	107	n/a	0	circle.bmp
+361.6698181818	n/a	90417.4545	right_press	n/a	n/a	107	n/a	4096	n/a
+362.9307272727	n/a	90732.6818	show_cross	n/a	n/a	108	n/a	n/a	cross.bmp
+363.5607272727	n/a	90890.1818	show_face	famous_face	first_show	108	n/a	5	f125.bmp
+364.388	n/a	91097.0	show_circle	n/a	n/a	108	n/a	0	circle.bmp
+364.46254545449995	n/a	91115.6364	right_press	n/a	n/a	108	n/a	4096	n/a
+366.088	n/a	91522.0	show_cross	n/a	n/a	109	n/a	n/a	cross.bmp
+366.5507272727	n/a	91637.6818	show_face	famous_face	immediate_repeat	109	1	6	f125.bmp
+367.40527272730003	n/a	91851.3182	show_circle	n/a	n/a	109	n/a	0	circle.bmp
+369.1052727273	n/a	92276.3182	show_cross	n/a	n/a	110	n/a	n/a	cross.bmp
+369.26254545449996	n/a	92315.6364	right_press	n/a	n/a	110	n/a	4096	n/a
+369.708	n/a	92427.0	show_face	scrambled_face	delayed_repeat	110	11	19	s019.bmp
+370.5689090909	n/a	92642.2273	show_circle	n/a	n/a	110	n/a	0	circle.bmp
+371.2998181818	n/a	92824.9545	left_press	n/a	n/a	110	n/a	256	n/a
+372.26890909089997	n/a	93067.2273	show_cross	n/a	n/a	111	n/a	n/a	cross.bmp
+372.8652727273	n/a	93216.3182	show_face	unfamiliar_face	first_show	111	n/a	13	u117.bmp
+373.808	n/a	93452.0	show_circle	n/a	n/a	111	n/a	0	circle.bmp
+373.8107272727	n/a	93452.6818	right_press	n/a	n/a	111	n/a	4096	n/a
+375.508	n/a	93877.0	show_cross	n/a	n/a	112	n/a	n/a	cross.bmp
+376.0898181818	n/a	94022.4545	show_face	unfamiliar_face	immediate_repeat	112	1	14	u117.bmp
+376.7343636364	n/a	94183.5909	right_press	n/a	n/a	112	n/a	4096	n/a
+376.9798181818	n/a	94244.9545	show_circle	n/a	n/a	112	n/a	0	circle.bmp
+378.6798181818	n/a	94669.9545	show_cross	n/a	n/a	113	n/a	n/a	cross.bmp
+379.3134545455	n/a	94828.3636	show_face	unfamiliar_face	delayed_repeat	113	12	15	u116.bmp
+380.0861818182	n/a	95021.5455	right_press	n/a	n/a	113	n/a	4096	n/a
+380.13527272730005	n/a	95033.8182	show_circle	n/a	n/a	113	n/a	0	circle.bmp
+381.83527272730004	n/a	95458.8182	show_cross	n/a	n/a	114	n/a	n/a	cross.bmp
+382.3043636364	n/a	95576.0909	show_face	scrambled_face	first_show	114	n/a	17	s134.bmp
+383.16436363639997	n/a	95791.0909	right_press	n/a	n/a	114	n/a	4096	n/a
+383.27254545449995	n/a	95818.1364	show_circle	n/a	n/a	114	n/a	0	circle.bmp
+384.9725454545	n/a	96243.1364	show_cross	n/a	n/a	115	n/a	n/a	cross.bmp
+385.478	n/a	96369.5	show_face	scrambled_face	immediate_repeat	115	1	18	s134.bmp
+385.96072727269996	n/a	96490.1818	right_press	n/a	n/a	115	n/a	4096	n/a
+386.4152727273	n/a	96603.8182	show_circle	n/a	n/a	115	n/a	0	circle.bmp
+388.1152727273	n/a	97028.8182	show_cross	n/a	n/a	116	n/a	n/a	cross.bmp
+388.63527272730005	n/a	97158.8182	show_face	unfamiliar_face	delayed_repeat	116	14	15	u036.bmp
+389.468	n/a	97367.0	show_circle	n/a	n/a	116	n/a	0	circle.bmp
+389.5534545455	n/a	97388.3636	left_press	n/a	n/a	116	n/a	256	n/a
+391.168	n/a	97792.0	show_cross	n/a	n/a	117	n/a	n/a	cross.bmp
+391.65890909089995	n/a	97914.7273	show_face	scrambled_face	first_show	117	n/a	17	s119.bmp
+392.23890909089994	n/a	98059.7273	left_press	n/a	n/a	117	n/a	256	n/a
+392.588	n/a	98147.0	show_circle	n/a	n/a	117	n/a	0	circle.bmp
+394.288	n/a	98572.0	show_cross	n/a	n/a	118	n/a	n/a	cross.bmp
+394.7325454545	n/a	98683.1364	show_face	famous_face	delayed_repeat	118	14	7	f053.bmp
+395.4798181818	n/a	98869.9545	left_press	n/a	n/a	118	n/a	256	n/a
+395.59345454550004	n/a	98898.3636	show_circle	n/a	n/a	118	n/a	0	circle.bmp
+397.2934545455	n/a	99323.3636	show_cross	n/a	n/a	119	n/a	n/a	cross.bmp
+397.7898181818	n/a	99447.4545	show_face	scrambled_face	first_show	119	n/a	17	s021.bmp
+398.63527272730005	n/a	99658.8182	show_circle	n/a	n/a	119	n/a	0	circle.bmp
+400.33527272730004	n/a	100083.8182	show_cross	n/a	n/a	120	n/a	n/a	cross.bmp
+400.96345454550004	n/a	100240.8636	show_face	scrambled_face	immediate_repeat	120	1	18	s021.bmp
+401.8698181818	n/a	100467.4545	left_press	n/a	n/a	120	n/a	256	n/a
+401.9307272727	n/a	100482.6818	show_circle	n/a	n/a	120	n/a	0	circle.bmp
+403.63072727269997	n/a	100907.6818	show_cross	n/a	n/a	121	n/a	n/a	cross.bmp
+404.2216363636	n/a	101055.4091	show_face	unfamiliar_face	delayed_repeat	121	15	15	u067.bmp
+405.0061818182	n/a	101251.5455	left_press	n/a	n/a	121	n/a	256	n/a
+405.168	n/a	101292.0	show_circle	n/a	n/a	121	n/a	0	circle.bmp
+406.868	n/a	101717.0	show_cross	n/a	n/a	122	n/a	n/a	cross.bmp
+407.3961818182	n/a	101849.0455	show_face	scrambled_face	first_show	122	n/a	17	s061.bmp
+408.37254545449997	n/a	102093.1364	show_circle	n/a	n/a	122	n/a	0	circle.bmp
+410.07254545449996	n/a	102518.1364	show_cross	n/a	n/a	123	n/a	n/a	cross.bmp
+410.7198181818	n/a	102679.9545	show_face	unfamiliar_face	first_show	123	n/a	13	u111.bmp
+411.3516363636	n/a	102837.9091	right_press	n/a	n/a	123	n/a	4096	n/a
+411.58527272730004	n/a	102896.3182	show_circle	n/a	n/a	123	n/a	0	circle.bmp
+413.2852727273	n/a	103321.3182	show_cross	n/a	n/a	124	n/a	n/a	cross.bmp
+413.7770909091	n/a	103444.2727	show_face	unfamiliar_face	immediate_repeat	124	1	14	u111.bmp
+414.278	n/a	103569.5	right_press	n/a	n/a	124	n/a	4096	n/a
+414.6807272727	n/a	103670.1818	show_circle	n/a	n/a	124	n/a	0	circle.bmp
+416.38072727269997	n/a	104095.1818	show_cross	n/a	n/a	125	n/a	n/a	cross.bmp
+416.86709090910006	n/a	104216.7727	show_face	unfamiliar_face	first_show	125	n/a	13	u004.bmp
+417.838	n/a	104459.5	show_circle	n/a	n/a	125	n/a	0	circle.bmp
+418.0016363636	n/a	104500.4091	left_press	n/a	n/a	125	n/a	256	n/a
+419.538	n/a	104884.5	show_cross	n/a	n/a	126	n/a	n/a	cross.bmp
+420.058	n/a	105014.5	show_face	scrambled_face	first_show	126	n/a	17	s040.bmp
+420.9198181818	n/a	105229.9545	left_press	n/a	n/a	126	n/a	256	n/a
+421.02890909089996	n/a	105257.2273	show_circle	n/a	n/a	126	n/a	0	circle.bmp
+422.72890909089995	n/a	105682.2273	show_cross	n/a	n/a	127	n/a	n/a	cross.bmp
+423.198	n/a	105799.5	show_face	scrambled_face	immediate_repeat	127	1	18	s040.bmp
+424.15072727269995	n/a	106037.6818	show_circle	n/a	n/a	127	n/a	0	circle.bmp
+425.85072727269994	n/a	106462.6818	show_cross	n/a	n/a	128	n/a	n/a	cross.bmp
+426.37254545449997	n/a	106593.1364	show_face	scrambled_face	delayed_repeat	128	11	19	s119.bmp
+427.2543636364	n/a	106813.5909	show_circle	n/a	n/a	128	n/a	0	circle.bmp
+428.9543636364	n/a	107238.5909	show_cross	n/a	n/a	129	n/a	n/a	cross.bmp
+429.5970909091	n/a	107399.2727	show_face	famous_face	first_show	129	n/a	5	f006.bmp
+430.528	n/a	107632.0	show_circle	n/a	n/a	129	n/a	0	circle.bmp
+432.228	n/a	108057.0	show_cross	n/a	n/a	130	n/a	n/a	cross.bmp
+432.8370909091	n/a	108209.2727	show_face	famous_face	immediate_repeat	130	1	6	f006.bmp
+433.49709090910005	n/a	108374.2727	right_press	n/a	n/a	130	n/a	4096	n/a
+433.84890909089995	n/a	108462.2273	show_circle	n/a	n/a	130	n/a	0	circle.bmp
+435.54890909089994	n/a	108887.2273	show_cross	n/a	n/a	131	n/a	n/a	cross.bmp
+436.19527272730005	n/a	109048.8182	show_face	unfamiliar_face	first_show	131	n/a	13	u034.bmp
+436.8398181818	n/a	109209.9545	right_press	n/a	n/a	131	n/a	4096	n/a
+437.10436363639997	n/a	109276.0909	show_circle	n/a	n/a	131	n/a	0	circle.bmp
+438.8043636364	n/a	109701.0909	show_cross	n/a	n/a	132	n/a	n/a	cross.bmp
+439.38527272730005	n/a	109846.3182	show_face	unfamiliar_face	immediate_repeat	132	1	14	u034.bmp
+439.82345454550006	n/a	109955.8636	right_press	n/a	n/a	132	n/a	4096	n/a
+440.38345454550006	n/a	110095.8636	show_circle	n/a	n/a	132	n/a	0	circle.bmp
+442.08345454550005	n/a	110520.8636	show_cross	n/a	n/a	133	n/a	n/a	cross.bmp
+442.6934545455	n/a	110673.3636	show_face	scrambled_face	delayed_repeat	133	11	19	s061.bmp
+443.6361818182	n/a	110909.0455	right_press	n/a	n/a	133	n/a	4096	n/a
+443.6716363636	n/a	110917.9091	show_circle	n/a	n/a	133	n/a	0	circle.bmp
+445.37163636360003	n/a	111342.9091	show_cross	n/a	n/a	134	n/a	n/a	cross.bmp
+445.9170909091	n/a	111479.2727	show_face	unfamiliar_face	first_show	134	n/a	13	u075.bmp
+446.6943636364	n/a	111673.5909	left_press	n/a	n/a	134	n/a	256	n/a
+446.928	n/a	111732.0	show_circle	n/a	n/a	134	n/a	0	circle.bmp
+448.628	n/a	112157.0	show_cross	n/a	n/a	135	n/a	n/a	cross.bmp
+449.108	n/a	112277.0	show_face	scrambled_face	first_show	135	n/a	17	s027.bmp
+449.9752727273	n/a	112493.8182	right_press	n/a	n/a	135	n/a	4096	n/a
+450.06981818180003	n/a	112517.4545	show_circle	n/a	n/a	135	n/a	0	circle.bmp
+451.7698181818	n/a	112942.4545	show_cross	n/a	n/a	136	n/a	n/a	cross.bmp
+452.2816363636	n/a	113070.4091	show_face	unfamiliar_face	delayed_repeat	136	11	15	u004.bmp
+453.2407272727	n/a	113310.1818	left_press	n/a	n/a	136	n/a	256	n/a
+453.2561818182	n/a	113314.0455	show_circle	n/a	n/a	136	n/a	0	circle.bmp
+454.9561818182	n/a	113739.0455	show_cross	n/a	n/a	137	n/a	n/a	cross.bmp
+455.5898181818	n/a	113897.4545	show_face	famous_face	first_show	137	n/a	5	f024.bmp
+456.348	n/a	114087.0	left_press	n/a	n/a	137	n/a	256	n/a
+456.528	n/a	114132.0	show_circle	n/a	n/a	137	n/a	0	circle.bmp
+458.228	n/a	114557.0	show_cross	n/a	n/a	138	n/a	n/a	cross.bmp
+458.8134545455	n/a	114703.3636	show_face	famous_face	immediate_repeat	138	1	6	f024.bmp
+459.82345454550006	n/a	114955.8636	show_circle	n/a	n/a	138	n/a	0	circle.bmp
+461.52345454550004	n/a	115380.8636	show_cross	n/a	n/a	139	n/a	n/a	cross.bmp
+462.0716363636	n/a	115517.9091	show_face	scrambled_face	first_show	139	n/a	17	s057.bmp
+463.0298181818	n/a	115757.4545	show_circle	n/a	n/a	139	n/a	0	circle.bmp
+463.1152727273	n/a	115778.8182	left_press	n/a	n/a	139	n/a	256	n/a
+464.7298181818	n/a	116182.4545	show_cross	n/a	n/a	140	n/a	n/a	cross.bmp
+465.22890909089995	n/a	116307.2273	show_face	famous_face	first_show	140	n/a	5	f126.bmp
+466.1707272727	n/a	116542.6818	show_circle	n/a	n/a	140	n/a	0	circle.bmp
+467.8707272727	n/a	116967.6818	show_cross	n/a	n/a	141	n/a	n/a	cross.bmp
+468.3861818182	n/a	117096.5455	show_face	unfamiliar_face	first_show	141	n/a	13	u135.bmp
+469.2334545455	n/a	117308.3636	right_press	n/a	n/a	141	n/a	4096	n/a
+469.32527272730005	n/a	117331.3182	show_circle	n/a	n/a	141	n/a	0	circle.bmp
+471.02527272730003	n/a	117756.3182	show_cross	n/a	n/a	142	n/a	n/a	cross.bmp
+471.5261818182	n/a	117881.5455	show_face	unfamiliar_face	immediate_repeat	142	1	14	u135.bmp
+472.5361818182	n/a	118134.0455	show_circle	n/a	n/a	142	n/a	0	circle.bmp
+474.2361818182	n/a	118559.0455	show_cross	n/a	n/a	143	n/a	n/a	cross.bmp
+474.7507272727	n/a	118687.6818	show_face	unfamiliar_face	delayed_repeat	143	9	15	u075.bmp
+475.44254545449996	n/a	118860.6364	left_press	n/a	n/a	143	n/a	256	n/a
+475.57345454550006	n/a	118893.3636	show_circle	n/a	n/a	143	n/a	0	circle.bmp
+477.27345454550004	n/a	119318.3636	show_cross	n/a	n/a	144	n/a	n/a	cross.bmp
+477.908	n/a	119477.0	show_face	unfamiliar_face	first_show	144	n/a	13	u110.bmp
+478.8343636364	n/a	119708.5909	show_circle	n/a	n/a	144	n/a	0	circle.bmp
+479.05709090910005	n/a	119764.2727	left_press	n/a	n/a	144	n/a	256	n/a
+480.5343636364	n/a	120133.5909	show_cross	n/a	n/a	145	n/a	n/a	cross.bmp
+481.1816363636	n/a	120295.4091	show_face	unfamiliar_face	immediate_repeat	145	1	14	u110.bmp
+481.65345454550004	n/a	120413.3636	left_press	n/a	n/a	145	n/a	256	n/a
+482.1670909091	n/a	120541.7727	show_circle	n/a	n/a	145	n/a	0	circle.bmp
+483.86709090910006	n/a	120966.7727	show_cross	n/a	n/a	146	n/a	n/a	cross.bmp
+484.3898181818	n/a	121097.4545	show_face	scrambled_face	delayed_repeat	146	11	19	s027.bmp
+484.97890909089995	n/a	121244.7273	left_press	n/a	n/a	146	n/a	256	n/a
+485.2416363636	n/a	121310.4091	show_circle	n/a	n/a	146	n/a	0	circle.bmp
+486.9416363636	n/a	121735.4091	show_cross	n/a	n/a	147	n/a	n/a	cross.bmp
+487.51345454550005	n/a	121878.3636	show_face	unfamiliar_face	first_show	147	n/a	13	u072.bmp
+488.13527272730005	n/a	122033.8182	left_press	n/a	n/a	147	n/a	256	n/a
+488.39890909089996	n/a	122099.7273	show_circle	n/a	n/a	147	n/a	0	circle.bmp
+490.09890909089995	n/a	122524.7273	show_cross	n/a	n/a	148	n/a	n/a	cross.bmp
+490.73709090910006	n/a	122684.2727	show_face	unfamiliar_face	immediate_repeat	148	1	14	u072.bmp
+491.18527272730006	n/a	122796.3182	left_press	n/a	n/a	148	n/a	256	n/a
+491.5689090909	n/a	122892.2273	show_circle	n/a	n/a	148	n/a	0	circle.bmp
+493.26890909089997	n/a	123317.2273	show_cross	n/a	n/a	149	n/a	n/a	cross.bmp

--- a/eeg_hed_small/sub-003/eeg/sub-003_task-FacePerception_run-6_events.tsv
+++ b/eeg_hed_small/sub-003/eeg/sub-003_task-FacePerception_run-6_events.tsv
@@ -1,592 +1,592 @@
-onset	duration	sample	event_type	face_type	repetition_type	trigger	stim_file
-0.0040000000	n/a	1	setup	n/a	n/a	n/a	n/a
-0.0040000000	n/a	1	right_sym	n/a	n/a	n/a	n/a
-23.9716363636	n/a	5992.9091	show_face	famous_face	first_show	5	f140.bmp
-24.5898181818	n/a	6147.4545	right_press	n/a	n/a	4096	n/a
-24.9252727273	n/a	6231.3182	show_circle	n/a	n/a	0	circle.bmp
-26.6252727273	n/a	6656.3182	show_cross	n/a	n/a	n/a	cross.bmp
-27.1798181818	n/a	6794.9545	show_face	famous_face	immediate_repeat	6	f140.bmp
-27.5707272727	n/a	6892.6818	right_press	n/a	n/a	4096	n/a
-28.0243636364	n/a	7006.0909	show_circle	n/a	n/a	0	circle.bmp
-29.7243636364	n/a	7431.0909	show_cross	n/a	n/a	n/a	cross.bmp
-30.3870909091	n/a	7596.7727	show_face	scrambled_face	first_show	17	s064.bmp
-30.9552727273	n/a	7738.8182	left_press	n/a	n/a	256	n/a
-31.2907272727	n/a	7822.6818	show_circle	n/a	n/a	0	circle.bmp
-32.9907272727	n/a	8247.6818	show_cross	n/a	n/a	n/a	cross.bmp
-33.5443636364	n/a	8386.0909	show_face	scrambled_face	immediate_repeat	18	s064.bmp
-33.9398181818	n/a	8484.9545	left_press	n/a	n/a	256	n/a
-34.4707272727	n/a	8617.6818	show_circle	n/a	n/a	0	circle.bmp
-36.1707272727	n/a	9042.6818	show_cross	n/a	n/a	n/a	cross.bmp
-36.7180000000	n/a	9179.5	show_face	scrambled_face	first_show	17	s092.bmp
-37.4434545455	n/a	9360.8636	left_press	n/a	n/a	256	n/a
-37.7170909091	n/a	9429.2727	show_circle	n/a	n/a	0	circle.bmp
-39.4170909091	n/a	9854.2727	show_cross	n/a	n/a	n/a	cross.bmp
-39.8752727273	n/a	9968.8182	show_face	scrambled_face	immediate_repeat	18	s092.bmp
-40.2989090909	n/a	10074.7273	left_press	n/a	n/a	256	n/a
-40.7552727273	n/a	10188.8182	show_circle	n/a	n/a	0	circle.bmp
-42.4552727273	n/a	10613.8182	show_cross	n/a	n/a	n/a	cross.bmp
-43.0325454545	n/a	10758.1364	show_face	unfamiliar_face	first_show	13	u041.bmp
-43.6798181818	n/a	10919.9545	right_press	n/a	n/a	4096	n/a
-43.8752727273	n/a	10968.8182	show_circle	n/a	n/a	0	circle.bmp
-45.5752727273	n/a	11393.8182	show_cross	n/a	n/a	n/a	cross.bmp
-46.1898181818	n/a	11547.4545	show_face	unfamiliar_face	immediate_repeat	14	u041.bmp
-46.6507272727	n/a	11662.6818	right_press	n/a	n/a	4096	n/a
-47.1034545455	n/a	11775.8636	show_circle	n/a	n/a	0	circle.bmp
-48.8034545455	n/a	12200.8636	show_cross	n/a	n/a	n/a	cross.bmp
-49.4307272727	n/a	12357.6818	show_face	unfamiliar_face	first_show	13	u099.bmp
-50.0125454545	n/a	12503.1364	right_press	n/a	n/a	4096	n/a
-50.4080000000	n/a	12602	show_circle	n/a	n/a	0	circle.bmp
-52.1080000000	n/a	13027	show_cross	n/a	n/a	n/a	cross.bmp
-52.7052727273	n/a	13176.3182	show_face	unfamiliar_face	first_show	13	u031.bmp
-53.2843636364	n/a	13321.0909	right_press	n/a	n/a	4096	n/a
-53.6443636364	n/a	13411.0909	show_circle	n/a	n/a	0	circle.bmp
-55.3443636364	n/a	13836.0909	show_cross	n/a	n/a	n/a	cross.bmp
-55.8789090909	n/a	13969.7273	show_face	famous_face	first_show	5	f071.bmp
-56.4361818182	n/a	14109.0455	right_press	n/a	n/a	4096	n/a
-56.7307272727	n/a	14182.6818	show_circle	n/a	n/a	0	circle.bmp
-58.4307272727	n/a	14607.6818	show_cross	n/a	n/a	n/a	cross.bmp
-58.9025454545	n/a	14725.6364	show_face	famous_face	first_show	5	f018.bmp
-59.4089090909	n/a	14852.2273	right_press	n/a	n/a	4096	n/a
-59.9198181818	n/a	14979.9545	show_circle	n/a	n/a	0	circle.bmp
-61.6198181818	n/a	15404.9545	show_cross	n/a	n/a	n/a	cross.bmp
-62.1598181818	n/a	15539.9545	show_face	famous_face	immediate_repeat	6	f018.bmp
-62.6743636364	n/a	15668.5909	right_press	n/a	n/a	4096	n/a
-63.1170909091	n/a	15779.2727	show_circle	n/a	n/a	0	circle.bmp
-64.8170909091	n/a	16204.2727	show_cross	n/a	n/a	n/a	cross.bmp
-65.4680000000	n/a	16367	show_face	unfamiliar_face	first_show	13	u035.bmp
-66.1689090909	n/a	16542.2273	left_press	n/a	n/a	256	n/a
-66.4534545455	n/a	16613.3636	show_circle	n/a	n/a	0	circle.bmp
-68.1534545455	n/a	17038.3636	show_cross	n/a	n/a	n/a	cross.bmp
-68.7589090909	n/a	17189.7273	show_face	unfamiliar_face	immediate_repeat	14	u035.bmp
-69.1625454545	n/a	17290.6364	left_press	n/a	n/a	256	n/a
-69.6552727273	n/a	17413.8182	show_circle	n/a	n/a	0	circle.bmp
-71.3552727273	n/a	17838.8182	show_cross	n/a	n/a	n/a	cross.bmp
-71.9825454545	n/a	17995.6364	show_face	unfamiliar_face	first_show	13	u039.bmp
-72.5725454545	n/a	18143.1364	right_press	n/a	n/a	4096	n/a
-72.9234545455	n/a	18230.8636	show_circle	n/a	n/a	0	circle.bmp
-74.6234545455	n/a	18655.8636	show_cross	n/a	n/a	n/a	cross.bmp
-75.2734545455	n/a	18818.3636	show_face	unfamiliar_face	delayed_repeat	15	u099.bmp
-75.8198181818	n/a	18954.9545	right_press	n/a	n/a	4096	n/a
-76.2352727273	n/a	19058.8182	show_circle	n/a	n/a	0	circle.bmp
-77.9352727273	n/a	19483.8182	show_cross	n/a	n/a	n/a	cross.bmp
-78.5643636364	n/a	19641.0909	show_face	scrambled_face	first_show	17	s013.bmp
-79.3861818182	n/a	19846.5455	left_press	n/a	n/a	256	n/a
-79.4452727273	n/a	19861.3182	show_circle	n/a	n/a	0	circle.bmp
-81.1452727273	n/a	20286.3182	show_cross	n/a	n/a	n/a	cross.bmp
-81.7716363636	n/a	20442.9091	show_face	scrambled_face	immediate_repeat	18	s013.bmp
-82.3643636364	n/a	20591.0909	right_press	n/a	n/a	4096	n/a
-82.7161818182	n/a	20679.0455	show_circle	n/a	n/a	0	circle.bmp
-84.4161818182	n/a	21104.0455	show_cross	n/a	n/a	n/a	cross.bmp
-85.0625454545	n/a	21265.6364	show_face	unfamiliar_face	delayed_repeat	15	u031.bmp
-85.9389090909	n/a	21484.7273	show_circle	n/a	n/a	0	circle.bmp
-86.0243636364	n/a	21506.0909	right_press	n/a	n/a	4096	n/a
-87.6389090909	n/a	21909.7273	show_cross	n/a	n/a	n/a	cross.bmp
-88.1198181818	n/a	22029.9545	show_face	famous_face	first_show	5	f079.bmp
-88.8952727273	n/a	22223.8182	right_press	n/a	n/a	4096	n/a
-89.0534545455	n/a	22263.3636	show_circle	n/a	n/a	0	circle.bmp
-90.7534545455	n/a	22688.3636	show_cross	n/a	n/a	n/a	cross.bmp
-91.3107272727	n/a	22827.6818	show_face	famous_face	delayed_repeat	7	f071.bmp
-91.9261818182	n/a	22981.5455	right_press	n/a	n/a	4096	n/a
-92.3198181818	n/a	23079.9545	show_circle	n/a	n/a	0	circle.bmp
-94.0198181818	n/a	23504.9545	show_cross	n/a	n/a	n/a	cross.bmp
-94.5180000000	n/a	23629.5	show_face	unfamiliar_face	first_show	13	u045.bmp
-95.0661818182	n/a	23766.5455	right_press	n/a	n/a	4096	n/a
-95.3898181818	n/a	23847.4545	show_circle	n/a	n/a	0	circle.bmp
-97.0898181818	n/a	24272.4545	show_cross	n/a	n/a	n/a	cross.bmp
-97.6416363636	n/a	24410.4091	show_face	scrambled_face	first_show	17	s112.bmp
-98.2443636364	n/a	24561.0909	left_press	n/a	n/a	256	n/a
-98.5852727273	n/a	24646.3182	show_circle	n/a	n/a	0	circle.bmp
-100.2852727273	n/a	25071.3182	show_cross	n/a	n/a	n/a	cross.bmp
-100.8325454545	n/a	25208.1364	show_face	unfamiliar_face	first_show	13	u087.bmp
-101.4989090909	n/a	25374.7273	right_press	n/a	n/a	4096	n/a
-101.7725454545	n/a	25443.1364	show_circle	n/a	n/a	0	circle.bmp
-103.4725454545	n/a	25868.1364	show_cross	n/a	n/a	n/a	cross.bmp
-104.0061818182	n/a	26001.5455	show_face	unfamiliar_face	delayed_repeat	15	u039.bmp
-104.6216363636	n/a	26155.4091	right_press	n/a	n/a	4096	n/a
-104.8952727273	n/a	26223.8182	show_circle	n/a	n/a	0	circle.bmp
-106.5952727273	n/a	26648.8182	show_cross	n/a	n/a	n/a	cross.bmp
-107.1307272727	n/a	26782.6818	show_face	famous_face	first_show	5	f008.bmp
-107.8898181818	n/a	26972.4545	right_press	n/a	n/a	4096	n/a
-108.1407272727	n/a	27035.1818	show_circle	n/a	n/a	0	circle.bmp
-109.8407272727	n/a	27460.1818	show_cross	n/a	n/a	n/a	cross.bmp
-110.3716363636	n/a	27592.9091	show_face	famous_face	immediate_repeat	6	f008.bmp
-110.8080000000	n/a	27702	right_press	n/a	n/a	4096	n/a
-111.2007272727	n/a	27800.1818	show_circle	n/a	n/a	0	circle.bmp
-112.9007272727	n/a	28225.1818	show_cross	n/a	n/a	n/a	cross.bmp
-113.4952727273	n/a	28373.8182	show_face	famous_face	first_show	5	f129.bmp
-114.0834545455	n/a	28520.8636	right_press	n/a	n/a	4096	n/a
-114.4361818182	n/a	28609.0455	show_circle	n/a	n/a	0	circle.bmp
-116.1361818182	n/a	29034.0455	show_cross	n/a	n/a	n/a	cross.bmp
-116.7189090909	n/a	29179.7273	show_face	famous_face	immediate_repeat	6	f129.bmp
-117.1625454545	n/a	29290.6364	right_press	n/a	n/a	4096	n/a
-117.5370909091	n/a	29384.2727	show_circle	n/a	n/a	0	circle.bmp
-119.2370909091	n/a	29809.2727	show_cross	n/a	n/a	n/a	cross.bmp
-119.7925454545	n/a	29948.1364	show_face	famous_face	delayed_repeat	7	f079.bmp
-120.4880000000	n/a	30122	right_press	n/a	n/a	4096	n/a
-120.7534545455	n/a	30188.3636	show_circle	n/a	n/a	0	circle.bmp
-122.4534545455	n/a	30613.3636	show_cross	n/a	n/a	n/a	cross.bmp
-122.9507272727	n/a	30737.6818	show_face	famous_face	first_show	5	f088.bmp
-123.6907272727	n/a	30922.6818	right_press	n/a	n/a	4096	n/a
-123.8452727273	n/a	30961.3182	show_circle	n/a	n/a	0	circle.bmp
-125.5452727273	n/a	31386.3182	show_cross	n/a	n/a	n/a	cross.bmp
-126.0407272727	n/a	31510.1818	show_face	unfamiliar_face	delayed_repeat	15	u045.bmp
-126.6834545455	n/a	31670.8636	right_press	n/a	n/a	4096	n/a
-126.9389090909	n/a	31734.7273	show_circle	n/a	n/a	0	circle.bmp
-128.6389090909	n/a	32159.7273	show_cross	n/a	n/a	n/a	cross.bmp
-129.1816363636	n/a	32295.4091	show_face	unfamiliar_face	first_show	13	u085.bmp
-129.6898181818	n/a	32422.4545	left_press	n/a	n/a	256	n/a
-130.0880000000	n/a	32522	show_circle	n/a	n/a	0	circle.bmp
-131.7880000000	n/a	32947	show_cross	n/a	n/a	n/a	cross.bmp
-132.3389090909	n/a	33084.7273	show_face	scrambled_face	delayed_repeat	19	s112.bmp
-132.8152727273	n/a	33203.8182	left_press	n/a	n/a	256	n/a
-133.1807272727	n/a	33295.1818	show_circle	n/a	n/a	0	circle.bmp
-134.8807272727	n/a	33720.1818	show_cross	n/a	n/a	n/a	cross.bmp
-135.5125454545	n/a	33878.1364	show_face	unfamiliar_face	first_show	13	u027.bmp
-136.1243636364	n/a	34031.0909	left_press	n/a	n/a	256	n/a
-136.4352727273	n/a	34108.8182	show_circle	n/a	n/a	0	circle.bmp
-138.1352727273	n/a	34533.8182	show_cross	n/a	n/a	n/a	cross.bmp
-138.7361818182	n/a	34684.0455	show_face	unfamiliar_face	delayed_repeat	15	u087.bmp
-139.3298181818	n/a	34832.4545	right_press	n/a	n/a	4096	n/a
-139.6961818182	n/a	34924.0455	show_circle	n/a	n/a	0	circle.bmp
-141.3961818182	n/a	35349.0455	show_cross	n/a	n/a	n/a	cross.bmp
-141.9943636364	n/a	35498.5909	show_face	famous_face	first_show	5	f050.bmp
-142.6025454545	n/a	35650.6364	right_press	n/a	n/a	4096	n/a
-142.9480000000	n/a	35737	show_circle	n/a	n/a	0	circle.bmp
-144.6480000000	n/a	36162	show_cross	n/a	n/a	n/a	cross.bmp
-145.1180000000	n/a	36279.5	show_face	famous_face	immediate_repeat	6	f050.bmp
-145.5661818182	n/a	36391.5455	right_press	n/a	n/a	4096	n/a
-146.0261818182	n/a	36506.5455	show_circle	n/a	n/a	0	circle.bmp
-147.7261818182	n/a	36931.5455	show_cross	n/a	n/a	n/a	cross.bmp
-148.2416363636	n/a	37060.4091	show_face	unfamiliar_face	first_show	13	u129.bmp
-148.8216363636	n/a	37205.4091	left_press	n/a	n/a	256	n/a
-149.1616363636	n/a	37290.4091	show_circle	n/a	n/a	0	circle.bmp
-150.8616363636	n/a	37715.4091	show_cross	n/a	n/a	n/a	cross.bmp
-151.5161818182	n/a	37879.0455	show_face	scrambled_face	first_show	17	s117.bmp
-152.0552727273	n/a	38013.8182	left_press	n/a	n/a	256	n/a
-152.3916363636	n/a	38097.9091	show_circle	n/a	n/a	0	circle.bmp
-154.0916363636	n/a	38522.9091	show_cross	n/a	n/a	n/a	cross.bmp
-154.6061818182	n/a	38651.5455	show_face	famous_face	delayed_repeat	7	f088.bmp
-155.3170909091	n/a	38829.2727	right_press	n/a	n/a	4096	n/a
-155.5852727273	n/a	38896.3182	show_circle	n/a	n/a	0	circle.bmp
-157.2852727273	n/a	39321.3182	show_cross	n/a	n/a	n/a	cross.bmp
-157.7807272727	n/a	39445.1818	show_face	famous_face	first_show	5	f021.bmp
-158.4861818182	n/a	39621.5455	left_press	n/a	n/a	256	n/a
-158.6907272727	n/a	39672.6818	show_circle	n/a	n/a	0	circle.bmp
-160.3907272727	n/a	40097.6818	show_cross	n/a	n/a	n/a	cross.bmp
-160.9207272727	n/a	40230.1818	show_face	famous_face	immediate_repeat	6	f021.bmp
-161.3316363636	n/a	40332.9091	left_press	n/a	n/a	256	n/a
-161.9380000000	n/a	40484.5	show_circle	n/a	n/a	0	circle.bmp
-163.6380000000	n/a	40909.5	show_cross	n/a	n/a	n/a	cross.bmp
-164.2625454545	n/a	41065.6364	show_face	unfamiliar_face	delayed_repeat	15	u085.bmp
-164.8534545455	n/a	41213.3636	left_press	n/a	n/a	256	n/a
-165.2598181818	n/a	41314.9545	show_circle	n/a	n/a	0	circle.bmp
-166.9598181818	n/a	41739.9545	show_cross	n/a	n/a	n/a	cross.bmp
-167.6034545455	n/a	41900.8636	show_face	unfamiliar_face	first_show	13	u088.bmp
-168.1989090909	n/a	42049.7273	left_press	n/a	n/a	256	n/a
-168.4452727273	n/a	42111.3182	show_circle	n/a	n/a	0	circle.bmp
-170.1452727273	n/a	42536.3182	show_cross	n/a	n/a	n/a	cross.bmp
-170.6770909091	n/a	42669.2727	show_face	unfamiliar_face	immediate_repeat	14	u088.bmp
-171.1061818182	n/a	42776.5455	left_press	n/a	n/a	256	n/a
-171.5152727273	n/a	42878.8182	show_circle	n/a	n/a	0	circle.bmp
-173.2152727273	n/a	43303.8182	show_cross	n/a	n/a	n/a	cross.bmp
-173.8343636364	n/a	43458.5909	show_face	unfamiliar_face	delayed_repeat	15	u027.bmp
-174.4361818182	n/a	43609.0455	left_press	n/a	n/a	256	n/a
-174.6825454545	n/a	43670.6364	show_circle	n/a	n/a	0	circle.bmp
-176.3825454545	n/a	44095.6364	show_cross	n/a	n/a	n/a	cross.bmp
-177.0416363636	n/a	44260.4091	show_face	scrambled_face	first_show	17	s037.bmp
-177.6034545455	n/a	44400.8636	left_press	n/a	n/a	256	n/a
-178.0098181818	n/a	44502.4545	show_circle	n/a	n/a	0	circle.bmp
-179.7098181818	n/a	44927.4545	show_cross	n/a	n/a	n/a	cross.bmp
-180.2825454545	n/a	45070.6364	show_face	famous_face	first_show	5	f060.bmp
-180.8661818182	n/a	45216.5455	left_press	n/a	n/a	256	n/a
-181.1452727273	n/a	45286.3182	show_circle	n/a	n/a	0	circle.bmp
-182.8452727273	n/a	45711.3182	show_cross	n/a	n/a	n/a	cross.bmp
-183.3725454545	n/a	45843.1364	show_face	unfamiliar_face	delayed_repeat	15	u129.bmp
-183.9316363636	n/a	45982.9091	left_press	n/a	n/a	256	n/a
-184.3834545455	n/a	46095.8636	show_circle	n/a	n/a	0	circle.bmp
-186.0834545455	n/a	46520.8636	show_cross	n/a	n/a	n/a	cross.bmp
-186.6470909091	n/a	46661.7727	show_face	famous_face	first_show	5	f019.bmp
-187.3216363636	n/a	46830.4091	right_press	n/a	n/a	4096	n/a
-187.4934545455	n/a	46873.3636	show_circle	n/a	n/a	0	circle.bmp
-189.1934545455	n/a	47298.3636	show_cross	n/a	n/a	n/a	cross.bmp
-189.7707272727	n/a	47442.6818	show_face	famous_face	immediate_repeat	6	f019.bmp
-190.2380000000	n/a	47559.5	right_press	n/a	n/a	4096	n/a
-190.6534545455	n/a	47663.3636	show_circle	n/a	n/a	0	circle.bmp
-192.3534545455	n/a	48088.3636	show_cross	n/a	n/a	n/a	cross.bmp
-192.9952727273	n/a	48248.8182	show_face	scrambled_face	delayed_repeat	19	s117.bmp
-193.5261818182	n/a	48381.5455	left_press	n/a	n/a	256	n/a
-193.8461818182	n/a	48461.5455	show_circle	n/a	n/a	0	circle.bmp
-195.5461818182	n/a	48886.5455	show_cross	n/a	n/a	n/a	cross.bmp
-196.0852727273	n/a	49021.3182	show_face	unfamiliar_face	first_show	13	u060.bmp
-196.6780000000	n/a	49169.5	right_press	n/a	n/a	4096	n/a
-196.9580000000	n/a	49239.5	show_circle	n/a	n/a	0	circle.bmp
-198.6580000000	n/a	49664.5	show_cross	n/a	n/a	n/a	cross.bmp
-199.2598181818	n/a	49814.9545	show_face	scrambled_face	first_show	17	s065.bmp
-199.7489090909	n/a	49937.2273	left_press	n/a	n/a	256	n/a
-200.1480000000	n/a	50037	show_circle	n/a	n/a	0	circle.bmp
-201.8480000000	n/a	50462	show_cross	n/a	n/a	n/a	cross.bmp
-202.4498181818	n/a	50612.4545	show_face	scrambled_face	immediate_repeat	18	s065.bmp
-202.9889090909	n/a	50747.2273	left_press	n/a	n/a	256	n/a
-203.3589090909	n/a	50839.7273	show_circle	n/a	n/a	0	circle.bmp
-205.0589090909	n/a	51264.7273	show_cross	n/a	n/a	n/a	cross.bmp
-205.7080000000	n/a	51427	show_face	scrambled_face	first_show	17	s136.bmp
-206.1689090909	n/a	51542.2273	left_press	n/a	n/a	256	n/a
-206.6543636364	n/a	51663.5909	show_circle	n/a	n/a	0	circle.bmp
-208.3543636364	n/a	52088.5909	show_cross	n/a	n/a	n/a	cross.bmp
-208.9489090909	n/a	52237.2273	show_face	scrambled_face	delayed_repeat	19	s037.bmp
-209.6625454545	n/a	52415.6364	left_press	n/a	n/a	256	n/a
-209.7689090909	n/a	52442.2273	show_circle	n/a	n/a	0	circle.bmp
-211.4689090909	n/a	52867.2273	show_cross	n/a	n/a	n/a	cross.bmp
-212.1061818182	n/a	53026.5455	show_face	famous_face	first_show	5	f094.bmp
-212.6298181818	n/a	53157.4545	right_press	n/a	n/a	4096	n/a
-212.9416363636	n/a	53235.4091	show_circle	n/a	n/a	0	circle.bmp
-214.6416363636	n/a	53660.4091	show_cross	n/a	n/a	n/a	cross.bmp
-215.0961818182	n/a	53774.0455	show_face	famous_face	immediate_repeat	6	f094.bmp
-215.5607272727	n/a	53890.1818	right_press	n/a	n/a	4096	n/a
-215.9416363636	n/a	53985.4091	show_circle	n/a	n/a	0	circle.bmp
-217.6416363636	n/a	54410.4091	show_cross	n/a	n/a	n/a	cross.bmp
-218.1025454545	n/a	54525.6364	show_face	famous_face	delayed_repeat	7	f060.bmp
-218.6370909091	n/a	54659.2727	left_press	n/a	n/a	256	n/a
-219.0243636364	n/a	54756.0909	show_circle	n/a	n/a	0	circle.bmp
-220.7243636364	n/a	55181.0909	show_cross	n/a	n/a	n/a	cross.bmp
-221.2270909091	n/a	55306.7727	show_face	unfamiliar_face	first_show	13	u018.bmp
-222.0016363636	n/a	55500.4091	left_press	n/a	n/a	256	n/a
-222.2034545455	n/a	55550.8636	show_circle	n/a	n/a	0	circle.bmp
-223.9034545455	n/a	55975.8636	show_cross	n/a	n/a	n/a	cross.bmp
-224.5180000000	n/a	56129.5	show_face	unfamiliar_face	immediate_repeat	14	u018.bmp
-224.9843636364	n/a	56246.0909	left_press	n/a	n/a	256	n/a
-225.4725454545	n/a	56368.1364	show_circle	n/a	n/a	0	circle.bmp
-227.1725454545	n/a	56793.1364	show_cross	n/a	n/a	n/a	cross.bmp
-227.7589090909	n/a	56939.7273	show_face	scrambled_face	first_show	17	s034.bmp
-228.3207272727	n/a	57080.1818	left_press	n/a	n/a	256	n/a
-228.5934545455	n/a	57148.3636	show_circle	n/a	n/a	0	circle.bmp
-230.2934545455	n/a	57573.3636	show_cross	n/a	n/a	n/a	cross.bmp
-230.7825454545	n/a	57695.6364	show_face	unfamiliar_face	delayed_repeat	15	u060.bmp
-231.2843636364	n/a	57821.0909	right_press	n/a	n/a	4096	n/a
-231.6634545455	n/a	57915.8636	show_circle	n/a	n/a	0	circle.bmp
-233.3634545455	n/a	58340.8636	show_cross	n/a	n/a	n/a	cross.bmp
-233.8725454545	n/a	58468.1364	show_face	scrambled_face	first_show	17	s110.bmp
-234.4280000000	n/a	58607	left_press	n/a	n/a	256	n/a
-234.8343636364	n/a	58708.5909	show_circle	n/a	n/a	0	circle.bmp
-236.5343636364	n/a	59133.5909	show_cross	n/a	n/a	n/a	cross.bmp
-237.1298181818	n/a	59282.4545	show_face	famous_face	first_show	5	f122.bmp
-237.9398181818	n/a	59484.9545	right_press	n/a	n/a	4096	n/a
-237.9589090909	n/a	59489.7273	show_circle	n/a	n/a	0	circle.bmp
-239.6589090909	n/a	59914.7273	show_cross	n/a	n/a	n/a	cross.bmp
-240.3043636364	n/a	60076.0909	show_face	scrambled_face	delayed_repeat	19	s136.bmp
-241.1280000000	n/a	60282	show_circle	n/a	n/a	0	circle.bmp
-241.1343636364	n/a	60283.5909	left_press	n/a	n/a	256	n/a
-242.8280000000	n/a	60707	show_cross	n/a	n/a	n/a	cross.bmp
-243.2943636364	n/a	60823.5909	show_face	famous_face	first_show	5	f007.bmp
-244.0898181818	n/a	61022.4545	right_press	n/a	n/a	4096	n/a
-244.3070909091	n/a	61076.7727	show_circle	n/a	n/a	0	circle.bmp
-246.0070909091	n/a	61501.7727	show_cross	n/a	n/a	n/a	cross.bmp
-246.6352727273	n/a	61658.8182	show_face	famous_face	immediate_repeat	6	f007.bmp
-247.4216363636	n/a	61855.4091	right_press	n/a	n/a	4096	n/a
-247.6470909091	n/a	61911.7727	show_circle	n/a	n/a	0	circle.bmp
-249.3470909091	n/a	62336.7727	show_cross	n/a	n/a	n/a	cross.bmp
-249.8261818182	n/a	62456.5455	show_face	scrambled_face	first_show	17	s107.bmp
-250.4334545455	n/a	62608.3636	left_press	n/a	n/a	256	n/a
-250.6925454545	n/a	62673.1364	show_circle	n/a	n/a	0	circle.bmp
-252.3925454545	n/a	63098.1364	show_cross	n/a	n/a	n/a	cross.bmp
-252.9834545455	n/a	63245.8636	show_face	scrambled_face	first_show	17	s133.bmp
-253.8570909091	n/a	63464.2727	show_circle	n/a	n/a	0	circle.bmp
-253.9525454545	n/a	63488.1364	right_press	n/a	n/a	4096	n/a
-255.5570909091	n/a	63889.2727	show_cross	n/a	n/a	n/a	cross.bmp
-256.0234545455	n/a	64005.8636	show_face	scrambled_face	immediate_repeat	18	s133.bmp
-256.6725454545	n/a	64168.1364	right_press	n/a	n/a	4096	n/a
-256.8452727273	n/a	64211.3182	show_circle	n/a	n/a	0	circle.bmp
-258.5452727273	n/a	64636.3182	show_cross	n/a	n/a	n/a	cross.bmp
-259.0470909091	n/a	64761.7727	show_face	scrambled_face	delayed_repeat	19	s034.bmp
-259.5898181818	n/a	64897.4545	left_press	n/a	n/a	256	n/a
-259.8743636364	n/a	64968.5909	show_circle	n/a	n/a	0	circle.bmp
-261.5743636364	n/a	65393.5909	show_cross	n/a	n/a	n/a	cross.bmp
-262.0380000000	n/a	65509.5	show_face	famous_face	first_show	5	f069.bmp
-262.6925454545	n/a	65673.1364	left_press	n/a	n/a	256	n/a
-262.8616363636	n/a	65715.4091	show_circle	n/a	n/a	0	circle.bmp
-264.5616363636	n/a	66140.4091	show_cross	n/a	n/a	n/a	cross.bmp
-265.1616363636	n/a	66290.4091	show_face	scrambled_face	delayed_repeat	19	s110.bmp
-265.7370909091	n/a	66434.2727	left_press	n/a	n/a	256	n/a
-266.0207272727	n/a	66505.1818	show_circle	n/a	n/a	0	circle.bmp
-267.7207272727	n/a	66930.1818	show_cross	n/a	n/a	n/a	cross.bmp
-268.2180000000	n/a	67054.5	show_face	famous_face	first_show	5	f142.bmp
-268.8325454545	n/a	67208.1364	right_press	n/a	n/a	4096	n/a
-269.2334545455	n/a	67308.3636	show_circle	n/a	n/a	0	circle.bmp
-270.9334545455	n/a	67733.3636	show_cross	n/a	n/a	n/a	cross.bmp
-271.4425454545	n/a	67860.6364	show_face	famous_face	delayed_repeat	7	f122.bmp
-272.0361818182	n/a	68009.0455	right_press	n/a	n/a	4096	n/a
-272.3889090909	n/a	68097.2273	show_circle	n/a	n/a	0	circle.bmp
-274.0889090909	n/a	68522.2273	show_cross	n/a	n/a	n/a	cross.bmp
-274.6498181818	n/a	68662.4545	show_face	famous_face	first_show	5	f058.bmp
-275.2498181818	n/a	68812.4545	right_press	n/a	n/a	4096	n/a
-275.6170909091	n/a	68904.2727	show_circle	n/a	n/a	0	circle.bmp
-277.3170909091	n/a	69329.2727	show_cross	n/a	n/a	n/a	cross.bmp
-277.8407272727	n/a	69460.1818	show_face	famous_face	immediate_repeat	6	f058.bmp
-278.7034545455	n/a	69675.8636	show_circle	n/a	n/a	0	circle.bmp
-278.8825454545	n/a	69720.6364	right_press	n/a	n/a	4096	n/a
-280.4034545455	n/a	70100.8636	show_cross	n/a	n/a	n/a	cross.bmp
-280.8980000000	n/a	70224.5	show_face	famous_face	first_show	5	f144.bmp
-281.7298181818	n/a	70432.4545	right_press	n/a	n/a	4096	n/a
-281.8889090909	n/a	70472.2273	show_circle	n/a	n/a	0	circle.bmp
-283.5889090909	n/a	70897.2273	show_cross	n/a	n/a	n/a	cross.bmp
-284.1552727273	n/a	71038.8182	show_face	famous_face	immediate_repeat	6	f144.bmp
-284.6007272727	n/a	71150.1818	right_press	n/a	n/a	4096	n/a
-285.0689090909	n/a	71267.2273	show_circle	n/a	n/a	0	circle.bmp
-286.7689090909	n/a	71692.2273	show_cross	n/a	n/a	n/a	cross.bmp
-287.2961818182	n/a	71824.0455	show_face	scrambled_face	delayed_repeat	19	s107.bmp
-287.9316363636	n/a	71982.9091	left_press	n/a	n/a	256	n/a
-288.1216363636	n/a	72030.4091	show_circle	n/a	n/a	0	circle.bmp
-289.8216363636	n/a	72455.4091	show_cross	n/a	n/a	n/a	cross.bmp
-290.3861818182	n/a	72596.5455	show_face	famous_face	first_show	5	f056.bmp
-291.2161818182	n/a	72804.0455	right_press	n/a	n/a	4096	n/a
-291.3189090909	n/a	72829.7273	show_circle	n/a	n/a	0	circle.bmp
-293.0189090909	n/a	73254.7273	show_cross	n/a	n/a	n/a	cross.bmp
-293.5434545455	n/a	73385.8636	show_face	famous_face	immediate_repeat	6	f056.bmp
-294.0098181818	n/a	73502.4545	right_press	n/a	n/a	4096	n/a
-294.4080000000	n/a	73602	show_circle	n/a	n/a	0	circle.bmp
-296.1080000000	n/a	74027	show_cross	n/a	n/a	n/a	cross.bmp
-296.6343636364	n/a	74158.5909	show_face	unfamiliar_face	first_show	13	u123.bmp
-297.1689090909	n/a	74292.2273	left_press	n/a	n/a	256	n/a
-297.5080000000	n/a	74377	show_circle	n/a	n/a	0	circle.bmp
-299.2080000000	n/a	74802	show_cross	n/a	n/a	n/a	cross.bmp
-299.8416363636	n/a	74960.4091	show_face	famous_face	delayed_repeat	7	f069.bmp
-300.4052727273	n/a	75101.3182	right_press	n/a	n/a	4096	n/a
-300.7289090909	n/a	75182.2273	show_circle	n/a	n/a	0	circle.bmp
-302.4289090909	n/a	75607.2273	show_cross	n/a	n/a	n/a	cross.bmp
-302.9152727273	n/a	75728.8182	show_face	unfamiliar_face	first_show	13	u081.bmp
-303.4952727273	n/a	75873.8182	left_press	n/a	n/a	256	n/a
-303.7370909091	n/a	75934.2727	show_circle	n/a	n/a	0	circle.bmp
-305.4370909091	n/a	76359.2727	show_cross	n/a	n/a	n/a	cross.bmp
-306.0725454545	n/a	76518.1364	show_face	unfamiliar_face	immediate_repeat	14	u081.bmp
-306.5334545455	n/a	76633.3636	left_press	n/a	n/a	256	n/a
-307.0352727273	n/a	76758.8182	show_circle	n/a	n/a	0	circle.bmp
-308.7352727273	n/a	77183.8182	show_cross	n/a	n/a	n/a	cross.bmp
-309.2461818182	n/a	77311.5455	show_face	famous_face	delayed_repeat	7	f142.bmp
-309.8880000000	n/a	77472	right_press	n/a	n/a	4096	n/a
-310.2443636364	n/a	77561.0909	show_circle	n/a	n/a	0	circle.bmp
-311.9443636364	n/a	77986.0909	show_cross	n/a	n/a	n/a	cross.bmp
-312.5370909091	n/a	78134.2727	show_face	unfamiliar_face	first_show	13	u063.bmp
-313.0852727273	n/a	78271.3182	left_press	n/a	n/a	256	n/a
-313.5061818182	n/a	78376.5455	show_circle	n/a	n/a	0	circle.bmp
-315.2061818182	n/a	78801.5455	show_cross	n/a	n/a	n/a	cross.bmp
-315.7943636364	n/a	78948.5909	show_face	unfamiliar_face	immediate_repeat	14	u063.bmp
-316.2961818182	n/a	79074.0455	left_press	n/a	n/a	256	n/a
-316.7770909091	n/a	79194.2727	show_circle	n/a	n/a	0	circle.bmp
-318.4770909091	n/a	79619.2727	show_cross	n/a	n/a	n/a	cross.bmp
-319.0525454545	n/a	79763.1364	show_face	scrambled_face	first_show	17	s149.bmp
-319.6498181818	n/a	79912.4545	left_press	n/a	n/a	256	n/a
-319.8852727273	n/a	79971.3182	show_circle	n/a	n/a	0	circle.bmp
-321.5852727273	n/a	80396.3182	show_cross	n/a	n/a	n/a	cross.bmp
-322.0925454545	n/a	80523.1364	show_face	scrambled_face	immediate_repeat	18	s149.bmp
-322.5616363636	n/a	80640.4091	left_press	n/a	n/a	256	n/a
-323.0852727273	n/a	80771.3182	show_circle	n/a	n/a	0	circle.bmp
-324.7852727273	n/a	81196.3182	show_cross	n/a	n/a	n/a	cross.bmp
-325.2834545455	n/a	81320.8636	show_face	scrambled_face	first_show	17	s088.bmp
-325.8652727273	n/a	81466.3182	left_press	n/a	n/a	256	n/a
-326.2416363636	n/a	81560.4091	show_circle	n/a	n/a	0	circle.bmp
-327.9416363636	n/a	81985.4091	show_cross	n/a	n/a	n/a	cross.bmp
-328.4070909091	n/a	82101.7727	show_face	scrambled_face	first_show	17	s084.bmp
-329.1043636364	n/a	82276.0909	left_press	n/a	n/a	256	n/a
-329.3216363636	n/a	82330.4091	show_circle	n/a	n/a	0	circle.bmp
-331.0216363636	n/a	82755.4091	show_cross	n/a	n/a	n/a	cross.bmp
-331.6143636364	n/a	82903.5909	show_face	unfamiliar_face	delayed_repeat	15	u123.bmp
-332.3298181818	n/a	83082.4545	left_press	n/a	n/a	256	n/a
-332.4861818182	n/a	83121.5455	show_circle	n/a	n/a	0	circle.bmp
-334.1861818182	n/a	83546.5455	show_cross	n/a	n/a	n/a	cross.bmp
-334.7552727273	n/a	83688.8182	show_face	scrambled_face	first_show	17	s038.bmp
-335.5216363636	n/a	83880.4091	left_press	n/a	n/a	256	n/a
-335.7298181818	n/a	83932.4545	show_circle	n/a	n/a	0	circle.bmp
-337.4298181818	n/a	84357.4545	show_cross	n/a	n/a	n/a	cross.bmp
-337.9461818182	n/a	84486.5455	show_face	scrambled_face	immediate_repeat	18	s038.bmp
-338.3934545455	n/a	84598.3636	left_press	n/a	n/a	256	n/a
-338.7852727273	n/a	84696.3182	show_circle	n/a	n/a	0	circle.bmp
-340.4852727273	n/a	85121.3182	show_cross	n/a	n/a	n/a	cross.bmp
-340.9525454545	n/a	85238.1364	show_face	unfamiliar_face	first_show	13	u112.bmp
-341.8089090909	n/a	85452.2273	show_circle	n/a	n/a	0	circle.bmp
-341.8780000000	n/a	85469.5	right_press	n/a	n/a	4096	n/a
-343.5089090909	n/a	85877.2273	show_cross	n/a	n/a	n/a	cross.bmp
-344.1270909091	n/a	86031.7727	show_face	unfamiliar_face	immediate_repeat	14	u112.bmp
-344.5770909091	n/a	86144.2727	right_press	n/a	n/a	4096	n/a
-345.1207272727	n/a	86280.1818	show_circle	n/a	n/a	0	circle.bmp
-346.8207272727	n/a	86705.1818	show_cross	n/a	n/a	n/a	cross.bmp
-347.4007272727	n/a	86850.1818	show_face	unfamiliar_face	first_show	13	u021.bmp
-348.0507272727	n/a	87012.6818	left_press	n/a	n/a	256	n/a
-348.3170909091	n/a	87079.2727	show_circle	n/a	n/a	0	circle.bmp
-350.0170909091	n/a	87504.2727	show_cross	n/a	n/a	n/a	cross.bmp
-350.6425454545	n/a	87660.6364	show_face	famous_face	first_show	5	f059.bmp
-351.2652727273	n/a	87816.3182	right_press	n/a	n/a	4096	n/a
-351.5543636364	n/a	87888.5909	show_circle	n/a	n/a	0	circle.bmp
-353.2543636364	n/a	88313.5909	show_cross	n/a	n/a	n/a	cross.bmp
-353.8661818182	n/a	88466.5455	show_face	scrambled_face	delayed_repeat	19	s088.bmp
-354.7470909091	n/a	88686.7727	right_press	n/a	n/a	4096	n/a
-354.7761818182	n/a	88694.0455	show_circle	n/a	n/a	0	circle.bmp
-356.4761818182	n/a	89119.0455	show_cross	n/a	n/a	n/a	cross.bmp
-357.0234545455	n/a	89255.8636	show_face	scrambled_face	first_show	17	s081.bmp
-357.5634545455	n/a	89390.8636	left_press	n/a	n/a	256	n/a
-357.9680000000	n/a	89492	show_circle	n/a	n/a	0	circle.bmp
-359.6680000000	n/a	89917	show_cross	n/a	n/a	n/a	cross.bmp
-360.2134545455	n/a	90053.3636	show_face	scrambled_face	delayed_repeat	19	s084.bmp
-360.8898181818	n/a	90222.4545	right_press	n/a	n/a	4096	n/a
-361.0543636364	n/a	90263.5909	show_circle	n/a	n/a	0	circle.bmp
-362.7543636364	n/a	90688.5909	show_cross	n/a	n/a	n/a	cross.bmp
-363.3707272727	n/a	90842.6818	show_face	famous_face	first_show	5	f104.bmp
-364.0034545455	n/a	91000.8636	right_press	n/a	n/a	4096	n/a
-364.2689090909	n/a	91067.2273	show_circle	n/a	n/a	0	circle.bmp
-365.9689090909	n/a	91492.2273	show_cross	n/a	n/a	n/a	cross.bmp
-366.5452727273	n/a	91636.3182	show_face	famous_face	immediate_repeat	6	f104.bmp
-366.9789090909	n/a	91744.7273	right_press	n/a	n/a	4096	n/a
-367.4816363636	n/a	91870.4091	show_circle	n/a	n/a	0	circle.bmp
-369.1816363636	n/a	92295.4091	show_cross	n/a	n/a	n/a	cross.bmp
-369.7189090909	n/a	92429.7273	show_face	unfamiliar_face	first_show	13	u076.bmp
-370.3589090909	n/a	92589.7273	left_press	n/a	n/a	256	n/a
-370.5543636364	n/a	92638.5909	show_circle	n/a	n/a	0	circle.bmp
-372.2543636364	n/a	93063.5909	show_cross	n/a	n/a	n/a	cross.bmp
-372.7261818182	n/a	93181.5455	show_face	unfamiliar_face	immediate_repeat	14	u076.bmp
-373.1807272727	n/a	93295.1818	left_press	n/a	n/a	256	n/a
-373.6134545455	n/a	93403.3636	show_circle	n/a	n/a	0	circle.bmp
-375.3134545455	n/a	93828.3636	show_cross	n/a	n/a	n/a	cross.bmp
-375.8170909091	n/a	93954.2727	show_face	unfamiliar_face	first_show	13	u118.bmp
-376.4970909091	n/a	94124.2727	right_press	n/a	n/a	4096	n/a
-376.7761818182	n/a	94194.0455	show_circle	n/a	n/a	0	circle.bmp
-378.4761818182	n/a	94619.0455	show_cross	n/a	n/a	n/a	cross.bmp
-379.1070909091	n/a	94776.7727	show_face	unfamiliar_face	delayed_repeat	15	u021.bmp
-379.9370909091	n/a	94984.2727	show_circle	n/a	n/a	0	circle.bmp
-380.3634545455	n/a	95090.8636	left_press	n/a	n/a	256	n/a
-381.6370909091	n/a	95409.2727	show_cross	n/a	n/a	n/a	cross.bmp
-382.1807272727	n/a	95545.1818	show_face	unfamiliar_face	first_show	13	u149.bmp
-382.6852727273	n/a	95671.3182	left_press	n/a	n/a	256	n/a
-383.0625454545	n/a	95765.6364	show_circle	n/a	n/a	0	circle.bmp
-384.7625454545	n/a	96190.6364	show_cross	n/a	n/a	n/a	cross.bmp
-385.3216363636	n/a	96330.4091	show_face	famous_face	delayed_repeat	7	f059.bmp
-386.0289090909	n/a	96507.2273	right_press	n/a	n/a	4096	n/a
-386.3234545455	n/a	96580.8636	show_circle	n/a	n/a	0	circle.bmp
-388.0234545455	n/a	97005.8636	show_cross	n/a	n/a	n/a	cross.bmp
-388.5970909091	n/a	97149.2727	show_face	scrambled_face	first_show	17	s031.bmp
-389.3870909091	n/a	97346.7727	left_press	n/a	n/a	256	n/a
-389.5861818182	n/a	97396.5455	show_circle	n/a	n/a	0	circle.bmp
-391.2861818182	n/a	97821.5455	show_cross	n/a	n/a	n/a	cross.bmp
-391.8698181818	n/a	97967.4545	show_face	scrambled_face	immediate_repeat	18	s031.bmp
-392.4716363636	n/a	98117.9091	left_press	n/a	n/a	256	n/a
-392.6916363636	n/a	98172.9091	show_circle	n/a	n/a	0	circle.bmp
-394.3916363636	n/a	98597.9091	show_cross	n/a	n/a	n/a	cross.bmp
-394.8607272727	n/a	98715.1818	show_face	scrambled_face	delayed_repeat	19	s081.bmp
-395.6943636364	n/a	98923.5909	left_press	n/a	n/a	256	n/a
-395.8180000000	n/a	98954.5	show_circle	n/a	n/a	0	circle.bmp
-397.5180000000	n/a	99379.5	show_cross	n/a	n/a	n/a	cross.bmp
-398.0680000000	n/a	99517	show_face	unfamiliar_face	first_show	13	u096.bmp
-398.5580000000	n/a	99639.5	right_press	n/a	n/a	4096	n/a
-398.9770909091	n/a	99744.2727	show_circle	n/a	n/a	0	circle.bmp
-400.6770909091	n/a	100169.2727	show_cross	n/a	n/a	n/a	cross.bmp
-401.2416363636	n/a	100310.4091	show_face	unfamiliar_face	immediate_repeat	14	u096.bmp
-401.7107272727	n/a	100427.6818	right_press	n/a	n/a	4096	n/a
-402.2543636364	n/a	100563.5909	show_circle	n/a	n/a	0	circle.bmp
-403.9543636364	n/a	100988.5909	show_cross	n/a	n/a	n/a	cross.bmp
-404.6161818182	n/a	101154.0455	show_face	scrambled_face	first_show	17	s120.bmp
-405.5889090909	n/a	101397.2273	show_circle	n/a	n/a	0	circle.bmp
-405.8098181818	n/a	101452.4545	left_press	n/a	n/a	256	n/a
-407.2889090909	n/a	101822.2273	show_cross	n/a	n/a	n/a	cross.bmp
-407.7570909091	n/a	101939.2727	show_face	scrambled_face	first_show	17	s047.bmp
-408.4343636364	n/a	102108.5909	left_press	n/a	n/a	256	n/a
-408.7289090909	n/a	102182.2273	show_circle	n/a	n/a	0	circle.bmp
-410.4289090909	n/a	102607.2273	show_cross	n/a	n/a	n/a	cross.bmp
-410.9143636364	n/a	102728.5909	show_face	scrambled_face	immediate_repeat	18	s047.bmp
-411.3780000000	n/a	102844.5	left_press	n/a	n/a	256	n/a
-411.7480000000	n/a	102937	show_circle	n/a	n/a	0	circle.bmp
-413.4480000000	n/a	103362	show_cross	n/a	n/a	n/a	cross.bmp
-413.9380000000	n/a	103484.5	show_face	unfamiliar_face	delayed_repeat	15	u118.bmp
-414.7452727273	n/a	103686.3182	left_press	n/a	n/a	256	n/a
-414.8870909091	n/a	103721.7727	show_circle	n/a	n/a	0	circle.bmp
-416.5870909091	n/a	104146.7727	show_cross	n/a	n/a	n/a	cross.bmp
-417.2452727273	n/a	104311.3182	show_face	scrambled_face	first_show	17	s102.bmp
-418.1607272727	n/a	104540.1818	show_circle	n/a	n/a	0	circle.bmp
-418.3034545455	n/a	104575.8636	left_press	n/a	n/a	256	n/a
-419.8607272727	n/a	104965.1818	show_cross	n/a	n/a	n/a	cross.bmp
-420.4861818182	n/a	105121.5455	show_face	unfamiliar_face	delayed_repeat	15	u149.bmp
-421.0380000000	n/a	105259.5	left_press	n/a	n/a	256	n/a
-421.3280000000	n/a	105332	show_circle	n/a	n/a	0	circle.bmp
-423.0280000000	n/a	105757	show_cross	n/a	n/a	n/a	cross.bmp
-423.6434545455	n/a	105910.8636	show_face	famous_face	first_show	5	f077.bmp
-424.2789090909	n/a	106069.7273	left_press	n/a	n/a	256	n/a
-424.5452727273	n/a	106136.3182	show_circle	n/a	n/a	0	circle.bmp
-426.2452727273	n/a	106561.3182	show_cross	n/a	n/a	n/a	cross.bmp
-426.7170909091	n/a	106679.2727	show_face	famous_face	immediate_repeat	6	f077.bmp
-427.2052727273	n/a	106801.3182	left_press	n/a	n/a	256	n/a
-427.5916363636	n/a	106897.9091	show_circle	n/a	n/a	0	circle.bmp
-429.2916363636	n/a	107322.9091	show_cross	n/a	n/a	n/a	cross.bmp
-429.9416363636	n/a	107485.4091	show_face	unfamiliar_face	first_show	13	u057.bmp
-430.5561818182	n/a	107639.0455	left_press	n/a	n/a	256	n/a
-430.8452727273	n/a	107711.3182	show_circle	n/a	n/a	0	circle.bmp
-430.8461818182	n/a	107711.5455	show_circle	n/a	n/a	0	circle.bmp
-432.5452727273	n/a	108136.3182	show_cross	n/a	n/a	n/a	cross.bmp
-432.5461818182	n/a	108136.5455	show_cross	n/a	n/a	n/a	cross.bmp
-433.1816363636	n/a	108295.4091	show_face	scrambled_face	first_show	17	s074.bmp
-433.7925454545	n/a	108448.1364	left_press	n/a	n/a	256	n/a
-433.9998181818	n/a	108499.9545	show_circle	n/a	n/a	0	circle.bmp
-435.6998181818	n/a	108924.9545	show_cross	n/a	n/a	n/a	cross.bmp
-436.3225454545	n/a	109080.6364	show_face	scrambled_face	immediate_repeat	18	s074.bmp
-436.8707272727	n/a	109217.6818	left_press	n/a	n/a	256	n/a
-437.1616363636	n/a	109290.4091	show_circle	n/a	n/a	0	circle.bmp
-438.8616363636	n/a	109715.4091	show_cross	n/a	n/a	n/a	cross.bmp
-439.4461818182	n/a	109861.5455	show_face	scrambled_face	delayed_repeat	19	s120.bmp
-440.0452727273	n/a	110011.3182	left_press	n/a	n/a	256	n/a
-440.4470909091	n/a	110111.7727	show_circle	n/a	n/a	0	circle.bmp
-442.1470909091	n/a	110536.7727	show_cross	n/a	n/a	n/a	cross.bmp
-442.6870909091	n/a	110671.7727	show_face	famous_face	first_show	5	f113.bmp
-443.6734545455	n/a	110918.3636	show_circle	n/a	n/a	0	circle.bmp
-444.2407272727	n/a	111060.1818	right_press	n/a	n/a	4096	n/a
-445.3734545455	n/a	111343.3636	show_cross	n/a	n/a	n/a	cross.bmp
-445.8443636364	n/a	111461.0909	show_face	scrambled_face	first_show	17	s104.bmp
-446.7661818182	n/a	111691.5455	right_press	n/a	n/a	4096	n/a
-446.7752727273	n/a	111693.8182	show_circle	n/a	n/a	0	circle.bmp
-448.4752727273	n/a	112118.8182	show_cross	n/a	n/a	n/a	cross.bmp
-449.0016363636	n/a	112250.4091	show_face	scrambled_face	delayed_repeat	19	s102.bmp
-449.6870909091	n/a	112421.7727	left_press	n/a	n/a	256	n/a
-449.8316363636	n/a	112457.9091	show_circle	n/a	n/a	0	circle.bmp
-451.5316363636	n/a	112882.9091	show_cross	n/a	n/a	n/a	cross.bmp
-452.0425454545	n/a	113010.6364	show_face	unfamiliar_face	first_show	13	u047.bmp
-452.7634545455	n/a	113190.8636	left_press	n/a	n/a	256	n/a
-452.9080000000	n/a	113227	show_circle	n/a	n/a	0	circle.bmp
-454.6080000000	n/a	113652	show_cross	n/a	n/a	n/a	cross.bmp
-455.2325454545	n/a	113808.1364	show_face	unfamiliar_face	immediate_repeat	14	u047.bmp
-455.7052727273	n/a	113926.3182	left_press	n/a	n/a	256	n/a
-456.1007272727	n/a	114025.1818	show_circle	n/a	n/a	0	circle.bmp
-457.8007272727	n/a	114450.1818	show_cross	n/a	n/a	n/a	cross.bmp
-458.3234545455	n/a	114580.8636	show_face	famous_face	first_show	5	f141.bmp
-459.0389090909	n/a	114759.7273	right_press	n/a	n/a	4096	n/a
-459.2680000000	n/a	114817	show_circle	n/a	n/a	0	circle.bmp
-460.9680000000	n/a	115242	show_cross	n/a	n/a	n/a	cross.bmp
-461.5807272727	n/a	115395.1818	show_face	unfamiliar_face	delayed_repeat	15	u057.bmp
-462.4661818182	n/a	115616.5455	show_circle	n/a	n/a	0	circle.bmp
-462.6089090909	n/a	115652.2273	right_press	n/a	n/a	4096	n/a
-464.1661818182	n/a	116041.5455	show_cross	n/a	n/a	n/a	cross.bmp
-464.7380000000	n/a	116184.5	show_face	famous_face	first_show	5	f135.bmp
-465.6743636364	n/a	116418.5909	show_circle	n/a	n/a	0	circle.bmp
-465.9470909091	n/a	116486.7727	left_press	n/a	n/a	256	n/a
-467.3743636364	n/a	116843.5909	show_cross	n/a	n/a	n/a	cross.bmp
-467.8789090909	n/a	116969.7273	show_face	famous_face	immediate_repeat	6	f135.bmp
-468.4907272727	n/a	117122.6818	left_press	n/a	n/a	256	n/a
-468.7925454545	n/a	117198.1364	show_circle	n/a	n/a	0	circle.bmp
-470.4925454545	n/a	117623.1364	show_cross	n/a	n/a	n/a	cross.bmp
-471.1198181818	n/a	117779.9545	show_face	unfamiliar_face	first_show	13	u126.bmp
-471.9761818182	n/a	117994.0455	left_press	n/a	n/a	256	n/a
-472.1207272727	n/a	118030.1818	show_circle	n/a	n/a	0	circle.bmp
-473.8207272727	n/a	118455.1818	show_cross	n/a	n/a	n/a	cross.bmp
-474.3098181818	n/a	118577.4545	show_face	unfamiliar_face	immediate_repeat	14	u126.bmp
-474.7716363636	n/a	118692.9091	left_press	n/a	n/a	256	n/a
-475.1698181818	n/a	118792.4545	show_circle	n/a	n/a	0	circle.bmp
-476.8698181818	n/a	119217.4545	show_cross	n/a	n/a	n/a	cross.bmp
-477.4670909091	n/a	119366.7727	show_face	famous_face	delayed_repeat	7	f113.bmp
-478.2998181818	n/a	119574.9545	show_circle	n/a	n/a	0	circle.bmp
-478.3625454545	n/a	119590.6364	left_press	n/a	n/a	256	n/a
-479.9998181818	n/a	119999.9545	show_cross	n/a	n/a	n/a	cross.bmp
-480.4907272727	n/a	120122.6818	show_face	scrambled_face	first_show	17	s070.bmp
-481.4270909091	n/a	120356.7727	show_circle	n/a	n/a	0	circle.bmp
-481.9034545455	n/a	120475.8636	right_press	n/a	n/a	4096	n/a
-483.1270909091	n/a	120781.7727	show_cross	n/a	n/a	n/a	cross.bmp
-483.6480000000	n/a	120912	show_face	scrambled_face	delayed_repeat	19	s104.bmp
-484.5207272727	n/a	121130.1818	left_press	n/a	n/a	256	n/a
-484.6443636364	n/a	121161.0909	show_circle	n/a	n/a	0	circle.bmp
-486.3443636364	n/a	121586.0909	show_cross	n/a	n/a	n/a	cross.bmp
-486.8725454545	n/a	121718.1364	show_face	scrambled_face	first_show	17	s130.bmp
-487.8716363636	n/a	121967.9091	show_circle	n/a	n/a	0	circle.bmp
-489.5716363636	n/a	122392.9091	show_cross	n/a	n/a	n/a	cross.bmp
+onset	duration	sample	event_type	face_type	repetition_type	trial	trial_lag	trigger	stim_file
+0.004	n/a	1.0	setup	n/a	n/a	n/a	n/a	n/a	n/a
+0.004	n/a	1.0	right_sym	n/a	n/a	n/a	n/a	n/a	n/a
+23.971636363600002	n/a	5992.9091	show_face	famous_face	first_show	1	n/a	5	f140.bmp
+24.5898181818	n/a	6147.4545	right_press	n/a	n/a	1	n/a	4096	n/a
+24.9252727273	n/a	6231.3182	show_circle	n/a	n/a	1	n/a	0	circle.bmp
+26.6252727273	n/a	6656.3182	show_cross	n/a	n/a	2	n/a	n/a	cross.bmp
+27.179818181799998	n/a	6794.9545	show_face	famous_face	immediate_repeat	2	1	6	f140.bmp
+27.5707272727	n/a	6892.6818	right_press	n/a	n/a	2	n/a	4096	n/a
+28.0243636364	n/a	7006.0909	show_circle	n/a	n/a	2	n/a	0	circle.bmp
+29.7243636364	n/a	7431.0909	show_cross	n/a	n/a	3	n/a	n/a	cross.bmp
+30.3870909091	n/a	7596.7727	show_face	scrambled_face	first_show	3	n/a	17	s064.bmp
+30.9552727273	n/a	7738.8182	left_press	n/a	n/a	3	n/a	256	n/a
+31.2907272727	n/a	7822.6818	show_circle	n/a	n/a	3	n/a	0	circle.bmp
+32.9907272727	n/a	8247.6818	show_cross	n/a	n/a	4	n/a	n/a	cross.bmp
+33.5443636364	n/a	8386.0909	show_face	scrambled_face	immediate_repeat	4	1	18	s064.bmp
+33.9398181818	n/a	8484.9545	left_press	n/a	n/a	4	n/a	256	n/a
+34.4707272727	n/a	8617.6818	show_circle	n/a	n/a	4	n/a	0	circle.bmp
+36.1707272727	n/a	9042.6818	show_cross	n/a	n/a	5	n/a	n/a	cross.bmp
+36.718	n/a	9179.5	show_face	scrambled_face	first_show	5	n/a	17	s092.bmp
+37.4434545455	n/a	9360.8636	left_press	n/a	n/a	5	n/a	256	n/a
+37.7170909091	n/a	9429.2727	show_circle	n/a	n/a	5	n/a	0	circle.bmp
+39.4170909091	n/a	9854.2727	show_cross	n/a	n/a	6	n/a	n/a	cross.bmp
+39.8752727273	n/a	9968.8182	show_face	scrambled_face	immediate_repeat	6	1	18	s092.bmp
+40.298909090900004	n/a	10074.7273	left_press	n/a	n/a	6	n/a	256	n/a
+40.7552727273	n/a	10188.8182	show_circle	n/a	n/a	6	n/a	0	circle.bmp
+42.4552727273	n/a	10613.8182	show_cross	n/a	n/a	7	n/a	n/a	cross.bmp
+43.032545454499996	n/a	10758.1364	show_face	unfamiliar_face	first_show	7	n/a	13	u041.bmp
+43.6798181818	n/a	10919.9545	right_press	n/a	n/a	7	n/a	4096	n/a
+43.87527272729999	n/a	10968.8182	show_circle	n/a	n/a	7	n/a	0	circle.bmp
+45.575272727299996	n/a	11393.8182	show_cross	n/a	n/a	8	n/a	n/a	cross.bmp
+46.1898181818	n/a	11547.4545	show_face	unfamiliar_face	immediate_repeat	8	1	14	u041.bmp
+46.6507272727	n/a	11662.6818	right_press	n/a	n/a	8	n/a	4096	n/a
+47.1034545455	n/a	11775.8636	show_circle	n/a	n/a	8	n/a	0	circle.bmp
+48.8034545455	n/a	12200.8636	show_cross	n/a	n/a	9	n/a	n/a	cross.bmp
+49.430727272700004	n/a	12357.6818	show_face	unfamiliar_face	first_show	9	n/a	13	u099.bmp
+50.0125454545	n/a	12503.1364	right_press	n/a	n/a	9	n/a	4096	n/a
+50.408	n/a	12602.0	show_circle	n/a	n/a	9	n/a	0	circle.bmp
+52.108	n/a	13027.0	show_cross	n/a	n/a	10	n/a	n/a	cross.bmp
+52.7052727273	n/a	13176.3182	show_face	unfamiliar_face	first_show	10	n/a	13	u031.bmp
+53.2843636364	n/a	13321.0909	right_press	n/a	n/a	10	n/a	4096	n/a
+53.6443636364	n/a	13411.0909	show_circle	n/a	n/a	10	n/a	0	circle.bmp
+55.344363636400004	n/a	13836.0909	show_cross	n/a	n/a	11	n/a	n/a	cross.bmp
+55.8789090909	n/a	13969.7273	show_face	famous_face	first_show	11	n/a	5	f071.bmp
+56.4361818182	n/a	14109.0455	right_press	n/a	n/a	11	n/a	4096	n/a
+56.7307272727	n/a	14182.6818	show_circle	n/a	n/a	11	n/a	0	circle.bmp
+58.430727272700004	n/a	14607.6818	show_cross	n/a	n/a	12	n/a	n/a	cross.bmp
+58.9025454545	n/a	14725.6364	show_face	famous_face	first_show	12	n/a	5	f018.bmp
+59.4089090909	n/a	14852.2273	right_press	n/a	n/a	12	n/a	4096	n/a
+59.919818181800004	n/a	14979.9545	show_circle	n/a	n/a	12	n/a	0	circle.bmp
+61.61981818180001	n/a	15404.9545	show_cross	n/a	n/a	13	n/a	n/a	cross.bmp
+62.159818181800006	n/a	15539.9545	show_face	famous_face	immediate_repeat	13	1	6	f018.bmp
+62.6743636364	n/a	15668.5909	right_press	n/a	n/a	13	n/a	4096	n/a
+63.1170909091	n/a	15779.2727	show_circle	n/a	n/a	13	n/a	0	circle.bmp
+64.8170909091	n/a	16204.2727	show_cross	n/a	n/a	14	n/a	n/a	cross.bmp
+65.468	n/a	16367.0	show_face	unfamiliar_face	first_show	14	n/a	13	u035.bmp
+66.1689090909	n/a	16542.2273	left_press	n/a	n/a	14	n/a	256	n/a
+66.45345454550001	n/a	16613.3636	show_circle	n/a	n/a	14	n/a	0	circle.bmp
+68.1534545455	n/a	17038.3636	show_cross	n/a	n/a	15	n/a	n/a	cross.bmp
+68.7589090909	n/a	17189.7273	show_face	unfamiliar_face	immediate_repeat	15	1	14	u035.bmp
+69.16254545449999	n/a	17290.6364	left_press	n/a	n/a	15	n/a	256	n/a
+69.6552727273	n/a	17413.8182	show_circle	n/a	n/a	15	n/a	0	circle.bmp
+71.35527272729999	n/a	17838.8182	show_cross	n/a	n/a	16	n/a	n/a	cross.bmp
+71.9825454545	n/a	17995.6364	show_face	unfamiliar_face	first_show	16	n/a	13	u039.bmp
+72.5725454545	n/a	18143.1364	right_press	n/a	n/a	16	n/a	4096	n/a
+72.92345454550001	n/a	18230.8636	show_circle	n/a	n/a	16	n/a	0	circle.bmp
+74.6234545455	n/a	18655.8636	show_cross	n/a	n/a	17	n/a	n/a	cross.bmp
+75.2734545455	n/a	18818.3636	show_face	unfamiliar_face	delayed_repeat	17	8	15	u099.bmp
+75.8198181818	n/a	18954.9545	right_press	n/a	n/a	17	n/a	4096	n/a
+76.2352727273	n/a	19058.8182	show_circle	n/a	n/a	17	n/a	0	circle.bmp
+77.93527272729999	n/a	19483.8182	show_cross	n/a	n/a	18	n/a	n/a	cross.bmp
+78.5643636364	n/a	19641.0909	show_face	scrambled_face	first_show	18	n/a	17	s013.bmp
+79.3861818182	n/a	19846.5455	left_press	n/a	n/a	18	n/a	256	n/a
+79.4452727273	n/a	19861.3182	show_circle	n/a	n/a	18	n/a	0	circle.bmp
+81.1452727273	n/a	20286.3182	show_cross	n/a	n/a	19	n/a	n/a	cross.bmp
+81.7716363636	n/a	20442.9091	show_face	scrambled_face	immediate_repeat	19	1	18	s013.bmp
+82.3643636364	n/a	20591.0909	right_press	n/a	n/a	19	n/a	4096	n/a
+82.7161818182	n/a	20679.0455	show_circle	n/a	n/a	19	n/a	0	circle.bmp
+84.4161818182	n/a	21104.0455	show_cross	n/a	n/a	20	n/a	n/a	cross.bmp
+85.0625454545	n/a	21265.6364	show_face	unfamiliar_face	delayed_repeat	20	10	15	u031.bmp
+85.9389090909	n/a	21484.7273	show_circle	n/a	n/a	20	n/a	0	circle.bmp
+86.0243636364	n/a	21506.0909	right_press	n/a	n/a	20	n/a	4096	n/a
+87.6389090909	n/a	21909.7273	show_cross	n/a	n/a	21	n/a	n/a	cross.bmp
+88.1198181818	n/a	22029.9545	show_face	famous_face	first_show	21	n/a	5	f079.bmp
+88.8952727273	n/a	22223.8182	right_press	n/a	n/a	21	n/a	4096	n/a
+89.05345454549999	n/a	22263.3636	show_circle	n/a	n/a	21	n/a	0	circle.bmp
+90.75345454549999	n/a	22688.3636	show_cross	n/a	n/a	22	n/a	n/a	cross.bmp
+91.3107272727	n/a	22827.6818	show_face	famous_face	delayed_repeat	22	11	7	f071.bmp
+91.92618181819999	n/a	22981.5455	right_press	n/a	n/a	22	n/a	4096	n/a
+92.3198181818	n/a	23079.9545	show_circle	n/a	n/a	22	n/a	0	circle.bmp
+94.0198181818	n/a	23504.9545	show_cross	n/a	n/a	23	n/a	n/a	cross.bmp
+94.518	n/a	23629.5	show_face	unfamiliar_face	first_show	23	n/a	13	u045.bmp
+95.0661818182	n/a	23766.5455	right_press	n/a	n/a	23	n/a	4096	n/a
+95.38981818180001	n/a	23847.4545	show_circle	n/a	n/a	23	n/a	0	circle.bmp
+97.0898181818	n/a	24272.4545	show_cross	n/a	n/a	24	n/a	n/a	cross.bmp
+97.6416363636	n/a	24410.4091	show_face	scrambled_face	first_show	24	n/a	17	s112.bmp
+98.2443636364	n/a	24561.0909	left_press	n/a	n/a	24	n/a	256	n/a
+98.5852727273	n/a	24646.3182	show_circle	n/a	n/a	24	n/a	0	circle.bmp
+100.2852727273	n/a	25071.3182	show_cross	n/a	n/a	25	n/a	n/a	cross.bmp
+100.8325454545	n/a	25208.1364	show_face	unfamiliar_face	first_show	25	n/a	13	u087.bmp
+101.4989090909	n/a	25374.7273	right_press	n/a	n/a	25	n/a	4096	n/a
+101.7725454545	n/a	25443.1364	show_circle	n/a	n/a	25	n/a	0	circle.bmp
+103.47254545450001	n/a	25868.1364	show_cross	n/a	n/a	26	n/a	n/a	cross.bmp
+104.00618181819999	n/a	26001.5455	show_face	unfamiliar_face	delayed_repeat	26	10	15	u039.bmp
+104.6216363636	n/a	26155.4091	right_press	n/a	n/a	26	n/a	4096	n/a
+104.8952727273	n/a	26223.8182	show_circle	n/a	n/a	26	n/a	0	circle.bmp
+106.5952727273	n/a	26648.8182	show_cross	n/a	n/a	27	n/a	n/a	cross.bmp
+107.1307272727	n/a	26782.6818	show_face	famous_face	first_show	27	n/a	5	f008.bmp
+107.88981818180001	n/a	26972.4545	right_press	n/a	n/a	27	n/a	4096	n/a
+108.1407272727	n/a	27035.1818	show_circle	n/a	n/a	27	n/a	0	circle.bmp
+109.84072727270001	n/a	27460.1818	show_cross	n/a	n/a	28	n/a	n/a	cross.bmp
+110.3716363636	n/a	27592.9091	show_face	famous_face	immediate_repeat	28	1	6	f008.bmp
+110.808	n/a	27702.0	right_press	n/a	n/a	28	n/a	4096	n/a
+111.20072727270001	n/a	27800.1818	show_circle	n/a	n/a	28	n/a	0	circle.bmp
+112.90072727270001	n/a	28225.1818	show_cross	n/a	n/a	29	n/a	n/a	cross.bmp
+113.49527272729999	n/a	28373.8182	show_face	famous_face	first_show	29	n/a	5	f129.bmp
+114.08345454549999	n/a	28520.8636	right_press	n/a	n/a	29	n/a	4096	n/a
+114.4361818182	n/a	28609.0455	show_circle	n/a	n/a	29	n/a	0	circle.bmp
+116.1361818182	n/a	29034.0455	show_cross	n/a	n/a	30	n/a	n/a	cross.bmp
+116.7189090909	n/a	29179.7273	show_face	famous_face	immediate_repeat	30	1	6	f129.bmp
+117.1625454545	n/a	29290.6364	right_press	n/a	n/a	30	n/a	4096	n/a
+117.5370909091	n/a	29384.2727	show_circle	n/a	n/a	30	n/a	0	circle.bmp
+119.2370909091	n/a	29809.2727	show_cross	n/a	n/a	31	n/a	n/a	cross.bmp
+119.7925454545	n/a	29948.1364	show_face	famous_face	delayed_repeat	31	10	7	f079.bmp
+120.488	n/a	30122.0	right_press	n/a	n/a	31	n/a	4096	n/a
+120.75345454549999	n/a	30188.3636	show_circle	n/a	n/a	31	n/a	0	circle.bmp
+122.4534545455	n/a	30613.3636	show_cross	n/a	n/a	32	n/a	n/a	cross.bmp
+122.95072727270001	n/a	30737.6818	show_face	famous_face	first_show	32	n/a	5	f088.bmp
+123.6907272727	n/a	30922.6818	right_press	n/a	n/a	32	n/a	4096	n/a
+123.8452727273	n/a	30961.3182	show_circle	n/a	n/a	32	n/a	0	circle.bmp
+125.5452727273	n/a	31386.3182	show_cross	n/a	n/a	33	n/a	n/a	cross.bmp
+126.04072727270001	n/a	31510.1818	show_face	unfamiliar_face	delayed_repeat	33	10	15	u045.bmp
+126.6834545455	n/a	31670.8636	right_press	n/a	n/a	33	n/a	4096	n/a
+126.9389090909	n/a	31734.7273	show_circle	n/a	n/a	33	n/a	0	circle.bmp
+128.6389090909	n/a	32159.7273	show_cross	n/a	n/a	34	n/a	n/a	cross.bmp
+129.1816363636	n/a	32295.4091	show_face	unfamiliar_face	first_show	34	n/a	13	u085.bmp
+129.6898181818	n/a	32422.4545	left_press	n/a	n/a	34	n/a	256	n/a
+130.088	n/a	32522.0	show_circle	n/a	n/a	34	n/a	0	circle.bmp
+131.788	n/a	32947.0	show_cross	n/a	n/a	35	n/a	n/a	cross.bmp
+132.3389090909	n/a	33084.7273	show_face	scrambled_face	delayed_repeat	35	11	19	s112.bmp
+132.8152727273	n/a	33203.8182	left_press	n/a	n/a	35	n/a	256	n/a
+133.1807272727	n/a	33295.1818	show_circle	n/a	n/a	35	n/a	0	circle.bmp
+134.8807272727	n/a	33720.1818	show_cross	n/a	n/a	36	n/a	n/a	cross.bmp
+135.5125454545	n/a	33878.1364	show_face	unfamiliar_face	first_show	36	n/a	13	u027.bmp
+136.1243636364	n/a	34031.0909	left_press	n/a	n/a	36	n/a	256	n/a
+136.4352727273	n/a	34108.8182	show_circle	n/a	n/a	36	n/a	0	circle.bmp
+138.1352727273	n/a	34533.8182	show_cross	n/a	n/a	37	n/a	n/a	cross.bmp
+138.7361818182	n/a	34684.0455	show_face	unfamiliar_face	delayed_repeat	37	12	15	u087.bmp
+139.3298181818	n/a	34832.4545	right_press	n/a	n/a	37	n/a	4096	n/a
+139.6961818182	n/a	34924.0455	show_circle	n/a	n/a	37	n/a	0	circle.bmp
+141.3961818182	n/a	35349.0455	show_cross	n/a	n/a	38	n/a	n/a	cross.bmp
+141.99436363639998	n/a	35498.5909	show_face	famous_face	first_show	38	n/a	5	f050.bmp
+142.60254545450002	n/a	35650.6364	right_press	n/a	n/a	38	n/a	4096	n/a
+142.948	n/a	35737.0	show_circle	n/a	n/a	38	n/a	0	circle.bmp
+144.648	n/a	36162.0	show_cross	n/a	n/a	39	n/a	n/a	cross.bmp
+145.118	n/a	36279.5	show_face	famous_face	immediate_repeat	39	1	6	f050.bmp
+145.5661818182	n/a	36391.5455	right_press	n/a	n/a	39	n/a	4096	n/a
+146.0261818182	n/a	36506.5455	show_circle	n/a	n/a	39	n/a	0	circle.bmp
+147.7261818182	n/a	36931.5455	show_cross	n/a	n/a	40	n/a	n/a	cross.bmp
+148.2416363636	n/a	37060.4091	show_face	unfamiliar_face	first_show	40	n/a	13	u129.bmp
+148.8216363636	n/a	37205.4091	left_press	n/a	n/a	40	n/a	256	n/a
+149.1616363636	n/a	37290.4091	show_circle	n/a	n/a	40	n/a	0	circle.bmp
+150.8616363636	n/a	37715.4091	show_cross	n/a	n/a	41	n/a	n/a	cross.bmp
+151.5161818182	n/a	37879.0455	show_face	scrambled_face	first_show	41	n/a	17	s117.bmp
+152.0552727273	n/a	38013.8182	left_press	n/a	n/a	41	n/a	256	n/a
+152.3916363636	n/a	38097.9091	show_circle	n/a	n/a	41	n/a	0	circle.bmp
+154.0916363636	n/a	38522.9091	show_cross	n/a	n/a	42	n/a	n/a	cross.bmp
+154.60618181819999	n/a	38651.5455	show_face	famous_face	delayed_repeat	42	10	7	f088.bmp
+155.3170909091	n/a	38829.2727	right_press	n/a	n/a	42	n/a	4096	n/a
+155.5852727273	n/a	38896.3182	show_circle	n/a	n/a	42	n/a	0	circle.bmp
+157.2852727273	n/a	39321.3182	show_cross	n/a	n/a	43	n/a	n/a	cross.bmp
+157.7807272727	n/a	39445.1818	show_face	famous_face	first_show	43	n/a	5	f021.bmp
+158.4861818182	n/a	39621.5455	left_press	n/a	n/a	43	n/a	256	n/a
+158.6907272727	n/a	39672.6818	show_circle	n/a	n/a	43	n/a	0	circle.bmp
+160.3907272727	n/a	40097.6818	show_cross	n/a	n/a	44	n/a	n/a	cross.bmp
+160.9207272727	n/a	40230.1818	show_face	famous_face	immediate_repeat	44	1	6	f021.bmp
+161.3316363636	n/a	40332.9091	left_press	n/a	n/a	44	n/a	256	n/a
+161.938	n/a	40484.5	show_circle	n/a	n/a	44	n/a	0	circle.bmp
+163.638	n/a	40909.5	show_cross	n/a	n/a	45	n/a	n/a	cross.bmp
+164.2625454545	n/a	41065.6364	show_face	unfamiliar_face	delayed_repeat	45	11	15	u085.bmp
+164.8534545455	n/a	41213.3636	left_press	n/a	n/a	45	n/a	256	n/a
+165.2598181818	n/a	41314.9545	show_circle	n/a	n/a	45	n/a	0	circle.bmp
+166.95981818180002	n/a	41739.9545	show_cross	n/a	n/a	46	n/a	n/a	cross.bmp
+167.6034545455	n/a	41900.8636	show_face	unfamiliar_face	first_show	46	n/a	13	u088.bmp
+168.1989090909	n/a	42049.7273	left_press	n/a	n/a	46	n/a	256	n/a
+168.4452727273	n/a	42111.3182	show_circle	n/a	n/a	46	n/a	0	circle.bmp
+170.14527272729998	n/a	42536.3182	show_cross	n/a	n/a	47	n/a	n/a	cross.bmp
+170.6770909091	n/a	42669.2727	show_face	unfamiliar_face	immediate_repeat	47	1	14	u088.bmp
+171.10618181819999	n/a	42776.5455	left_press	n/a	n/a	47	n/a	256	n/a
+171.5152727273	n/a	42878.8182	show_circle	n/a	n/a	47	n/a	0	circle.bmp
+173.2152727273	n/a	43303.8182	show_cross	n/a	n/a	48	n/a	n/a	cross.bmp
+173.83436363639998	n/a	43458.5909	show_face	unfamiliar_face	delayed_repeat	48	12	15	u027.bmp
+174.4361818182	n/a	43609.0455	left_press	n/a	n/a	48	n/a	256	n/a
+174.6825454545	n/a	43670.6364	show_circle	n/a	n/a	48	n/a	0	circle.bmp
+176.38254545450002	n/a	44095.6364	show_cross	n/a	n/a	49	n/a	n/a	cross.bmp
+177.04163636360002	n/a	44260.4091	show_face	scrambled_face	first_show	49	n/a	17	s037.bmp
+177.6034545455	n/a	44400.8636	left_press	n/a	n/a	49	n/a	256	n/a
+178.0098181818	n/a	44502.4545	show_circle	n/a	n/a	49	n/a	0	circle.bmp
+179.70981818180002	n/a	44927.4545	show_cross	n/a	n/a	50	n/a	n/a	cross.bmp
+180.2825454545	n/a	45070.6364	show_face	famous_face	first_show	50	n/a	5	f060.bmp
+180.8661818182	n/a	45216.5455	left_press	n/a	n/a	50	n/a	256	n/a
+181.14527272729998	n/a	45286.3182	show_circle	n/a	n/a	50	n/a	0	circle.bmp
+182.8452727273	n/a	45711.3182	show_cross	n/a	n/a	51	n/a	n/a	cross.bmp
+183.3725454545	n/a	45843.1364	show_face	unfamiliar_face	delayed_repeat	51	11	15	u129.bmp
+183.9316363636	n/a	45982.9091	left_press	n/a	n/a	51	n/a	256	n/a
+184.3834545455	n/a	46095.8636	show_circle	n/a	n/a	51	n/a	0	circle.bmp
+186.0834545455	n/a	46520.8636	show_cross	n/a	n/a	52	n/a	n/a	cross.bmp
+186.6470909091	n/a	46661.7727	show_face	famous_face	first_show	52	n/a	5	f019.bmp
+187.3216363636	n/a	46830.4091	right_press	n/a	n/a	52	n/a	4096	n/a
+187.4934545455	n/a	46873.3636	show_circle	n/a	n/a	52	n/a	0	circle.bmp
+189.1934545455	n/a	47298.3636	show_cross	n/a	n/a	53	n/a	n/a	cross.bmp
+189.77072727270001	n/a	47442.6818	show_face	famous_face	immediate_repeat	53	1	6	f019.bmp
+190.238	n/a	47559.5	right_press	n/a	n/a	53	n/a	4096	n/a
+190.65345454549998	n/a	47663.3636	show_circle	n/a	n/a	53	n/a	0	circle.bmp
+192.3534545455	n/a	48088.3636	show_cross	n/a	n/a	54	n/a	n/a	cross.bmp
+192.9952727273	n/a	48248.8182	show_face	scrambled_face	delayed_repeat	54	13	19	s117.bmp
+193.5261818182	n/a	48381.5455	left_press	n/a	n/a	54	n/a	256	n/a
+193.8461818182	n/a	48461.5455	show_circle	n/a	n/a	54	n/a	0	circle.bmp
+195.54618181819998	n/a	48886.5455	show_cross	n/a	n/a	55	n/a	n/a	cross.bmp
+196.0852727273	n/a	49021.3182	show_face	unfamiliar_face	first_show	55	n/a	13	u060.bmp
+196.678	n/a	49169.5	right_press	n/a	n/a	55	n/a	4096	n/a
+196.958	n/a	49239.5	show_circle	n/a	n/a	55	n/a	0	circle.bmp
+198.658	n/a	49664.5	show_cross	n/a	n/a	56	n/a	n/a	cross.bmp
+199.2598181818	n/a	49814.9545	show_face	scrambled_face	first_show	56	n/a	17	s065.bmp
+199.7489090909	n/a	49937.2273	left_press	n/a	n/a	56	n/a	256	n/a
+200.148	n/a	50037.0	show_circle	n/a	n/a	56	n/a	0	circle.bmp
+201.848	n/a	50462.0	show_cross	n/a	n/a	57	n/a	n/a	cross.bmp
+202.4498181818	n/a	50612.4545	show_face	scrambled_face	immediate_repeat	57	1	18	s065.bmp
+202.9889090909	n/a	50747.2273	left_press	n/a	n/a	57	n/a	256	n/a
+203.3589090909	n/a	50839.7273	show_circle	n/a	n/a	57	n/a	0	circle.bmp
+205.0589090909	n/a	51264.7273	show_cross	n/a	n/a	58	n/a	n/a	cross.bmp
+205.708	n/a	51427.0	show_face	scrambled_face	first_show	58	n/a	17	s136.bmp
+206.1689090909	n/a	51542.2273	left_press	n/a	n/a	58	n/a	256	n/a
+206.6543636364	n/a	51663.5909	show_circle	n/a	n/a	58	n/a	0	circle.bmp
+208.3543636364	n/a	52088.5909	show_cross	n/a	n/a	59	n/a	n/a	cross.bmp
+208.9489090909	n/a	52237.2273	show_face	scrambled_face	delayed_repeat	59	10	19	s037.bmp
+209.66254545450002	n/a	52415.6364	left_press	n/a	n/a	59	n/a	256	n/a
+209.7689090909	n/a	52442.2273	show_circle	n/a	n/a	59	n/a	0	circle.bmp
+211.4689090909	n/a	52867.2273	show_cross	n/a	n/a	60	n/a	n/a	cross.bmp
+212.10618181819999	n/a	53026.5455	show_face	famous_face	first_show	60	n/a	5	f094.bmp
+212.6298181818	n/a	53157.4545	right_press	n/a	n/a	60	n/a	4096	n/a
+212.9416363636	n/a	53235.4091	show_circle	n/a	n/a	60	n/a	0	circle.bmp
+214.6416363636	n/a	53660.4091	show_cross	n/a	n/a	61	n/a	n/a	cross.bmp
+215.0961818182	n/a	53774.0455	show_face	famous_face	immediate_repeat	61	1	6	f094.bmp
+215.5607272727	n/a	53890.1818	right_press	n/a	n/a	61	n/a	4096	n/a
+215.9416363636	n/a	53985.4091	show_circle	n/a	n/a	61	n/a	0	circle.bmp
+217.6416363636	n/a	54410.4091	show_cross	n/a	n/a	62	n/a	n/a	cross.bmp
+218.10254545450002	n/a	54525.6364	show_face	famous_face	delayed_repeat	62	12	7	f060.bmp
+218.6370909091	n/a	54659.2727	left_press	n/a	n/a	62	n/a	256	n/a
+219.02436363639998	n/a	54756.0909	show_circle	n/a	n/a	62	n/a	0	circle.bmp
+220.7243636364	n/a	55181.0909	show_cross	n/a	n/a	63	n/a	n/a	cross.bmp
+221.22709090909999	n/a	55306.7727	show_face	unfamiliar_face	first_show	63	n/a	13	u018.bmp
+222.0016363636	n/a	55500.4091	left_press	n/a	n/a	63	n/a	256	n/a
+222.2034545455	n/a	55550.8636	show_circle	n/a	n/a	63	n/a	0	circle.bmp
+223.90345454549998	n/a	55975.8636	show_cross	n/a	n/a	64	n/a	n/a	cross.bmp
+224.518	n/a	56129.5	show_face	unfamiliar_face	immediate_repeat	64	1	14	u018.bmp
+224.9843636364	n/a	56246.0909	left_press	n/a	n/a	64	n/a	256	n/a
+225.47254545450002	n/a	56368.1364	show_circle	n/a	n/a	64	n/a	0	circle.bmp
+227.1725454545	n/a	56793.1364	show_cross	n/a	n/a	65	n/a	n/a	cross.bmp
+227.7589090909	n/a	56939.7273	show_face	scrambled_face	first_show	65	n/a	17	s034.bmp
+228.3207272727	n/a	57080.1818	left_press	n/a	n/a	65	n/a	256	n/a
+228.59345454549998	n/a	57148.3636	show_circle	n/a	n/a	65	n/a	0	circle.bmp
+230.2934545455	n/a	57573.3636	show_cross	n/a	n/a	66	n/a	n/a	cross.bmp
+230.7825454545	n/a	57695.6364	show_face	unfamiliar_face	delayed_repeat	66	11	15	u060.bmp
+231.2843636364	n/a	57821.0909	right_press	n/a	n/a	66	n/a	4096	n/a
+231.6634545455	n/a	57915.8636	show_circle	n/a	n/a	66	n/a	0	circle.bmp
+233.3634545455	n/a	58340.8636	show_cross	n/a	n/a	67	n/a	n/a	cross.bmp
+233.8725454545	n/a	58468.1364	show_face	scrambled_face	first_show	67	n/a	17	s110.bmp
+234.428	n/a	58607.0	left_press	n/a	n/a	67	n/a	256	n/a
+234.83436363639998	n/a	58708.5909	show_circle	n/a	n/a	67	n/a	0	circle.bmp
+236.5343636364	n/a	59133.5909	show_cross	n/a	n/a	68	n/a	n/a	cross.bmp
+237.1298181818	n/a	59282.4545	show_face	famous_face	first_show	68	n/a	5	f122.bmp
+237.9398181818	n/a	59484.9545	right_press	n/a	n/a	68	n/a	4096	n/a
+237.9589090909	n/a	59489.7273	show_circle	n/a	n/a	68	n/a	0	circle.bmp
+239.6589090909	n/a	59914.7273	show_cross	n/a	n/a	69	n/a	n/a	cross.bmp
+240.30436363639998	n/a	60076.0909	show_face	scrambled_face	delayed_repeat	69	11	19	s136.bmp
+241.128	n/a	60282.0	show_circle	n/a	n/a	69	n/a	0	circle.bmp
+241.1343636364	n/a	60283.5909	left_press	n/a	n/a	69	n/a	256	n/a
+242.828	n/a	60707.0	show_cross	n/a	n/a	70	n/a	n/a	cross.bmp
+243.2943636364	n/a	60823.5909	show_face	famous_face	first_show	70	n/a	5	f007.bmp
+244.0898181818	n/a	61022.4545	right_press	n/a	n/a	70	n/a	4096	n/a
+244.3070909091	n/a	61076.7727	show_circle	n/a	n/a	70	n/a	0	circle.bmp
+246.0070909091	n/a	61501.7727	show_cross	n/a	n/a	71	n/a	n/a	cross.bmp
+246.6352727273	n/a	61658.8182	show_face	famous_face	immediate_repeat	71	1	6	f007.bmp
+247.42163636360002	n/a	61855.4091	right_press	n/a	n/a	71	n/a	4096	n/a
+247.6470909091	n/a	61911.7727	show_circle	n/a	n/a	71	n/a	0	circle.bmp
+249.3470909091	n/a	62336.7727	show_cross	n/a	n/a	72	n/a	n/a	cross.bmp
+249.82618181819998	n/a	62456.5455	show_face	scrambled_face	first_show	72	n/a	17	s107.bmp
+250.43345454549998	n/a	62608.3636	left_press	n/a	n/a	72	n/a	256	n/a
+250.69254545450002	n/a	62673.1364	show_circle	n/a	n/a	72	n/a	0	circle.bmp
+252.3925454545	n/a	63098.1364	show_cross	n/a	n/a	73	n/a	n/a	cross.bmp
+252.9834545455	n/a	63245.8636	show_face	scrambled_face	first_show	73	n/a	17	s133.bmp
+253.8570909091	n/a	63464.2727	show_circle	n/a	n/a	73	n/a	0	circle.bmp
+253.9525454545	n/a	63488.1364	right_press	n/a	n/a	73	n/a	4096	n/a
+255.5570909091	n/a	63889.2727	show_cross	n/a	n/a	74	n/a	n/a	cross.bmp
+256.0234545455	n/a	64005.8636	show_face	scrambled_face	immediate_repeat	74	1	18	s133.bmp
+256.6725454545	n/a	64168.1364	right_press	n/a	n/a	74	n/a	4096	n/a
+256.84527272729997	n/a	64211.3182	show_circle	n/a	n/a	74	n/a	0	circle.bmp
+258.5452727273	n/a	64636.3182	show_cross	n/a	n/a	75	n/a	n/a	cross.bmp
+259.0470909091	n/a	64761.7727	show_face	scrambled_face	delayed_repeat	75	10	19	s034.bmp
+259.5898181818	n/a	64897.4545	left_press	n/a	n/a	75	n/a	256	n/a
+259.8743636364	n/a	64968.5909	show_circle	n/a	n/a	75	n/a	0	circle.bmp
+261.5743636364	n/a	65393.5909	show_cross	n/a	n/a	76	n/a	n/a	cross.bmp
+262.038	n/a	65509.5	show_face	famous_face	first_show	76	n/a	5	f069.bmp
+262.6925454545	n/a	65673.1364	left_press	n/a	n/a	76	n/a	256	n/a
+262.8616363636	n/a	65715.4091	show_circle	n/a	n/a	76	n/a	0	circle.bmp
+264.56163636360003	n/a	66140.4091	show_cross	n/a	n/a	77	n/a	n/a	cross.bmp
+265.1616363636	n/a	66290.4091	show_face	scrambled_face	delayed_repeat	77	10	19	s110.bmp
+265.7370909091	n/a	66434.2727	left_press	n/a	n/a	77	n/a	256	n/a
+266.0207272727	n/a	66505.1818	show_circle	n/a	n/a	77	n/a	0	circle.bmp
+267.7207272727	n/a	66930.1818	show_cross	n/a	n/a	78	n/a	n/a	cross.bmp
+268.218	n/a	67054.5	show_face	famous_face	first_show	78	n/a	5	f142.bmp
+268.8325454545	n/a	67208.1364	right_press	n/a	n/a	78	n/a	4096	n/a
+269.23345454549997	n/a	67308.3636	show_circle	n/a	n/a	78	n/a	0	circle.bmp
+270.9334545455	n/a	67733.3636	show_cross	n/a	n/a	79	n/a	n/a	cross.bmp
+271.4425454545	n/a	67860.6364	show_face	famous_face	delayed_repeat	79	11	7	f122.bmp
+272.0361818182	n/a	68009.0455	right_press	n/a	n/a	79	n/a	4096	n/a
+272.38890909090003	n/a	68097.2273	show_circle	n/a	n/a	79	n/a	0	circle.bmp
+274.0889090909	n/a	68522.2273	show_cross	n/a	n/a	80	n/a	n/a	cross.bmp
+274.6498181818	n/a	68662.4545	show_face	famous_face	first_show	80	n/a	5	f058.bmp
+275.2498181818	n/a	68812.4545	right_press	n/a	n/a	80	n/a	4096	n/a
+275.6170909091	n/a	68904.2727	show_circle	n/a	n/a	80	n/a	0	circle.bmp
+277.3170909091	n/a	69329.2727	show_cross	n/a	n/a	81	n/a	n/a	cross.bmp
+277.8407272727	n/a	69460.1818	show_face	famous_face	immediate_repeat	81	1	6	f058.bmp
+278.7034545455	n/a	69675.8636	show_circle	n/a	n/a	81	n/a	0	circle.bmp
+278.8825454545	n/a	69720.6364	right_press	n/a	n/a	81	n/a	4096	n/a
+280.4034545455	n/a	70100.8636	show_cross	n/a	n/a	82	n/a	n/a	cross.bmp
+280.898	n/a	70224.5	show_face	famous_face	first_show	82	n/a	5	f144.bmp
+281.7298181818	n/a	70432.4545	right_press	n/a	n/a	82	n/a	4096	n/a
+281.88890909090003	n/a	70472.2273	show_circle	n/a	n/a	82	n/a	0	circle.bmp
+283.5889090909	n/a	70897.2273	show_cross	n/a	n/a	83	n/a	n/a	cross.bmp
+284.1552727273	n/a	71038.8182	show_face	famous_face	immediate_repeat	83	1	6	f144.bmp
+284.6007272727	n/a	71150.1818	right_press	n/a	n/a	83	n/a	4096	n/a
+285.0689090909	n/a	71267.2273	show_circle	n/a	n/a	83	n/a	0	circle.bmp
+286.7689090909	n/a	71692.2273	show_cross	n/a	n/a	84	n/a	n/a	cross.bmp
+287.2961818182	n/a	71824.0455	show_face	scrambled_face	delayed_repeat	84	12	19	s107.bmp
+287.9316363636	n/a	71982.9091	left_press	n/a	n/a	84	n/a	256	n/a
+288.12163636360003	n/a	72030.4091	show_circle	n/a	n/a	84	n/a	0	circle.bmp
+289.8216363636	n/a	72455.4091	show_cross	n/a	n/a	85	n/a	n/a	cross.bmp
+290.3861818182	n/a	72596.5455	show_face	famous_face	first_show	85	n/a	5	f056.bmp
+291.21618181819997	n/a	72804.0455	right_press	n/a	n/a	85	n/a	4096	n/a
+291.3189090909	n/a	72829.7273	show_circle	n/a	n/a	85	n/a	0	circle.bmp
+293.0189090909	n/a	73254.7273	show_cross	n/a	n/a	86	n/a	n/a	cross.bmp
+293.54345454549997	n/a	73385.8636	show_face	famous_face	immediate_repeat	86	1	6	f056.bmp
+294.00981818180003	n/a	73502.4545	right_press	n/a	n/a	86	n/a	4096	n/a
+294.408	n/a	73602.0	show_circle	n/a	n/a	86	n/a	0	circle.bmp
+296.108	n/a	74027.0	show_cross	n/a	n/a	87	n/a	n/a	cross.bmp
+296.6343636364	n/a	74158.5909	show_face	unfamiliar_face	first_show	87	n/a	13	u123.bmp
+297.1689090909	n/a	74292.2273	left_press	n/a	n/a	87	n/a	256	n/a
+297.508	n/a	74377.0	show_circle	n/a	n/a	87	n/a	0	circle.bmp
+299.208	n/a	74802.0	show_cross	n/a	n/a	88	n/a	n/a	cross.bmp
+299.8416363636	n/a	74960.4091	show_face	famous_face	delayed_repeat	88	12	7	f069.bmp
+300.4052727273	n/a	75101.3182	right_press	n/a	n/a	88	n/a	4096	n/a
+300.7289090909	n/a	75182.2273	show_circle	n/a	n/a	88	n/a	0	circle.bmp
+302.4289090909	n/a	75607.2273	show_cross	n/a	n/a	89	n/a	n/a	cross.bmp
+302.9152727273	n/a	75728.8182	show_face	unfamiliar_face	first_show	89	n/a	13	u081.bmp
+303.4952727273	n/a	75873.8182	left_press	n/a	n/a	89	n/a	256	n/a
+303.7370909091	n/a	75934.2727	show_circle	n/a	n/a	89	n/a	0	circle.bmp
+305.4370909091	n/a	76359.2727	show_cross	n/a	n/a	90	n/a	n/a	cross.bmp
+306.0725454545	n/a	76518.1364	show_face	unfamiliar_face	immediate_repeat	90	1	14	u081.bmp
+306.5334545455	n/a	76633.3636	left_press	n/a	n/a	90	n/a	256	n/a
+307.03527272729997	n/a	76758.8182	show_circle	n/a	n/a	90	n/a	0	circle.bmp
+308.7352727273	n/a	77183.8182	show_cross	n/a	n/a	91	n/a	n/a	cross.bmp
+309.2461818182	n/a	77311.5455	show_face	famous_face	delayed_repeat	91	13	7	f142.bmp
+309.888	n/a	77472.0	right_press	n/a	n/a	91	n/a	4096	n/a
+310.2443636364	n/a	77561.0909	show_circle	n/a	n/a	91	n/a	0	circle.bmp
+311.9443636364	n/a	77986.0909	show_cross	n/a	n/a	92	n/a	n/a	cross.bmp
+312.5370909091	n/a	78134.2727	show_face	unfamiliar_face	first_show	92	n/a	13	u063.bmp
+313.0852727273	n/a	78271.3182	left_press	n/a	n/a	92	n/a	256	n/a
+313.5061818182	n/a	78376.5455	show_circle	n/a	n/a	92	n/a	0	circle.bmp
+315.2061818182	n/a	78801.5455	show_cross	n/a	n/a	93	n/a	n/a	cross.bmp
+315.7943636364	n/a	78948.5909	show_face	unfamiliar_face	immediate_repeat	93	1	14	u063.bmp
+316.2961818182	n/a	79074.0455	left_press	n/a	n/a	93	n/a	256	n/a
+316.7770909091	n/a	79194.2727	show_circle	n/a	n/a	93	n/a	0	circle.bmp
+318.4770909091	n/a	79619.2727	show_cross	n/a	n/a	94	n/a	n/a	cross.bmp
+319.05254545450003	n/a	79763.1364	show_face	scrambled_face	first_show	94	n/a	17	s149.bmp
+319.6498181818	n/a	79912.4545	left_press	n/a	n/a	94	n/a	256	n/a
+319.8852727273	n/a	79971.3182	show_circle	n/a	n/a	94	n/a	0	circle.bmp
+321.5852727273	n/a	80396.3182	show_cross	n/a	n/a	95	n/a	n/a	cross.bmp
+322.0925454545	n/a	80523.1364	show_face	scrambled_face	immediate_repeat	95	1	18	s149.bmp
+322.56163636360003	n/a	80640.4091	left_press	n/a	n/a	95	n/a	256	n/a
+323.0852727273	n/a	80771.3182	show_circle	n/a	n/a	95	n/a	0	circle.bmp
+324.78527272729997	n/a	81196.3182	show_cross	n/a	n/a	96	n/a	n/a	cross.bmp
+325.2834545455	n/a	81320.8636	show_face	scrambled_face	first_show	96	n/a	17	s088.bmp
+325.8652727273	n/a	81466.3182	left_press	n/a	n/a	96	n/a	256	n/a
+326.2416363636	n/a	81560.4091	show_circle	n/a	n/a	96	n/a	0	circle.bmp
+327.9416363636	n/a	81985.4091	show_cross	n/a	n/a	97	n/a	n/a	cross.bmp
+328.4070909091	n/a	82101.7727	show_face	scrambled_face	first_show	97	n/a	17	s084.bmp
+329.10436363639997	n/a	82276.0909	left_press	n/a	n/a	97	n/a	256	n/a
+329.3216363636	n/a	82330.4091	show_circle	n/a	n/a	97	n/a	0	circle.bmp
+331.0216363636	n/a	82755.4091	show_cross	n/a	n/a	98	n/a	n/a	cross.bmp
+331.6143636364	n/a	82903.5909	show_face	unfamiliar_face	delayed_repeat	98	11	15	u123.bmp
+332.3298181818	n/a	83082.4545	left_press	n/a	n/a	98	n/a	256	n/a
+332.4861818182	n/a	83121.5455	show_circle	n/a	n/a	98	n/a	0	circle.bmp
+334.1861818182	n/a	83546.5455	show_cross	n/a	n/a	99	n/a	n/a	cross.bmp
+334.7552727273	n/a	83688.8182	show_face	scrambled_face	first_show	99	n/a	17	s038.bmp
+335.5216363636	n/a	83880.4091	left_press	n/a	n/a	99	n/a	256	n/a
+335.7298181818	n/a	83932.4545	show_circle	n/a	n/a	99	n/a	0	circle.bmp
+337.4298181818	n/a	84357.4545	show_cross	n/a	n/a	100	n/a	n/a	cross.bmp
+337.9461818182	n/a	84486.5455	show_face	scrambled_face	immediate_repeat	100	1	18	s038.bmp
+338.3934545455	n/a	84598.3636	left_press	n/a	n/a	100	n/a	256	n/a
+338.78527272729997	n/a	84696.3182	show_circle	n/a	n/a	100	n/a	0	circle.bmp
+340.4852727273	n/a	85121.3182	show_cross	n/a	n/a	101	n/a	n/a	cross.bmp
+340.9525454545	n/a	85238.1364	show_face	unfamiliar_face	first_show	101	n/a	13	u112.bmp
+341.8089090909	n/a	85452.2273	show_circle	n/a	n/a	101	n/a	0	circle.bmp
+341.878	n/a	85469.5	right_press	n/a	n/a	101	n/a	4096	n/a
+343.5089090909	n/a	85877.2273	show_cross	n/a	n/a	102	n/a	n/a	cross.bmp
+344.12709090910005	n/a	86031.7727	show_face	unfamiliar_face	immediate_repeat	102	1	14	u112.bmp
+344.57709090910004	n/a	86144.2727	right_press	n/a	n/a	102	n/a	4096	n/a
+345.1207272727	n/a	86280.1818	show_circle	n/a	n/a	102	n/a	0	circle.bmp
+346.82072727269997	n/a	86705.1818	show_cross	n/a	n/a	103	n/a	n/a	cross.bmp
+347.40072727269995	n/a	86850.1818	show_face	unfamiliar_face	first_show	103	n/a	13	u021.bmp
+348.0507272727	n/a	87012.6818	left_press	n/a	n/a	103	n/a	256	n/a
+348.31709090910005	n/a	87079.2727	show_circle	n/a	n/a	103	n/a	0	circle.bmp
+350.01709090910003	n/a	87504.2727	show_cross	n/a	n/a	104	n/a	n/a	cross.bmp
+350.64254545449995	n/a	87660.6364	show_face	famous_face	first_show	104	n/a	5	f059.bmp
+351.26527272730004	n/a	87816.3182	right_press	n/a	n/a	104	n/a	4096	n/a
+351.5543636364	n/a	87888.5909	show_circle	n/a	n/a	104	n/a	0	circle.bmp
+353.2543636364	n/a	88313.5909	show_cross	n/a	n/a	105	n/a	n/a	cross.bmp
+353.8661818182	n/a	88466.5455	show_face	scrambled_face	delayed_repeat	105	9	19	s088.bmp
+354.74709090910005	n/a	88686.7727	right_press	n/a	n/a	105	n/a	4096	n/a
+354.7761818182	n/a	88694.0455	show_circle	n/a	n/a	105	n/a	0	circle.bmp
+356.4761818182	n/a	89119.0455	show_cross	n/a	n/a	106	n/a	n/a	cross.bmp
+357.02345454550004	n/a	89255.8636	show_face	scrambled_face	first_show	106	n/a	17	s081.bmp
+357.5634545455	n/a	89390.8636	left_press	n/a	n/a	106	n/a	256	n/a
+357.968	n/a	89492.0	show_circle	n/a	n/a	106	n/a	0	circle.bmp
+359.668	n/a	89917.0	show_cross	n/a	n/a	107	n/a	n/a	cross.bmp
+360.21345454550004	n/a	90053.3636	show_face	scrambled_face	delayed_repeat	107	10	19	s084.bmp
+360.8898181818	n/a	90222.4545	right_press	n/a	n/a	107	n/a	4096	n/a
+361.0543636364	n/a	90263.5909	show_circle	n/a	n/a	107	n/a	0	circle.bmp
+362.7543636364	n/a	90688.5909	show_cross	n/a	n/a	108	n/a	n/a	cross.bmp
+363.3707272727	n/a	90842.6818	show_face	famous_face	first_show	108	n/a	5	f104.bmp
+364.0034545455	n/a	91000.8636	right_press	n/a	n/a	108	n/a	4096	n/a
+364.26890909089997	n/a	91067.2273	show_circle	n/a	n/a	108	n/a	0	circle.bmp
+365.96890909089996	n/a	91492.2273	show_cross	n/a	n/a	109	n/a	n/a	cross.bmp
+366.5452727273	n/a	91636.3182	show_face	famous_face	immediate_repeat	109	1	6	f104.bmp
+366.97890909089995	n/a	91744.7273	right_press	n/a	n/a	109	n/a	4096	n/a
+367.4816363636	n/a	91870.4091	show_circle	n/a	n/a	109	n/a	0	circle.bmp
+369.1816363636	n/a	92295.4091	show_cross	n/a	n/a	110	n/a	n/a	cross.bmp
+369.71890909089996	n/a	92429.7273	show_face	unfamiliar_face	first_show	110	n/a	13	u076.bmp
+370.35890909089994	n/a	92589.7273	left_press	n/a	n/a	110	n/a	256	n/a
+370.5543636364	n/a	92638.5909	show_circle	n/a	n/a	110	n/a	0	circle.bmp
+372.2543636364	n/a	93063.5909	show_cross	n/a	n/a	111	n/a	n/a	cross.bmp
+372.7261818182	n/a	93181.5455	show_face	unfamiliar_face	immediate_repeat	111	1	14	u076.bmp
+373.1807272727	n/a	93295.1818	left_press	n/a	n/a	111	n/a	256	n/a
+373.6134545455	n/a	93403.3636	show_circle	n/a	n/a	111	n/a	0	circle.bmp
+375.3134545455	n/a	93828.3636	show_cross	n/a	n/a	112	n/a	n/a	cross.bmp
+375.81709090910005	n/a	93954.2727	show_face	unfamiliar_face	first_show	112	n/a	13	u118.bmp
+376.49709090910005	n/a	94124.2727	right_press	n/a	n/a	112	n/a	4096	n/a
+376.7761818182	n/a	94194.0455	show_circle	n/a	n/a	112	n/a	0	circle.bmp
+378.4761818182	n/a	94619.0455	show_cross	n/a	n/a	113	n/a	n/a	cross.bmp
+379.1070909091	n/a	94776.7727	show_face	unfamiliar_face	delayed_repeat	113	10	15	u021.bmp
+379.93709090910005	n/a	94984.2727	show_circle	n/a	n/a	113	n/a	0	circle.bmp
+380.3634545455	n/a	95090.8636	left_press	n/a	n/a	113	n/a	256	n/a
+381.63709090910004	n/a	95409.2727	show_cross	n/a	n/a	114	n/a	n/a	cross.bmp
+382.1807272727	n/a	95545.1818	show_face	unfamiliar_face	first_show	114	n/a	13	u149.bmp
+382.68527272730006	n/a	95671.3182	left_press	n/a	n/a	114	n/a	256	n/a
+383.06254545449997	n/a	95765.6364	show_circle	n/a	n/a	114	n/a	0	circle.bmp
+384.76254545449996	n/a	96190.6364	show_cross	n/a	n/a	115	n/a	n/a	cross.bmp
+385.3216363636	n/a	96330.4091	show_face	famous_face	delayed_repeat	115	11	7	f059.bmp
+386.02890909089996	n/a	96507.2273	right_press	n/a	n/a	115	n/a	4096	n/a
+386.32345454550006	n/a	96580.8636	show_circle	n/a	n/a	115	n/a	0	circle.bmp
+388.02345454550004	n/a	97005.8636	show_cross	n/a	n/a	116	n/a	n/a	cross.bmp
+388.5970909091	n/a	97149.2727	show_face	scrambled_face	first_show	116	n/a	17	s031.bmp
+389.38709090910004	n/a	97346.7727	left_press	n/a	n/a	116	n/a	256	n/a
+389.5861818182	n/a	97396.5455	show_circle	n/a	n/a	116	n/a	0	circle.bmp
+391.2861818182	n/a	97821.5455	show_cross	n/a	n/a	117	n/a	n/a	cross.bmp
+391.8698181818	n/a	97967.4545	show_face	scrambled_face	immediate_repeat	117	1	18	s031.bmp
+392.4716363636	n/a	98117.9091	left_press	n/a	n/a	117	n/a	256	n/a
+392.6916363636	n/a	98172.9091	show_circle	n/a	n/a	117	n/a	0	circle.bmp
+394.3916363636	n/a	98597.9091	show_cross	n/a	n/a	118	n/a	n/a	cross.bmp
+394.8607272727	n/a	98715.1818	show_face	scrambled_face	delayed_repeat	118	12	19	s081.bmp
+395.6943636364	n/a	98923.5909	left_press	n/a	n/a	118	n/a	256	n/a
+395.818	n/a	98954.5	show_circle	n/a	n/a	118	n/a	0	circle.bmp
+397.518	n/a	99379.5	show_cross	n/a	n/a	119	n/a	n/a	cross.bmp
+398.068	n/a	99517.0	show_face	unfamiliar_face	first_show	119	n/a	13	u096.bmp
+398.558	n/a	99639.5	right_press	n/a	n/a	119	n/a	4096	n/a
+398.9770909091	n/a	99744.2727	show_circle	n/a	n/a	119	n/a	0	circle.bmp
+400.67709090910006	n/a	100169.2727	show_cross	n/a	n/a	120	n/a	n/a	cross.bmp
+401.2416363636	n/a	100310.4091	show_face	unfamiliar_face	immediate_repeat	120	1	14	u096.bmp
+401.71072727269996	n/a	100427.6818	right_press	n/a	n/a	120	n/a	4096	n/a
+402.2543636364	n/a	100563.5909	show_circle	n/a	n/a	120	n/a	0	circle.bmp
+403.9543636364	n/a	100988.5909	show_cross	n/a	n/a	121	n/a	n/a	cross.bmp
+404.6161818182	n/a	101154.0455	show_face	scrambled_face	first_show	121	n/a	17	s120.bmp
+405.58890909089996	n/a	101397.2273	show_circle	n/a	n/a	121	n/a	0	circle.bmp
+405.8098181818	n/a	101452.4545	left_press	n/a	n/a	121	n/a	256	n/a
+407.28890909089995	n/a	101822.2273	show_cross	n/a	n/a	122	n/a	n/a	cross.bmp
+407.75709090910004	n/a	101939.2727	show_face	scrambled_face	first_show	122	n/a	17	s047.bmp
+408.4343636364	n/a	102108.5909	left_press	n/a	n/a	122	n/a	256	n/a
+408.72890909089995	n/a	102182.2273	show_circle	n/a	n/a	122	n/a	0	circle.bmp
+410.42890909089994	n/a	102607.2273	show_cross	n/a	n/a	123	n/a	n/a	cross.bmp
+410.91436363639997	n/a	102728.5909	show_face	scrambled_face	immediate_repeat	123	1	18	s047.bmp
+411.378	n/a	102844.5	left_press	n/a	n/a	123	n/a	256	n/a
+411.748	n/a	102937.0	show_circle	n/a	n/a	123	n/a	0	circle.bmp
+413.448	n/a	103362.0	show_cross	n/a	n/a	124	n/a	n/a	cross.bmp
+413.938	n/a	103484.5	show_face	unfamiliar_face	delayed_repeat	124	12	15	u118.bmp
+414.74527272730006	n/a	103686.3182	left_press	n/a	n/a	124	n/a	256	n/a
+414.88709090910004	n/a	103721.7727	show_circle	n/a	n/a	124	n/a	0	circle.bmp
+416.5870909091	n/a	104146.7727	show_cross	n/a	n/a	125	n/a	n/a	cross.bmp
+417.24527272730006	n/a	104311.3182	show_face	scrambled_face	first_show	125	n/a	17	s102.bmp
+418.16072727269994	n/a	104540.1818	show_circle	n/a	n/a	125	n/a	0	circle.bmp
+418.3034545455	n/a	104575.8636	left_press	n/a	n/a	125	n/a	256	n/a
+419.8607272727	n/a	104965.1818	show_cross	n/a	n/a	126	n/a	n/a	cross.bmp
+420.4861818182	n/a	105121.5455	show_face	unfamiliar_face	delayed_repeat	126	12	15	u149.bmp
+421.038	n/a	105259.5	left_press	n/a	n/a	126	n/a	256	n/a
+421.328	n/a	105332.0	show_circle	n/a	n/a	126	n/a	0	circle.bmp
+423.028	n/a	105757.0	show_cross	n/a	n/a	127	n/a	n/a	cross.bmp
+423.64345454550005	n/a	105910.8636	show_face	famous_face	first_show	127	n/a	5	f077.bmp
+424.27890909089996	n/a	106069.7273	left_press	n/a	n/a	127	n/a	256	n/a
+424.5452727273	n/a	106136.3182	show_circle	n/a	n/a	127	n/a	0	circle.bmp
+426.24527272730006	n/a	106561.3182	show_cross	n/a	n/a	128	n/a	n/a	cross.bmp
+426.7170909091	n/a	106679.2727	show_face	famous_face	immediate_repeat	128	1	6	f077.bmp
+427.20527272730004	n/a	106801.3182	left_press	n/a	n/a	128	n/a	256	n/a
+427.5916363636	n/a	106897.9091	show_circle	n/a	n/a	128	n/a	0	circle.bmp
+429.2916363636	n/a	107322.9091	show_cross	n/a	n/a	129	n/a	n/a	cross.bmp
+429.9416363636	n/a	107485.4091	show_face	unfamiliar_face	first_show	129	n/a	13	u057.bmp
+430.5561818182	n/a	107639.0455	left_press	n/a	n/a	129	n/a	256	n/a
+430.8452727273	n/a	107711.3182	show_circle	n/a	n/a	129	n/a	0	circle.bmp
+430.8461818182	n/a	107711.5455	show_circle	n/a	n/a	129	n/a	0	circle.bmp
+432.5452727273	n/a	108136.3182	show_cross	n/a	n/a	130	n/a	n/a	cross.bmp
+432.5461818182	n/a	108136.5455	show_cross	n/a	n/a	131	n/a	n/a	cross.bmp
+433.1816363636	n/a	108295.4091	show_face	scrambled_face	first_show	131	n/a	17	s074.bmp
+433.7925454545	n/a	108448.1364	left_press	n/a	n/a	131	n/a	256	n/a
+433.9998181818	n/a	108499.9545	show_circle	n/a	n/a	131	n/a	0	circle.bmp
+435.6998181818	n/a	108924.9545	show_cross	n/a	n/a	132	n/a	n/a	cross.bmp
+436.32254545449996	n/a	109080.6364	show_face	scrambled_face	immediate_repeat	132	1	18	s074.bmp
+436.8707272727	n/a	109217.6818	left_press	n/a	n/a	132	n/a	256	n/a
+437.1616363636	n/a	109290.4091	show_circle	n/a	n/a	132	n/a	0	circle.bmp
+438.8616363636	n/a	109715.4091	show_cross	n/a	n/a	133	n/a	n/a	cross.bmp
+439.4461818182	n/a	109861.5455	show_face	scrambled_face	delayed_repeat	133	12	19	s120.bmp
+440.0452727273	n/a	110011.3182	left_press	n/a	n/a	133	n/a	256	n/a
+440.44709090910004	n/a	110111.7727	show_circle	n/a	n/a	133	n/a	0	circle.bmp
+442.14709090910003	n/a	110536.7727	show_cross	n/a	n/a	134	n/a	n/a	cross.bmp
+442.68709090910005	n/a	110671.7727	show_face	famous_face	first_show	134	n/a	5	f113.bmp
+443.6734545455	n/a	110918.3636	show_circle	n/a	n/a	134	n/a	0	circle.bmp
+444.2407272727	n/a	111060.1818	right_press	n/a	n/a	134	n/a	4096	n/a
+445.3734545455	n/a	111343.3636	show_cross	n/a	n/a	135	n/a	n/a	cross.bmp
+445.8443636364	n/a	111461.0909	show_face	scrambled_face	first_show	135	n/a	17	s104.bmp
+446.7661818182	n/a	111691.5455	right_press	n/a	n/a	135	n/a	4096	n/a
+446.77527272730003	n/a	111693.8182	show_circle	n/a	n/a	135	n/a	0	circle.bmp
+448.4752727273	n/a	112118.8182	show_cross	n/a	n/a	136	n/a	n/a	cross.bmp
+449.0016363636	n/a	112250.4091	show_face	scrambled_face	delayed_repeat	136	11	19	s102.bmp
+449.68709090910005	n/a	112421.7727	left_press	n/a	n/a	136	n/a	256	n/a
+449.8316363636	n/a	112457.9091	show_circle	n/a	n/a	136	n/a	0	circle.bmp
+451.5316363636	n/a	112882.9091	show_cross	n/a	n/a	137	n/a	n/a	cross.bmp
+452.0425454545	n/a	113010.6364	show_face	unfamiliar_face	first_show	137	n/a	13	u047.bmp
+452.76345454550005	n/a	113190.8636	left_press	n/a	n/a	137	n/a	256	n/a
+452.908	n/a	113227.0	show_circle	n/a	n/a	137	n/a	0	circle.bmp
+454.608	n/a	113652.0	show_cross	n/a	n/a	138	n/a	n/a	cross.bmp
+455.2325454545	n/a	113808.1364	show_face	unfamiliar_face	immediate_repeat	138	1	14	u047.bmp
+455.70527272730004	n/a	113926.3182	left_press	n/a	n/a	138	n/a	256	n/a
+456.10072727269994	n/a	114025.1818	show_circle	n/a	n/a	138	n/a	0	circle.bmp
+457.8007272727	n/a	114450.1818	show_cross	n/a	n/a	139	n/a	n/a	cross.bmp
+458.32345454550006	n/a	114580.8636	show_face	famous_face	first_show	139	n/a	5	f141.bmp
+459.03890909089995	n/a	114759.7273	right_press	n/a	n/a	139	n/a	4096	n/a
+459.268	n/a	114817.0	show_circle	n/a	n/a	139	n/a	0	circle.bmp
+460.968	n/a	115242.0	show_cross	n/a	n/a	140	n/a	n/a	cross.bmp
+461.58072727269996	n/a	115395.1818	show_face	unfamiliar_face	delayed_repeat	140	11	15	u057.bmp
+462.46618181819997	n/a	115616.5455	show_circle	n/a	n/a	140	n/a	0	circle.bmp
+462.60890909089994	n/a	115652.2273	right_press	n/a	n/a	140	n/a	4096	n/a
+464.1661818182	n/a	116041.5455	show_cross	n/a	n/a	141	n/a	n/a	cross.bmp
+464.738	n/a	116184.5	show_face	famous_face	first_show	141	n/a	5	f135.bmp
+465.6743636364	n/a	116418.5909	show_circle	n/a	n/a	141	n/a	0	circle.bmp
+465.94709090910004	n/a	116486.7727	left_press	n/a	n/a	141	n/a	256	n/a
+467.3743636364	n/a	116843.5909	show_cross	n/a	n/a	142	n/a	n/a	cross.bmp
+467.8789090909	n/a	116969.7273	show_face	famous_face	immediate_repeat	142	1	6	f135.bmp
+468.4907272727	n/a	117122.6818	left_press	n/a	n/a	142	n/a	256	n/a
+468.7925454545	n/a	117198.1364	show_circle	n/a	n/a	142	n/a	0	circle.bmp
+470.4925454545	n/a	117623.1364	show_cross	n/a	n/a	143	n/a	n/a	cross.bmp
+471.1198181818	n/a	117779.9545	show_face	unfamiliar_face	first_show	143	n/a	13	u126.bmp
+471.9761818182	n/a	117994.0455	left_press	n/a	n/a	143	n/a	256	n/a
+472.1207272727	n/a	118030.1818	show_circle	n/a	n/a	143	n/a	0	circle.bmp
+473.82072727269997	n/a	118455.1818	show_cross	n/a	n/a	144	n/a	n/a	cross.bmp
+474.3098181818	n/a	118577.4545	show_face	unfamiliar_face	immediate_repeat	144	1	14	u126.bmp
+474.7716363636	n/a	118692.9091	left_press	n/a	n/a	144	n/a	256	n/a
+475.1698181818	n/a	118792.4545	show_circle	n/a	n/a	144	n/a	0	circle.bmp
+476.8698181818	n/a	119217.4545	show_cross	n/a	n/a	145	n/a	n/a	cross.bmp
+477.4670909091	n/a	119366.7727	show_face	famous_face	delayed_repeat	145	11	7	f113.bmp
+478.2998181818	n/a	119574.9545	show_circle	n/a	n/a	145	n/a	0	circle.bmp
+478.3625454545	n/a	119590.6364	left_press	n/a	n/a	145	n/a	256	n/a
+479.9998181818	n/a	119999.9545	show_cross	n/a	n/a	146	n/a	n/a	cross.bmp
+480.4907272727	n/a	120122.6818	show_face	scrambled_face	first_show	146	n/a	17	s070.bmp
+481.42709090910006	n/a	120356.7727	show_circle	n/a	n/a	146	n/a	0	circle.bmp
+481.90345454550004	n/a	120475.8636	right_press	n/a	n/a	146	n/a	4096	n/a
+483.12709090910005	n/a	120781.7727	show_cross	n/a	n/a	147	n/a	n/a	cross.bmp
+483.648	n/a	120912.0	show_face	scrambled_face	delayed_repeat	147	12	19	s104.bmp
+484.52072727269996	n/a	121130.1818	left_press	n/a	n/a	147	n/a	256	n/a
+484.6443636364	n/a	121161.0909	show_circle	n/a	n/a	147	n/a	0	circle.bmp
+486.3443636364	n/a	121586.0909	show_cross	n/a	n/a	148	n/a	n/a	cross.bmp
+486.87254545449997	n/a	121718.1364	show_face	scrambled_face	first_show	148	n/a	17	s130.bmp
+487.87163636360003	n/a	121967.9091	show_circle	n/a	n/a	148	n/a	0	circle.bmp
+489.5716363636	n/a	122392.9091	show_cross	n/a	n/a	149	n/a	n/a	cross.bmp

--- a/eeg_hed_small/task-FacePerception_events.json
+++ b/eeg_hed_small/task-FacePerception_events.json
@@ -10,23 +10,23 @@
       "show_face": "Display a face to mark end of pre-stimulus and start of blink-inhibition.",
       "show_circle": "Display a white circle to mark end of the stimulus and blink inhibition.",
       "show_cross": "Display only a white cross to mark start of trial and fixation.",
-      "left_press": "Experimental participant presses a key with left index finger.",
-      "right_press": "Experimental participant presses a key with right index finger.",
+      "left_press": "Experiment participant presses a key with left index finger.",
+      "right_press": "Experiment participant presses a key with right index finger.",
       "left_sym": "Pressing key with left index finger means a face with above average symmetry.",
       "right_sym": "Pressing key with right index finger means a face with above average symmetry.",
       "setup": "Mark start of experiment and document applicable metadata.",
-      "4352": "A trigger code indicating that the user did an additional key press after response."
+      "double_press": "Experiment participant presses both keys ."
     },
     "HED": {
       "show_face": "Sensory-event, Experimental-stimulus, (Def/Face-image, Onset), (Def/Blink-inhibition-task,Onset),(Def/Cross-only, Offset)",
       "show_circle": "Sensory-event, (Intended-effect, Cue), (Def/Circle-only, Onset), (Def/Face-image, Offset), (Def/Blink-inhibition-task, Offset), (Def/Fixation-task, Offset)",
-      "show_cross": "Sensory-event, (Intended-effect, Cue), (Def/Cross-only, Onset), (Def/Fixation, Onset), (Def/Trial, Onset), (Def/Circle-only, Offset)",
+      "show_cross": "Sensory-event, (Intended-effect, Cue), (Def/Cross-only, Onset), (Def/Fixation-task, Onset),  (Def/Circle-only, Offset)",
       "left_press": "Agent-action, Participant-response, Def/Press-left-finger",
       "right_press": "Agent-action, Participant-response, Def/Press-right-finger",
       "left_sym": "Experiment-structure, (Def/Left-sym-cond, Onset)",
       "right_sym": "Experiment-structure, (Def/Right-sym-cond, Onset)",
       "setup": "Experiment-structure, (Def/Initialize-recording, Onset)",
-      "4352": "Agent-action, Indeterminate, (Press, Keyboard-key)"
+      "double_press": "Agent-action, Indeterminate-action, (Press, Keyboard-key)"
     }
   },
   "face_type": {
@@ -55,52 +55,61 @@
       "delayed_repeat": "Def/Delayed-repeat-cond"
     }
   },
+  "trial": {
+    "Description": "Indicates which trial this event belongs to.",
+    "HED": "Experimental-trial/#"
+  },
+  "trial_lag": {
+    "Description": "How many trials before this trial the image was previously presented.",
+    "HED": "(Parameter-label/Trial-lag, Item-interval/#)"
+  },
   "stim_file": {
     "Description": "Path of the stimulus file in the stimuli directory.",
-    "HED": "(Image, Path-name/#)"
+    "HED": "(Image, Pathname/#)"
   },
   "hed_def_sensory": {
     "Description": "Metadata dictionary for gathering sensory definitions",
     "HED": {
-      "cross_only_def": "(Definition/Cross-only, (Visual, (Foreground-view, (White, Cross), (Center-of, Screen)), (Background-view, Black), Description/A white fixation cross on a black background in the center of the screen.))",
-      "face_image_def": "(Definition/Face-image, (Visual, (Foreground-view, ((Image, Face, Hair), Color/Grayscale), ((White, Cross), (Center-of, Screen))), (Background-view, Black), Description/A happy or neutral face in frontal or three-quarters frontal pose with long hair cropped presented as an achromatic foreground image on a black background with a white fixation cross superposed.))",
-      "circle_only_def": "(Definition/Circle-only, (Visual, (Foreground-view, ((White, Circle), (Center-of, Screen))), (Background-view, Black), Description/A white circle on a black background in the center of the screen.))"
+      "cross_only_def": "(Definition/Cross-only, (Visual-presentation, (Foreground-view, (White, Cross), (Center-of, Computer-screen)), (Background-view, Black), Description/A white fixation cross on a black background in the center of the screen.))",
+      "face_image_def": "(Definition/Face-image, (Visual-presentation, (Foreground-view, ((Image, Face, Hair), Color/Grayscale), ((White, Cross), (Center-of, Computer-screen))), (Background-view, Black), Description/A happy or neutral face in frontal or three-quarters frontal pose with long hair cropped presented as an achromatic foreground image on a black background with a white fixation cross superposed.))",
+      "circle_only_def": "(Definition/Circle-only, (Visual-presentation, (Foreground-view, ((White, Circle), (Center-of, Computer-screen))), (Background-view, Black), Description/A white circle on a black background in the center of the screen.))"
     }
   },
   "hed_def_actions": {
     "Description": "Metadata dictionary for gathering participant action definitions",
     "HED": {
-      "press_left_finger_def": "(Definition/Press-left-finger, (Experimental-participant, (Index-finger, Left-side), (Press, Keyboard-key), Description/The participant presses a key with the left index finger to indicate a face symmetry judgment.))",
-      "press_right_finger_def": "(Definition/Press-right-finger, (Experimental-participant, (Index-finger, Right-side), (Press, Keyboard-key), Description/The participant presses a key with the right index finger to indicate a face symmetry evaluation.))"
+      "press_left_finger_def": "(Definition/Press-left-finger, ((Index-finger, (Left-side-of, Experiment-participant)), (Press, Keyboard-key), Description/The participant presses a key with the left index finger to indicate a face symmetry judgment.))",
+      "press_right_finger_def": "(Definition/Press-right-finger, ((Index-finger, (Right-side-of, Experiment-participant)), (Press, Keyboard-key), Description/The participant presses a key with the right index finger to indicate a face symmetry evaluation.))"
     }
   },
   "hed_def_conds": {
     "Description": "Metadata dictionary for gathering experimental condition definitions",
     "HED": {
-      "famous_face_cond_def": "(Definition/Famous-face-cond, (Experimental-condition, Label/Face-type, (Image, (Face, Famous)), Description/A face that should be recognized by the participants))",
-      "unfamiliar_face_cond_def": "(Definition/Unfamiliar-face-cond, (Experimental-condition, Label/Face-type, (Image, (Face, Unfamiliar)), Description/A face that should not be recognized by the participants.))",
-      "scrambled_face_cond_def": "(Definition/Scrambled-face-cond, (Experimental-condition, Label/Face-type, (Image, (Face, Disordered)), Description/A scrambled face image generated by taking face 2D FFT.))",
-      "first_show_cond_def": "(Definition/First-show-cond, (Experimental-condition, Label/Repetition-type, (First-item, Repetition/1), Description/Factor level indicating the first display of this face.))",
-      "immediate_repeat_cond_def": "(Definition/Immediate-repeat-cond, (Experimental-condition, Label/Repetition-type, (Next-item, Repetition/2), Description/Factor level indicating this face was the same as previous one.))",
-      "delayed_repeat_cond_def": "(Definition/Delayed-repeat-cond, (Experimental-condition, Label/Repetition-type, (Later-item, Repetition/2), Description/Factor level indicating face was seen 5 to 15 trials ago.))",
-      "left_sym_cond_def": "(Definition/Left-sym-cond, (Experimental-condition, Label/Key-assignment, ((Button, Left-side), Symmetric), ((Button, Right-side), Asymmetric), Description/Pressing a key with the left index finger indicates a face with above average symmetry.))",
-      "right_sym_cond_def": "(Definition/Right-sym-cond, (Experimental-condition, Label/Key-assignment, ((Button, Right-side), (Behavioral-evidence, Symmetric)), ((Button, Left-side), (Behavioral-evidence, Asymmetric)), Description/Right finger key press means above average symmetry.))"
+      "famous_face_cond_def": "(Definition/Famous-face-cond, (Condition-variable/Face-type, (Image, (Face, Famous)), Description/A face that should be recognized by the participants))",
+      "unfamiliar_face_cond_def": "(Definition/Unfamiliar-face-cond, (Condition-variable/Face-type, (Image, (Face, Unfamiliar)), Description/A face that should not be recognized by the participants.))",
+      "scrambled_face_cond_def": "(Definition/Scrambled-face-cond, (Condition-variable/Face-type, (Image, (Face, Disordered)), Description/A scrambled face image generated by taking face 2D FFT.))",
+      "first_show_cond_def": "(Definition/First-show-cond, ((Condition-variable/Repetition-type, (Item-count/1, Face), Item-interval/0), Description/Factor level indicating the first display of this face.))",
+      "immediate_repeat_cond_def": "(Definition/Immediate-repeat-cond, ((Condition-variable/Repetition-type, (Item-count/2, Face), Item-interval/1), Description/Factor level indicating this face was the same as previous one.))",
+      "delayed_repeat_cond_def": "(Definition/Delayed-repeat-cond, (Condition-variable/Repetition-type, (Item-count/2, Face), (Item-interval, (Greater-than-or-equal-to, Item-interval/5)), Description/Factor level indicating face was seen 5 to 15 trials ago.))",
+      "left_sym_cond_def": "(Definition/Left-sym-cond, (Condition-variable/Key-assignment, ((Index-finger, (Left-side-of, Experiment-participant)), (Behavioral-evidence, Symmetrical)), ((Index-finger, (Right-side-of, Experiment-participant)), (Behavioral-evidence, Asymmetrical)), Description/Pressing a key with the left index finger indicates a face with above average symmetry.))",
+      "right_sym_cond_def": "(Definition/Right-sym-cond, (Condition-variable/Key-assignment, ((Index-finger, (Right-side-of, Experiment-participant)), (Behavioral-evidence, Symmetrical)), ((Index-finger, (Left-side-of, Experiment-participant)), (Behavioral-evidence, Asymmetrical)), Description/Right finger key press means above average symmetry.))"
     }
   },
   "hed_def_tasks": {
     "Description": "Metadata dictionary for gathering task definitions",
     "HED": {
-      "face_symmetry_evaluation_task_def": "(Definition/Face-symmetry-evaluation-task, (Task, Experimental-participant, (Look, Face), (Discriminate, (Face, Symmetric)), (Press, Keyboard-key), Description/Evaluate degree of image symmetry and respond with key press evaluation.))",
-      "blink_inhibition_task_def": "(Definition/Blink-inhibition-task, (Task, Experimental-participant, Inhibit-blinks, Description/Do not blink while the face image is displayed.))",
-      "fixation_task_def": "(Definition/Fixation-task, (Task, Experimental-participant, (Fixate, Cross), Description/Fixate on the cross at the screen center.))",
-      "face_novelty_detection_task_def": "(Definition/Face-novelty-detection-task, ((Task, Implicit), Experimental-participant, (Look, Face), (Detect, (Face, Novel)), Description/Recognize presentations of previously unseen face images-implicit task.))"
-    },
-    "hed_def_setup": {
-      "Description": "Metadata dictionary for gathering setup definitions",
-      "HED": {
-        "initialize_recording_def": "(Definition/Initialize-recording, (Description/Stuff and setup stuff.))"
-      }
+      "face_symmetry_evaluation_task_def": "(Definition/Face-symmetry-evaluation-task, (Task, Experiment-participant, (See, Face), (Discriminate, (Face, Symmetrical)), (Press, Keyboard-key), Description/Evaluate degree of image symmetry and respond with key press evaluation.))",
+      "blink_inhibition_task_def": "(Definition/Blink-inhibition-task, (Task, Experiment-participant, Inhibit-blinks, Description/Do not blink while the face image is displayed.))",
+      "fixation_task_def": "(Definition/Fixation-task, (Task, Experiment-participant, (Fixate, Cross), Description/Fixate on the cross at the screen center.))",
+      "face_novelty_detection_task_def": "(Definition/Face-novelty-detection-task, ((Task, Implicit), Experiment-participant, (See, Face), (Detect, (Face, Novel)), Description/Recognize presentations of previously unseen face images-implicit task.))"
     }
+  },
+  "hed_def_setup": {
+     "Description": "Metadata dictionary for gathering setup definitions",
+     "HED": {
+        "initialize_recording_def": "(Definition/Initialize-recording, (Recording))"
+      }
+
   },
   "trigger": {
     "Description": "Numerical event marker",
@@ -115,8 +124,9 @@
       "x17": "Initial presentation of scrambled face",
       "x18": "Immediate repeated  presentation of scrambled face",
       "x19": "Delayed repeated  presentation of scrambled face",
-      "x256": "Left button press",
-      "x4096": "Right button press"
+      "x256": "Left finger key press",
+      "x4096": "Right finger key press",
+	  "x4352": "Left and right finger key presses"
     }
   }
 }


### PR DESCRIPTION
This example is now HED-3G compliant.  Bids validator version >= 1.8.2 is required.