### PR TITLE
[FIX] update pet datasets to 1.6 bids version

### DIFF
--- a/pet001/dataset_description.json
+++ b/pet001/dataset_description.json
@@ -1,4 +1,4 @@
-{"BIDSVersion":"1.5.0",
+{"BIDSVersion":"1.6.0",
     "License":"CCO license",
     "Name":"[11C]CIMBI36 PET dataset of a pig",
     "Authors":["Melanie Ganz-Benjaminsen","Martin Noergaard","Hanne Demant Hansen"],

--- a/pet003/dataset_description.json
+++ b/pet003/dataset_description.json
@@ -1,4 +1,4 @@
-{"BIDSVersion":"1.5.0",
+{"BIDSVersion":"1.6.0",
     "License":"CCO license",
     "Name":"[11C]DASB data set",
     "Authors":["Martin Norgaard","Christine Delorenzo","Ramin Parsey"],

--- a/pet004/dataset_description.json
+++ b/pet004/dataset_description.json
@@ -1,4 +1,4 @@
-{"BIDSVersion":"1.5.0",
+{"BIDSVersion":"1.6.0",
     "License":"CCO license",
     "Name":"[11C]CIMBI36 PET dataset of a pig, with ketanserin intervention",
     "Authors":["Melanie Ganz-Benjaminsen","Martin Noergaard","Hanne Demant Hansen"],

--- a/pet005/dataset_description.json
+++ b/pet005/dataset_description.json
@@ -1,4 +1,4 @@
-{"BIDSVersion":"1.5.0",
+{"BIDSVersion":"1.6.0",
     "License":"CCO license",
     "Name":"[11C]AZ10419369 PET dataset of a single person",
     "Authors":["Hanne Demant Hansen","Melanie Ganz-Benjaminsen","Martin Noergaard"],


### PR DESCRIPTION
closes #299 

I have checked ALS, qMRI and PET datasets and only the PET ones needed a BIDS version bump to be coherent with when the specification supported that data type.