### PR TITLE
Move some examples to use BIDS URIs

### DIFF
--- a/.github/workflows/validate_datasets.yml
+++ b/.github/workflows/validate_datasets.yml
@@ -48,7 +48,7 @@ jobs:
         pushd ..
         # Get npm 7+
         npm install -g npm@^7
-        git clone --depth 1 https://github.com/bids-standard/bids-validator
+        git clone --depth 1 https://github.com/sappelhoff/bids-validator/ --branch intendedfor/bidsuri
         cd bids-validator
         # Generate the full development node_modules
         npm clean-install

--- a/.github/workflows/validate_datasets.yml
+++ b/.github/workflows/validate_datasets.yml
@@ -48,7 +48,7 @@ jobs:
         pushd ..
         # Get npm 7+
         npm install -g npm@^7
-        git clone --depth 1 https://github.com/sappelhoff/bids-validator/ --branch intendedfor/bidsuri
+        git clone --depth 1 https://github.com/bids-standard/bids-validator
         cd bids-validator
         # Generate the full development node_modules
         npm clean-install

--- a/7t_trt/dataset_description.json
+++ b/7t_trt/dataset_description.json
@@ -1,4 +1,4 @@
 {
-    "BIDSVersion": "1.0.0rc3",
+    "BIDSVersion": "1.7",
     "Name": "7t_trt"
 }

--- a/7t_trt/dataset_description.json
+++ b/7t_trt/dataset_description.json
@@ -1,4 +1,4 @@
 {
-    "BIDSVersion": "1.7",
+    "BIDSVersion": "1.8.0",
     "Name": "7t_trt"
 }

--- a/7t_trt/sub-01/ses-1/fmap/sub-01_ses-1_run-1_phasediff.json
+++ b/7t_trt/sub-01/ses-1/fmap/sub-01_ses-1_run-1_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-1/func/sub-01_ses-1_task-rest_acq-fullbrain_run-1_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-01/ses-1/func/sub-01_ses-1_task-rest_acq-fullbrain_run-1_bold.nii.gz"}

--- a/7t_trt/sub-01/ses-1/fmap/sub-01_ses-1_run-2_phasediff.json
+++ b/7t_trt/sub-01/ses-1/fmap/sub-01_ses-1_run-2_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-1/func/sub-01_ses-1_task-rest_acq-fullbrain_run-2_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-01/ses-1/func/sub-01_ses-1_task-rest_acq-fullbrain_run-2_bold.nii.gz"}

--- a/7t_trt/sub-01/ses-2/fmap/sub-01_ses-2_run-1_phasediff.json
+++ b/7t_trt/sub-01/ses-2/fmap/sub-01_ses-2_run-1_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-2/func/sub-01_ses-2_task-rest_acq-fullbrain_run-1_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-01/ses-2/func/sub-01_ses-2_task-rest_acq-fullbrain_run-1_bold.nii.gz"}

--- a/7t_trt/sub-01/ses-2/fmap/sub-01_ses-2_run-2_phasediff.json
+++ b/7t_trt/sub-01/ses-2/fmap/sub-01_ses-2_run-2_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-2/func/sub-01_ses-2_task-rest_acq-fullbrain_run-2_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-01/ses-2/func/sub-01_ses-2_task-rest_acq-fullbrain_run-2_bold.nii.gz"}

--- a/7t_trt/sub-02/ses-1/fmap/sub-02_ses-1_run-1_phasediff.json
+++ b/7t_trt/sub-02/ses-1/fmap/sub-02_ses-1_run-1_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-1/func/sub-02_ses-1_task-rest_acq-fullbrain_run-1_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-02/ses-1/func/sub-02_ses-1_task-rest_acq-fullbrain_run-1_bold.nii.gz"}

--- a/7t_trt/sub-02/ses-1/fmap/sub-02_ses-1_run-2_phasediff.json
+++ b/7t_trt/sub-02/ses-1/fmap/sub-02_ses-1_run-2_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-1/func/sub-02_ses-1_task-rest_acq-fullbrain_run-2_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-02/ses-1/func/sub-02_ses-1_task-rest_acq-fullbrain_run-2_bold.nii.gz"}

--- a/7t_trt/sub-02/ses-2/fmap/sub-02_ses-2_run-1_phasediff.json
+++ b/7t_trt/sub-02/ses-2/fmap/sub-02_ses-2_run-1_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-2/func/sub-02_ses-2_task-rest_acq-fullbrain_run-1_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-02/ses-2/func/sub-02_ses-2_task-rest_acq-fullbrain_run-1_bold.nii.gz"}

--- a/7t_trt/sub-02/ses-2/fmap/sub-02_ses-2_run-2_phasediff.json
+++ b/7t_trt/sub-02/ses-2/fmap/sub-02_ses-2_run-2_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-2/func/sub-02_ses-2_task-rest_acq-fullbrain_run-2_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-02/ses-2/func/sub-02_ses-2_task-rest_acq-fullbrain_run-2_bold.nii.gz"}

--- a/7t_trt/sub-03/ses-1/fmap/sub-03_ses-1_run-1_phasediff.json
+++ b/7t_trt/sub-03/ses-1/fmap/sub-03_ses-1_run-1_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-1/func/sub-03_ses-1_task-rest_acq-fullbrain_run-1_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-03/ses-1/func/sub-03_ses-1_task-rest_acq-fullbrain_run-1_bold.nii.gz"}

--- a/7t_trt/sub-03/ses-1/fmap/sub-03_ses-1_run-2_phasediff.json
+++ b/7t_trt/sub-03/ses-1/fmap/sub-03_ses-1_run-2_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-1/func/sub-03_ses-1_task-rest_acq-fullbrain_run-2_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-03/ses-1/func/sub-03_ses-1_task-rest_acq-fullbrain_run-2_bold.nii.gz"}

--- a/7t_trt/sub-03/ses-2/fmap/sub-03_ses-2_run-1_phasediff.json
+++ b/7t_trt/sub-03/ses-2/fmap/sub-03_ses-2_run-1_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-2/func/sub-03_ses-2_task-rest_acq-fullbrain_run-1_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-03/ses-2/func/sub-03_ses-2_task-rest_acq-fullbrain_run-1_bold.nii.gz"}

--- a/7t_trt/sub-03/ses-2/fmap/sub-03_ses-2_run-2_phasediff.json
+++ b/7t_trt/sub-03/ses-2/fmap/sub-03_ses-2_run-2_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-2/func/sub-03_ses-2_task-rest_acq-fullbrain_run-2_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-03/ses-2/func/sub-03_ses-2_task-rest_acq-fullbrain_run-2_bold.nii.gz"}

--- a/7t_trt/sub-04/ses-1/fmap/sub-04_ses-1_run-1_phasediff.json
+++ b/7t_trt/sub-04/ses-1/fmap/sub-04_ses-1_run-1_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-1/func/sub-04_ses-1_task-rest_acq-fullbrain_run-1_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-04/ses-1/func/sub-04_ses-1_task-rest_acq-fullbrain_run-1_bold.nii.gz"}

--- a/7t_trt/sub-04/ses-1/fmap/sub-04_ses-1_run-2_phasediff.json
+++ b/7t_trt/sub-04/ses-1/fmap/sub-04_ses-1_run-2_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-1/func/sub-04_ses-1_task-rest_acq-fullbrain_run-2_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-04/ses-1/func/sub-04_ses-1_task-rest_acq-fullbrain_run-2_bold.nii.gz"}

--- a/7t_trt/sub-04/ses-2/fmap/sub-04_ses-2_run-1_phasediff.json
+++ b/7t_trt/sub-04/ses-2/fmap/sub-04_ses-2_run-1_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-2/func/sub-04_ses-2_task-rest_acq-fullbrain_run-1_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-04/ses-2/func/sub-04_ses-2_task-rest_acq-fullbrain_run-1_bold.nii.gz"}

--- a/7t_trt/sub-04/ses-2/fmap/sub-04_ses-2_run-2_phasediff.json
+++ b/7t_trt/sub-04/ses-2/fmap/sub-04_ses-2_run-2_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-2/func/sub-04_ses-2_task-rest_acq-fullbrain_run-2_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-04/ses-2/func/sub-04_ses-2_task-rest_acq-fullbrain_run-2_bold.nii.gz"}

--- a/7t_trt/sub-05/ses-1/fmap/sub-05_ses-1_run-1_phasediff.json
+++ b/7t_trt/sub-05/ses-1/fmap/sub-05_ses-1_run-1_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-1/func/sub-05_ses-1_task-rest_acq-fullbrain_run-1_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-05/ses-1/func/sub-05_ses-1_task-rest_acq-fullbrain_run-1_bold.nii.gz"}

--- a/7t_trt/sub-05/ses-1/fmap/sub-05_ses-1_run-2_phasediff.json
+++ b/7t_trt/sub-05/ses-1/fmap/sub-05_ses-1_run-2_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-1/func/sub-05_ses-1_task-rest_acq-fullbrain_run-2_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-05/ses-1/func/sub-05_ses-1_task-rest_acq-fullbrain_run-2_bold.nii.gz"}

--- a/7t_trt/sub-05/ses-2/fmap/sub-05_ses-2_run-1_phasediff.json
+++ b/7t_trt/sub-05/ses-2/fmap/sub-05_ses-2_run-1_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-2/func/sub-05_ses-2_task-rest_acq-fullbrain_run-1_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-05/ses-2/func/sub-05_ses-2_task-rest_acq-fullbrain_run-1_bold.nii.gz"}

--- a/7t_trt/sub-05/ses-2/fmap/sub-05_ses-2_run-2_phasediff.json
+++ b/7t_trt/sub-05/ses-2/fmap/sub-05_ses-2_run-2_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-2/func/sub-05_ses-2_task-rest_acq-fullbrain_run-2_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-05/ses-2/func/sub-05_ses-2_task-rest_acq-fullbrain_run-2_bold.nii.gz"}

--- a/7t_trt/sub-06/ses-1/fmap/sub-06_ses-1_run-1_phasediff.json
+++ b/7t_trt/sub-06/ses-1/fmap/sub-06_ses-1_run-1_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-1/func/sub-06_ses-1_task-rest_acq-fullbrain_run-1_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-06/ses-1/func/sub-06_ses-1_task-rest_acq-fullbrain_run-1_bold.nii.gz"}

--- a/7t_trt/sub-06/ses-1/fmap/sub-06_ses-1_run-2_phasediff.json
+++ b/7t_trt/sub-06/ses-1/fmap/sub-06_ses-1_run-2_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-1/func/sub-06_ses-1_task-rest_acq-fullbrain_run-2_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-06/ses-1/func/sub-06_ses-1_task-rest_acq-fullbrain_run-2_bold.nii.gz"}

--- a/7t_trt/sub-06/ses-2/fmap/sub-06_ses-2_run-1_phasediff.json
+++ b/7t_trt/sub-06/ses-2/fmap/sub-06_ses-2_run-1_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-2/func/sub-06_ses-2_task-rest_acq-fullbrain_run-1_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-06/ses-2/func/sub-06_ses-2_task-rest_acq-fullbrain_run-1_bold.nii.gz"}

--- a/7t_trt/sub-06/ses-2/fmap/sub-06_ses-2_run-2_phasediff.json
+++ b/7t_trt/sub-06/ses-2/fmap/sub-06_ses-2_run-2_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-2/func/sub-06_ses-2_task-rest_acq-fullbrain_run-2_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-06/ses-2/func/sub-06_ses-2_task-rest_acq-fullbrain_run-2_bold.nii.gz"}

--- a/7t_trt/sub-07/ses-1/fmap/sub-07_ses-1_run-1_phasediff.json
+++ b/7t_trt/sub-07/ses-1/fmap/sub-07_ses-1_run-1_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-1/func/sub-07_ses-1_task-rest_acq-fullbrain_run-1_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-07/ses-1/func/sub-07_ses-1_task-rest_acq-fullbrain_run-1_bold.nii.gz"}

--- a/7t_trt/sub-07/ses-1/fmap/sub-07_ses-1_run-2_phasediff.json
+++ b/7t_trt/sub-07/ses-1/fmap/sub-07_ses-1_run-2_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-1/func/sub-07_ses-1_task-rest_acq-fullbrain_run-2_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-07/ses-1/func/sub-07_ses-1_task-rest_acq-fullbrain_run-2_bold.nii.gz"}

--- a/7t_trt/sub-07/ses-2/fmap/sub-07_ses-2_run-1_phasediff.json
+++ b/7t_trt/sub-07/ses-2/fmap/sub-07_ses-2_run-1_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-2/func/sub-07_ses-2_task-rest_acq-fullbrain_run-1_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-07/ses-2/func/sub-07_ses-2_task-rest_acq-fullbrain_run-1_bold.nii.gz"}

--- a/7t_trt/sub-07/ses-2/fmap/sub-07_ses-2_run-2_phasediff.json
+++ b/7t_trt/sub-07/ses-2/fmap/sub-07_ses-2_run-2_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-2/func/sub-07_ses-2_task-rest_acq-fullbrain_run-2_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-07/ses-2/func/sub-07_ses-2_task-rest_acq-fullbrain_run-2_bold.nii.gz"}

--- a/7t_trt/sub-08/ses-1/fmap/sub-08_ses-1_run-1_phasediff.json
+++ b/7t_trt/sub-08/ses-1/fmap/sub-08_ses-1_run-1_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-1/func/sub-08_ses-1_task-rest_acq-fullbrain_run-1_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-08/ses-1/func/sub-08_ses-1_task-rest_acq-fullbrain_run-1_bold.nii.gz"}

--- a/7t_trt/sub-08/ses-1/fmap/sub-08_ses-1_run-2_phasediff.json
+++ b/7t_trt/sub-08/ses-1/fmap/sub-08_ses-1_run-2_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-1/func/sub-08_ses-1_task-rest_acq-fullbrain_run-2_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-08/ses-1/func/sub-08_ses-1_task-rest_acq-fullbrain_run-2_bold.nii.gz"}

--- a/7t_trt/sub-08/ses-2/fmap/sub-08_ses-2_run-1_phasediff.json
+++ b/7t_trt/sub-08/ses-2/fmap/sub-08_ses-2_run-1_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-2/func/sub-08_ses-2_task-rest_acq-fullbrain_run-1_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-08/ses-2/func/sub-08_ses-2_task-rest_acq-fullbrain_run-1_bold.nii.gz"}

--- a/7t_trt/sub-08/ses-2/fmap/sub-08_ses-2_run-2_phasediff.json
+++ b/7t_trt/sub-08/ses-2/fmap/sub-08_ses-2_run-2_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-2/func/sub-08_ses-2_task-rest_acq-fullbrain_run-2_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-08/ses-2/func/sub-08_ses-2_task-rest_acq-fullbrain_run-2_bold.nii.gz"}

--- a/7t_trt/sub-09/ses-1/fmap/sub-09_ses-1_run-1_phasediff.json
+++ b/7t_trt/sub-09/ses-1/fmap/sub-09_ses-1_run-1_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-1/func/sub-09_ses-1_task-rest_acq-fullbrain_run-1_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-09/ses-1/func/sub-09_ses-1_task-rest_acq-fullbrain_run-1_bold.nii.gz"}

--- a/7t_trt/sub-09/ses-1/fmap/sub-09_ses-1_run-2_phasediff.json
+++ b/7t_trt/sub-09/ses-1/fmap/sub-09_ses-1_run-2_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-1/func/sub-09_ses-1_task-rest_acq-fullbrain_run-2_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-09/ses-1/func/sub-09_ses-1_task-rest_acq-fullbrain_run-2_bold.nii.gz"}

--- a/7t_trt/sub-09/ses-2/fmap/sub-09_ses-2_run-1_phasediff.json
+++ b/7t_trt/sub-09/ses-2/fmap/sub-09_ses-2_run-1_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-2/func/sub-09_ses-2_task-rest_acq-fullbrain_run-1_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-09/ses-2/func/sub-09_ses-2_task-rest_acq-fullbrain_run-1_bold.nii.gz"}

--- a/7t_trt/sub-09/ses-2/fmap/sub-09_ses-2_run-2_phasediff.json
+++ b/7t_trt/sub-09/ses-2/fmap/sub-09_ses-2_run-2_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-2/func/sub-09_ses-2_task-rest_acq-fullbrain_run-2_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-09/ses-2/func/sub-09_ses-2_task-rest_acq-fullbrain_run-2_bold.nii.gz"}

--- a/7t_trt/sub-10/ses-1/fmap/sub-10_ses-1_run-1_phasediff.json
+++ b/7t_trt/sub-10/ses-1/fmap/sub-10_ses-1_run-1_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-1/func/sub-10_ses-1_task-rest_acq-fullbrain_run-1_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-10/ses-1/func/sub-10_ses-1_task-rest_acq-fullbrain_run-1_bold.nii.gz"}

--- a/7t_trt/sub-10/ses-1/fmap/sub-10_ses-1_run-2_phasediff.json
+++ b/7t_trt/sub-10/ses-1/fmap/sub-10_ses-1_run-2_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-1/func/sub-10_ses-1_task-rest_acq-fullbrain_run-2_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-10/ses-1/func/sub-10_ses-1_task-rest_acq-fullbrain_run-2_bold.nii.gz"}

--- a/7t_trt/sub-10/ses-2/fmap/sub-10_ses-2_run-1_phasediff.json
+++ b/7t_trt/sub-10/ses-2/fmap/sub-10_ses-2_run-1_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-2/func/sub-10_ses-2_task-rest_acq-fullbrain_run-1_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-10/ses-2/func/sub-10_ses-2_task-rest_acq-fullbrain_run-1_bold.nii.gz"}

--- a/7t_trt/sub-10/ses-2/fmap/sub-10_ses-2_run-2_phasediff.json
+++ b/7t_trt/sub-10/ses-2/fmap/sub-10_ses-2_run-2_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-2/func/sub-10_ses-2_task-rest_acq-fullbrain_run-2_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-10/ses-2/func/sub-10_ses-2_task-rest_acq-fullbrain_run-2_bold.nii.gz"}

--- a/7t_trt/sub-11/ses-1/fmap/sub-11_ses-1_run-1_phasediff.json
+++ b/7t_trt/sub-11/ses-1/fmap/sub-11_ses-1_run-1_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-1/func/sub-11_ses-1_task-rest_acq-fullbrain_run-1_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-11/ses-1/func/sub-11_ses-1_task-rest_acq-fullbrain_run-1_bold.nii.gz"}

--- a/7t_trt/sub-11/ses-1/fmap/sub-11_ses-1_run-2_phasediff.json
+++ b/7t_trt/sub-11/ses-1/fmap/sub-11_ses-1_run-2_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-1/func/sub-11_ses-1_task-rest_acq-fullbrain_run-2_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-11/ses-1/func/sub-11_ses-1_task-rest_acq-fullbrain_run-2_bold.nii.gz"}

--- a/7t_trt/sub-11/ses-2/fmap/sub-11_ses-2_run-1_phasediff.json
+++ b/7t_trt/sub-11/ses-2/fmap/sub-11_ses-2_run-1_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-2/func/sub-11_ses-2_task-rest_acq-fullbrain_run-1_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-11/ses-2/func/sub-11_ses-2_task-rest_acq-fullbrain_run-1_bold.nii.gz"}

--- a/7t_trt/sub-11/ses-2/fmap/sub-11_ses-2_run-2_phasediff.json
+++ b/7t_trt/sub-11/ses-2/fmap/sub-11_ses-2_run-2_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-2/func/sub-11_ses-2_task-rest_acq-fullbrain_run-2_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-11/ses-2/func/sub-11_ses-2_task-rest_acq-fullbrain_run-2_bold.nii.gz"}

--- a/7t_trt/sub-12/ses-1/fmap/sub-12_ses-1_run-1_phasediff.json
+++ b/7t_trt/sub-12/ses-1/fmap/sub-12_ses-1_run-1_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-1/func/sub-12_ses-1_task-rest_acq-fullbrain_run-1_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-12/ses-1/func/sub-12_ses-1_task-rest_acq-fullbrain_run-1_bold.nii.gz"}

--- a/7t_trt/sub-12/ses-1/fmap/sub-12_ses-1_run-2_phasediff.json
+++ b/7t_trt/sub-12/ses-1/fmap/sub-12_ses-1_run-2_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-1/func/sub-12_ses-1_task-rest_acq-fullbrain_run-2_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-12/ses-1/func/sub-12_ses-1_task-rest_acq-fullbrain_run-2_bold.nii.gz"}

--- a/7t_trt/sub-12/ses-2/fmap/sub-12_ses-2_run-1_phasediff.json
+++ b/7t_trt/sub-12/ses-2/fmap/sub-12_ses-2_run-1_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-2/func/sub-12_ses-2_task-rest_acq-fullbrain_run-1_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-12/ses-2/func/sub-12_ses-2_task-rest_acq-fullbrain_run-1_bold.nii.gz"}

--- a/7t_trt/sub-12/ses-2/fmap/sub-12_ses-2_run-2_phasediff.json
+++ b/7t_trt/sub-12/ses-2/fmap/sub-12_ses-2_run-2_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-2/func/sub-12_ses-2_task-rest_acq-fullbrain_run-2_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-12/ses-2/func/sub-12_ses-2_task-rest_acq-fullbrain_run-2_bold.nii.gz"}

--- a/7t_trt/sub-13/ses-1/fmap/sub-13_ses-1_run-1_phasediff.json
+++ b/7t_trt/sub-13/ses-1/fmap/sub-13_ses-1_run-1_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-1/func/sub-13_ses-1_task-rest_acq-fullbrain_run-1_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-13/ses-1/func/sub-13_ses-1_task-rest_acq-fullbrain_run-1_bold.nii.gz"}

--- a/7t_trt/sub-13/ses-1/fmap/sub-13_ses-1_run-2_phasediff.json
+++ b/7t_trt/sub-13/ses-1/fmap/sub-13_ses-1_run-2_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-1/func/sub-13_ses-1_task-rest_acq-fullbrain_run-2_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-13/ses-1/func/sub-13_ses-1_task-rest_acq-fullbrain_run-2_bold.nii.gz"}

--- a/7t_trt/sub-13/ses-2/fmap/sub-13_ses-2_run-1_phasediff.json
+++ b/7t_trt/sub-13/ses-2/fmap/sub-13_ses-2_run-1_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-2/func/sub-13_ses-2_task-rest_acq-fullbrain_run-1_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-13/ses-2/func/sub-13_ses-2_task-rest_acq-fullbrain_run-1_bold.nii.gz"}

--- a/7t_trt/sub-13/ses-2/fmap/sub-13_ses-2_run-2_phasediff.json
+++ b/7t_trt/sub-13/ses-2/fmap/sub-13_ses-2_run-2_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-2/func/sub-13_ses-2_task-rest_acq-fullbrain_run-2_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-13/ses-2/func/sub-13_ses-2_task-rest_acq-fullbrain_run-2_bold.nii.gz"}

--- a/7t_trt/sub-14/ses-1/fmap/sub-14_ses-1_run-1_phasediff.json
+++ b/7t_trt/sub-14/ses-1/fmap/sub-14_ses-1_run-1_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-1/func/sub-14_ses-1_task-rest_acq-fullbrain_run-1_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-14/ses-1/func/sub-14_ses-1_task-rest_acq-fullbrain_run-1_bold.nii.gz"}

--- a/7t_trt/sub-14/ses-1/fmap/sub-14_ses-1_run-2_phasediff.json
+++ b/7t_trt/sub-14/ses-1/fmap/sub-14_ses-1_run-2_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-1/func/sub-14_ses-1_task-rest_acq-fullbrain_run-2_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-14/ses-1/func/sub-14_ses-1_task-rest_acq-fullbrain_run-2_bold.nii.gz"}

--- a/7t_trt/sub-14/ses-2/fmap/sub-14_ses-2_run-1_phasediff.json
+++ b/7t_trt/sub-14/ses-2/fmap/sub-14_ses-2_run-1_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-2/func/sub-14_ses-2_task-rest_acq-fullbrain_run-1_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-14/ses-2/func/sub-14_ses-2_task-rest_acq-fullbrain_run-1_bold.nii.gz"}

--- a/7t_trt/sub-14/ses-2/fmap/sub-14_ses-2_run-2_phasediff.json
+++ b/7t_trt/sub-14/ses-2/fmap/sub-14_ses-2_run-2_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-2/func/sub-14_ses-2_task-rest_acq-fullbrain_run-2_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-14/ses-2/func/sub-14_ses-2_task-rest_acq-fullbrain_run-2_bold.nii.gz"}

--- a/7t_trt/sub-15/ses-1/fmap/sub-15_ses-1_run-1_phasediff.json
+++ b/7t_trt/sub-15/ses-1/fmap/sub-15_ses-1_run-1_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-1/func/sub-15_ses-1_task-rest_acq-fullbrain_run-1_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-15/ses-1/func/sub-15_ses-1_task-rest_acq-fullbrain_run-1_bold.nii.gz"}

--- a/7t_trt/sub-15/ses-1/fmap/sub-15_ses-1_run-2_phasediff.json
+++ b/7t_trt/sub-15/ses-1/fmap/sub-15_ses-1_run-2_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-1/func/sub-15_ses-1_task-rest_acq-fullbrain_run-2_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-15/ses-1/func/sub-15_ses-1_task-rest_acq-fullbrain_run-2_bold.nii.gz"}

--- a/7t_trt/sub-15/ses-2/fmap/sub-15_ses-2_run-1_phasediff.json
+++ b/7t_trt/sub-15/ses-2/fmap/sub-15_ses-2_run-1_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-2/func/sub-15_ses-2_task-rest_acq-fullbrain_run-1_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-15/ses-2/func/sub-15_ses-2_task-rest_acq-fullbrain_run-1_bold.nii.gz"}

--- a/7t_trt/sub-15/ses-2/fmap/sub-15_ses-2_run-2_phasediff.json
+++ b/7t_trt/sub-15/ses-2/fmap/sub-15_ses-2_run-2_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-2/func/sub-15_ses-2_task-rest_acq-fullbrain_run-2_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-15/ses-2/func/sub-15_ses-2_task-rest_acq-fullbrain_run-2_bold.nii.gz"}

--- a/7t_trt/sub-16/ses-1/fmap/sub-16_ses-1_run-1_phasediff.json
+++ b/7t_trt/sub-16/ses-1/fmap/sub-16_ses-1_run-1_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-1/func/sub-16_ses-1_task-rest_acq-fullbrain_run-1_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-16/ses-1/func/sub-16_ses-1_task-rest_acq-fullbrain_run-1_bold.nii.gz"}

--- a/7t_trt/sub-16/ses-1/fmap/sub-16_ses-1_run-2_phasediff.json
+++ b/7t_trt/sub-16/ses-1/fmap/sub-16_ses-1_run-2_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-1/func/sub-16_ses-1_task-rest_acq-fullbrain_run-2_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-16/ses-1/func/sub-16_ses-1_task-rest_acq-fullbrain_run-2_bold.nii.gz"}

--- a/7t_trt/sub-16/ses-2/fmap/sub-16_ses-2_run-1_phasediff.json
+++ b/7t_trt/sub-16/ses-2/fmap/sub-16_ses-2_run-1_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-2/func/sub-16_ses-2_task-rest_acq-fullbrain_run-1_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-16/ses-2/func/sub-16_ses-2_task-rest_acq-fullbrain_run-1_bold.nii.gz"}

--- a/7t_trt/sub-16/ses-2/fmap/sub-16_ses-2_run-2_phasediff.json
+++ b/7t_trt/sub-16/ses-2/fmap/sub-16_ses-2_run-2_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-2/func/sub-16_ses-2_task-rest_acq-fullbrain_run-2_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-16/ses-2/func/sub-16_ses-2_task-rest_acq-fullbrain_run-2_bold.nii.gz"}

--- a/7t_trt/sub-17/ses-1/fmap/sub-17_ses-1_run-1_phasediff.json
+++ b/7t_trt/sub-17/ses-1/fmap/sub-17_ses-1_run-1_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-1/func/sub-17_ses-1_task-rest_acq-fullbrain_run-1_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-17/ses-1/func/sub-17_ses-1_task-rest_acq-fullbrain_run-1_bold.nii.gz"}

--- a/7t_trt/sub-17/ses-1/fmap/sub-17_ses-1_run-2_phasediff.json
+++ b/7t_trt/sub-17/ses-1/fmap/sub-17_ses-1_run-2_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-1/func/sub-17_ses-1_task-rest_acq-fullbrain_run-2_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-17/ses-1/func/sub-17_ses-1_task-rest_acq-fullbrain_run-2_bold.nii.gz"}

--- a/7t_trt/sub-17/ses-2/fmap/sub-17_ses-2_run-1_phasediff.json
+++ b/7t_trt/sub-17/ses-2/fmap/sub-17_ses-2_run-1_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-2/func/sub-17_ses-2_task-rest_acq-fullbrain_run-1_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-17/ses-2/func/sub-17_ses-2_task-rest_acq-fullbrain_run-1_bold.nii.gz"}

--- a/7t_trt/sub-17/ses-2/fmap/sub-17_ses-2_run-2_phasediff.json
+++ b/7t_trt/sub-17/ses-2/fmap/sub-17_ses-2_run-2_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-2/func/sub-17_ses-2_task-rest_acq-fullbrain_run-2_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-17/ses-2/func/sub-17_ses-2_task-rest_acq-fullbrain_run-2_bold.nii.gz"}

--- a/7t_trt/sub-18/ses-1/fmap/sub-18_ses-1_run-1_phasediff.json
+++ b/7t_trt/sub-18/ses-1/fmap/sub-18_ses-1_run-1_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-1/func/sub-18_ses-1_task-rest_acq-fullbrain_run-1_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-18/ses-1/func/sub-18_ses-1_task-rest_acq-fullbrain_run-1_bold.nii.gz"}

--- a/7t_trt/sub-18/ses-1/fmap/sub-18_ses-1_run-2_phasediff.json
+++ b/7t_trt/sub-18/ses-1/fmap/sub-18_ses-1_run-2_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-1/func/sub-18_ses-1_task-rest_acq-fullbrain_run-2_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-18/ses-1/func/sub-18_ses-1_task-rest_acq-fullbrain_run-2_bold.nii.gz"}

--- a/7t_trt/sub-18/ses-2/fmap/sub-18_ses-2_run-1_phasediff.json
+++ b/7t_trt/sub-18/ses-2/fmap/sub-18_ses-2_run-1_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-2/func/sub-18_ses-2_task-rest_acq-fullbrain_run-1_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-18/ses-2/func/sub-18_ses-2_task-rest_acq-fullbrain_run-1_bold.nii.gz"}

--- a/7t_trt/sub-18/ses-2/fmap/sub-18_ses-2_run-2_phasediff.json
+++ b/7t_trt/sub-18/ses-2/fmap/sub-18_ses-2_run-2_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-2/func/sub-18_ses-2_task-rest_acq-fullbrain_run-2_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-18/ses-2/func/sub-18_ses-2_task-rest_acq-fullbrain_run-2_bold.nii.gz"}

--- a/7t_trt/sub-19/ses-1/fmap/sub-19_ses-1_run-1_phasediff.json
+++ b/7t_trt/sub-19/ses-1/fmap/sub-19_ses-1_run-1_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-1/func/sub-19_ses-1_task-rest_acq-fullbrain_run-1_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-19/ses-1/func/sub-19_ses-1_task-rest_acq-fullbrain_run-1_bold.nii.gz"}

--- a/7t_trt/sub-19/ses-1/fmap/sub-19_ses-1_run-2_phasediff.json
+++ b/7t_trt/sub-19/ses-1/fmap/sub-19_ses-1_run-2_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-1/func/sub-19_ses-1_task-rest_acq-fullbrain_run-2_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-19/ses-1/func/sub-19_ses-1_task-rest_acq-fullbrain_run-2_bold.nii.gz"}

--- a/7t_trt/sub-19/ses-2/fmap/sub-19_ses-2_run-1_phasediff.json
+++ b/7t_trt/sub-19/ses-2/fmap/sub-19_ses-2_run-1_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-2/func/sub-19_ses-2_task-rest_acq-fullbrain_run-1_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-19/ses-2/func/sub-19_ses-2_task-rest_acq-fullbrain_run-1_bold.nii.gz"}

--- a/7t_trt/sub-19/ses-2/fmap/sub-19_ses-2_run-2_phasediff.json
+++ b/7t_trt/sub-19/ses-2/fmap/sub-19_ses-2_run-2_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-2/func/sub-19_ses-2_task-rest_acq-fullbrain_run-2_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-19/ses-2/func/sub-19_ses-2_task-rest_acq-fullbrain_run-2_bold.nii.gz"}

--- a/7t_trt/sub-20/ses-1/fmap/sub-20_ses-1_run-1_phasediff.json
+++ b/7t_trt/sub-20/ses-1/fmap/sub-20_ses-1_run-1_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-1/func/sub-20_ses-1_task-rest_acq-fullbrain_run-1_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-20/ses-1/func/sub-20_ses-1_task-rest_acq-fullbrain_run-1_bold.nii.gz"}

--- a/7t_trt/sub-20/ses-1/fmap/sub-20_ses-1_run-2_phasediff.json
+++ b/7t_trt/sub-20/ses-1/fmap/sub-20_ses-1_run-2_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-1/func/sub-20_ses-1_task-rest_acq-fullbrain_run-2_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-20/ses-1/func/sub-20_ses-1_task-rest_acq-fullbrain_run-2_bold.nii.gz"}

--- a/7t_trt/sub-20/ses-2/fmap/sub-20_ses-2_run-1_phasediff.json
+++ b/7t_trt/sub-20/ses-2/fmap/sub-20_ses-2_run-1_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-2/func/sub-20_ses-2_task-rest_acq-fullbrain_run-1_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-20/ses-2/func/sub-20_ses-2_task-rest_acq-fullbrain_run-1_bold.nii.gz"}

--- a/7t_trt/sub-20/ses-2/fmap/sub-20_ses-2_run-2_phasediff.json
+++ b/7t_trt/sub-20/ses-2/fmap/sub-20_ses-2_run-2_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-2/func/sub-20_ses-2_task-rest_acq-fullbrain_run-2_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-20/ses-2/func/sub-20_ses-2_task-rest_acq-fullbrain_run-2_bold.nii.gz"}

--- a/7t_trt/sub-21/ses-1/fmap/sub-21_ses-1_run-1_phasediff.json
+++ b/7t_trt/sub-21/ses-1/fmap/sub-21_ses-1_run-1_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-1/func/sub-21_ses-1_task-rest_acq-fullbrain_run-1_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-21/ses-1/func/sub-21_ses-1_task-rest_acq-fullbrain_run-1_bold.nii.gz"}

--- a/7t_trt/sub-21/ses-1/fmap/sub-21_ses-1_run-2_phasediff.json
+++ b/7t_trt/sub-21/ses-1/fmap/sub-21_ses-1_run-2_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-1/func/sub-21_ses-1_task-rest_acq-fullbrain_run-2_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-21/ses-1/func/sub-21_ses-1_task-rest_acq-fullbrain_run-2_bold.nii.gz"}

--- a/7t_trt/sub-21/ses-2/fmap/sub-21_ses-2_run-1_phasediff.json
+++ b/7t_trt/sub-21/ses-2/fmap/sub-21_ses-2_run-1_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-2/func/sub-21_ses-2_task-rest_acq-fullbrain_run-1_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-21/ses-2/func/sub-21_ses-2_task-rest_acq-fullbrain_run-1_bold.nii.gz"}

--- a/7t_trt/sub-21/ses-2/fmap/sub-21_ses-2_run-2_phasediff.json
+++ b/7t_trt/sub-21/ses-2/fmap/sub-21_ses-2_run-2_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-2/func/sub-21_ses-2_task-rest_acq-fullbrain_run-2_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-21/ses-2/func/sub-21_ses-2_task-rest_acq-fullbrain_run-2_bold.nii.gz"}

--- a/7t_trt/sub-22/ses-1/fmap/sub-22_ses-1_run-1_phasediff.json
+++ b/7t_trt/sub-22/ses-1/fmap/sub-22_ses-1_run-1_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-1/func/sub-22_ses-1_task-rest_acq-fullbrain_run-1_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-22/ses-1/func/sub-22_ses-1_task-rest_acq-fullbrain_run-1_bold.nii.gz"}

--- a/7t_trt/sub-22/ses-1/fmap/sub-22_ses-1_run-2_phasediff.json
+++ b/7t_trt/sub-22/ses-1/fmap/sub-22_ses-1_run-2_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-1/func/sub-22_ses-1_task-rest_acq-fullbrain_run-2_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-22/ses-1/func/sub-22_ses-1_task-rest_acq-fullbrain_run-2_bold.nii.gz"}

--- a/7t_trt/sub-22/ses-2/fmap/sub-22_ses-2_run-1_phasediff.json
+++ b/7t_trt/sub-22/ses-2/fmap/sub-22_ses-2_run-1_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-2/func/sub-22_ses-2_task-rest_acq-fullbrain_run-1_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-22/ses-2/func/sub-22_ses-2_task-rest_acq-fullbrain_run-1_bold.nii.gz"}

--- a/7t_trt/sub-22/ses-2/fmap/sub-22_ses-2_run-2_phasediff.json
+++ b/7t_trt/sub-22/ses-2/fmap/sub-22_ses-2_run-2_phasediff.json
@@ -1,1 +1,1 @@
-{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "ses-2/func/sub-22_ses-2_task-rest_acq-fullbrain_run-2_bold.nii.gz"}
+{"EchoTime2": 0.00702, "EchoTime1": 0.006, "IntendedFor": "bids::sub-22/ses-2/func/sub-22_ses-2_task-rest_acq-fullbrain_run-2_bold.nii.gz"}

--- a/ds000117/dataset_description.json
+++ b/ds000117/dataset_description.json
@@ -15,6 +15,6 @@
         "https://openfmri.org/dataset/ds000117/",
         "ftp://ftp.mrc-cbu.cam.ac.uk/personal/rik.henson/wakemandg_hensonrn/Publications/"
     ],
-    "BIDSVersion": "1.0.2",
+    "BIDSVersion": "1.8.0",
     "DatasetDOI": "10.18112/openneuro.ds000117.v1.0.4"
 }

--- a/ds000117/derivatives/meg_derivatives/sub-emptyroom/ses-20090515/meg/sub-emptyroom_ses-20090515_task-noise_proc-sss_meg.json
+++ b/ds000117/derivatives/meg_derivatives/sub-emptyroom/ses-20090515/meg/sub-emptyroom_ses-20090515_task-noise_proc-sss_meg.json
@@ -1,5 +1,12 @@
 {
- "IntendedFor": "sub-05/ses-meg/meg; sub-06/ses-meg/meg; sub-07/ses-meg/meg; sub-08/ses-meg/meg; sub-09/ses-meg/meg; sub-10/ses-meg/meg",
+ "IntendedFor": [
+     "sub-05/ses-meg/meg",
+     "sub-06/ses-meg/meg",
+     "sub-07/ses-meg/meg",
+     "sub-08/ses-meg/meg",
+     "sub-09/ses-meg/meg",
+     "sub-10/ses-meg/meg"
+    ],
  "SoftwareFilters": {
   "SSS": {
    "frame": "device",

--- a/ds000117/derivatives/meg_derivatives/sub-emptyroom/ses-20090601/meg/sub-emptyroom_ses-20090601_task-noise_proc-sss_meg.json
+++ b/ds000117/derivatives/meg_derivatives/sub-emptyroom/ses-20090601/meg/sub-emptyroom_ses-20090601_task-noise_proc-sss_meg.json
@@ -1,5 +1,9 @@
 {
- "IntendedFor": "sub-11/ses-meg/meg; sub-12/ses-meg/meg; sub-13/ses-meg/meg",
+ "IntendedFor": [
+     "sub-11/ses-meg/meg",
+     "sub-12/ses-meg/meg",
+     "sub-13/ses-meg/meg"
+    ],
  "SoftwareFilters": {
   "SSS": {
    "frame": "device",

--- a/ds000117/derivatives/meg_derivatives/sub-emptyroom/ses-20091208/meg/sub-emptyroom_ses-20091208_task-noise_proc-sss_meg.json
+++ b/ds000117/derivatives/meg_derivatives/sub-emptyroom/ses-20091208/meg/sub-emptyroom_ses-20091208_task-noise_proc-sss_meg.json
@@ -1,5 +1,8 @@
 {
- "IntendedFor": "sub-15/ses-meg/meg; sub-16/ses-meg/meg",
+ "IntendedFor": [
+     "sub-15/ses-meg/meg",
+     "sub-16/ses-meg/meg"
+    ],
  "SoftwareFilters": {
   "SSS": {
    "frame": "device",

--- a/ds000246/dataset_description.json
+++ b/ds000246/dataset_description.json
@@ -1,6 +1,6 @@
 {
   "Name":"MEG-BIDS Brainstorm data sample",
-  "BIDSVersion":"1.4.1",
+  "BIDSVersion":"1.8.0",
   "License":"CC0",
   "Authors":[
       "Elizabeth Bock",

--- a/ds000246/sub-0001/meg/sub-0001_task-AEF_run-01_meg.json
+++ b/ds000246/sub-0001/meg/sub-0001_task-AEF_run-01_meg.json
@@ -23,4 +23,4 @@
 "MaxMovement":0.0009892724421254463,
 "DigitizedLandmarks":true,
 "DigitizedHeadPoints":true,
-"AssociatedEmptyRoom":"bids::/sub-emptyroom/meg/sub-emptyroom_task-noise_run-01_meg.ds"}
+"AssociatedEmptyRoom":"bids::sub-emptyroom/meg/sub-emptyroom_task-noise_run-01_meg.ds"}

--- a/ds000246/sub-0001/meg/sub-0001_task-AEF_run-01_meg.json
+++ b/ds000246/sub-0001/meg/sub-0001_task-AEF_run-01_meg.json
@@ -23,4 +23,4 @@
 "MaxMovement":0.0009892724421254463,
 "DigitizedLandmarks":true,
 "DigitizedHeadPoints":true,
-"AssociatedEmptyRoom":"/sub-emptyroom/meg/sub-emptyroom_task-noise_run-01_meg.ds"}
+"AssociatedEmptyRoom":"bids::/sub-emptyroom/meg/sub-emptyroom_task-noise_run-01_meg.ds"}

--- a/ds000246/sub-0001/meg/sub-0001_task-AEF_run-02_meg.json
+++ b/ds000246/sub-0001/meg/sub-0001_task-AEF_run-02_meg.json
@@ -24,4 +24,4 @@
 "MaxMovement":0.0032890058287054712,
 "DigitizedLandmarks":true,
 "DigitizedHeadPoints":true,
-"AssociatedEmptyRoom":"/sub-emptyroom/meg/sub-emptyroom_task-noise_run-01_meg.ds"}
+"AssociatedEmptyRoom":"bids::/sub-emptyroom/meg/sub-emptyroom_task-noise_run-01_meg.ds"}

--- a/ds000246/sub-0001/meg/sub-0001_task-AEF_run-02_meg.json
+++ b/ds000246/sub-0001/meg/sub-0001_task-AEF_run-02_meg.json
@@ -24,4 +24,4 @@
 "MaxMovement":0.0032890058287054712,
 "DigitizedLandmarks":true,
 "DigitizedHeadPoints":true,
-"AssociatedEmptyRoom":"bids::/sub-emptyroom/meg/sub-emptyroom_task-noise_run-01_meg.ds"}
+"AssociatedEmptyRoom":"bids::sub-emptyroom/meg/sub-emptyroom_task-noise_run-01_meg.ds"}

--- a/ds000246/sub-emptyroom/meg/sub-emptyroom_task-noise_run-01_meg.json
+++ b/ds000246/sub-emptyroom/meg/sub-emptyroom_task-noise_run-01_meg.json
@@ -25,5 +25,5 @@
     "ContinuousHeadLocalization":false,
     "DigitizedLandmarks":false,
     "DigitizedHeadPoints":false,
-    "AssociatedEmptyRoom":"/sub-emptyroom/meg/sub-emptyroom_task-noise_run-01_meg.ds"
+    "AssociatedEmptyRoom":"bids::/sub-emptyroom/meg/sub-emptyroom_task-noise_run-01_meg.ds"
 }

--- a/ds000246/sub-emptyroom/meg/sub-emptyroom_task-noise_run-01_meg.json
+++ b/ds000246/sub-emptyroom/meg/sub-emptyroom_task-noise_run-01_meg.json
@@ -25,5 +25,5 @@
     "ContinuousHeadLocalization":false,
     "DigitizedLandmarks":false,
     "DigitizedHeadPoints":false,
-    "AssociatedEmptyRoom":"bids::/sub-emptyroom/meg/sub-emptyroom_task-noise_run-01_meg.ds"
+    "AssociatedEmptyRoom":"bids::sub-emptyroom/meg/sub-emptyroom_task-noise_run-01_meg.ds"
 }

--- a/ieeg_filtered_speech/dataset_description.json
+++ b/ieeg_filtered_speech/dataset_description.json
@@ -1,6 +1,6 @@
 {
     "Name": "Filtered speech",
-    "BIDSVersion": "1.7",
+    "BIDSVersion": "1.8.0",
     "DatasetType": "raw",
     "Authors": [
         "Chris Holdgraf"

--- a/ieeg_filtered_speech/dataset_description.json
+++ b/ieeg_filtered_speech/dataset_description.json
@@ -1,6 +1,6 @@
 {
     "Name": "Filtered speech",
-    "BIDSVersion": "1.4.1",
+    "BIDSVersion": "1.7",
     "DatasetType": "raw",
     "Authors": [
         "Chris Holdgraf"

--- a/ieeg_filtered_speech/sub-cm4/ieeg/sub-cm4_coordsystem.json
+++ b/ieeg_filtered_speech/sub-cm4/ieeg/sub-cm4_coordsystem.json
@@ -1,5 +1,5 @@
 {
     "iEEGCoordinateSystem": "Pixels",
     "iEEGCoordinateUnits": "pixels",
-    "IntendedFor": "/sub-cm4/ieeg/sub-cm4_photo.jpg"
+    "IntendedFor": "bids::sub-cm4/ieeg/sub-cm4_photo.jpg"
 }

--- a/ieeg_filtered_speech/sub-cm8/ieeg/sub-cm8_coordsystem.json
+++ b/ieeg_filtered_speech/sub-cm8/ieeg/sub-cm8_coordsystem.json
@@ -1,5 +1,5 @@
 {
     "iEEGCoordinateSystem": "Pixels",
     "iEEGCoordinateUnits": "pixels",
-    "IntendedFor": "/sub-cm8/ieeg/sub-cm8_photo.jpg"
+    "IntendedFor": "bids::sub-cm8/ieeg/sub-cm8_photo.jpg"
 }

--- a/ieeg_filtered_speech/sub-ir05/ieeg/sub-ir05_coordsystem.json
+++ b/ieeg_filtered_speech/sub-ir05/ieeg/sub-ir05_coordsystem.json
@@ -1,5 +1,5 @@
 {
     "iEEGCoordinateSystem": "Pixels",
     "iEEGCoordinateUnits": "pixels",
-    "IntendedFor": "/sub-ir05/ieeg/sub-ir05_photo.jpg"
+    "IntendedFor": "bids::sub-ir05/ieeg/sub-ir05_photo.jpg"
 }

--- a/ieeg_filtered_speech/sub-ir07/ieeg/sub-ir07_coordsystem.json
+++ b/ieeg_filtered_speech/sub-ir07/ieeg/sub-ir07_coordsystem.json
@@ -1,5 +1,5 @@
 {
     "iEEGCoordinateSystem": "Pixels",
     "iEEGCoordinateUnits": "pixels",
-    "IntendedFor": "/sub-ir07/ieeg/sub-ir07_photo.jpg"
+    "IntendedFor": "bids::sub-ir07/ieeg/sub-ir07_photo.jpg"
 }

--- a/ieeg_filtered_speech/sub-ir08/ieeg/sub-ir08_coordsystem.json
+++ b/ieeg_filtered_speech/sub-ir08/ieeg/sub-ir08_coordsystem.json
@@ -1,5 +1,5 @@
 {
     "iEEGCoordinateSystem": "Pixels",
     "iEEGCoordinateUnits": "pixels",
-    "IntendedFor": "/sub-ir08/ieeg/sub-ir08_photo.jpg"
+    "IntendedFor": "bids::sub-ir08/ieeg/sub-ir08_photo.jpg"
 }

--- a/ieeg_filtered_speech/sub-jh17/ieeg/sub-jh17_coordsystem.json
+++ b/ieeg_filtered_speech/sub-jh17/ieeg/sub-jh17_coordsystem.json
@@ -1,5 +1,5 @@
 {
     "iEEGCoordinateSystem": "Pixels",
     "iEEGCoordinateUnits": "pixels",
-    "IntendedFor": "/sub-jh17/ieeg/sub-jh17_photo.jpg"
+    "IntendedFor": "bids::sub-jh17/ieeg/sub-jh17_photo.jpg"
 }

--- a/ieeg_filtered_speech/sub-jh19/ieeg/sub-jh19_coordsystem.json
+++ b/ieeg_filtered_speech/sub-jh19/ieeg/sub-jh19_coordsystem.json
@@ -1,5 +1,5 @@
 {
     "iEEGCoordinateSystem": "Pixels",
     "iEEGCoordinateUnits": "pixels",
-    "IntendedFor": "/sub-jh19/ieeg/sub-jh19_photo.jpg"
+    "IntendedFor": "bids::sub-jh19/ieeg/sub-jh19_photo.jpg"
 }

--- a/synthetic/dataset_description.json
+++ b/synthetic/dataset_description.json
@@ -1,6 +1,6 @@
 {
 	"Name": "Synthetic dataset for inclusion in BIDS-examples",
-	"BIDSVersion": "1.6",
+	"BIDSVersion": "1.8.0",
 	"DatasetType": "raw",
 	"License": "PD",
 	"Authors": [

--- a/synthetic/derivatives/fmriprep/dataset_description.json
+++ b/synthetic/derivatives/fmriprep/dataset_description.json
@@ -18,5 +18,8 @@
             "URL": "../.."
         }
     ],
-    "HowToAcknowledge": "Please cite our paper (https://doi.org/10.1038/s41592-018-0235-4), and include the generated citation boilerplate within the Methods section of the text."
+    "HowToAcknowledge": "Please cite our paper (https://doi.org/10.1038/s41592-018-0235-4), and include the generated citation boilerplate within the Methods section of the text.",
+    "DatasetLinks": {
+        "raw": "../../"
+    }
 }

--- a/synthetic/derivatives/fmriprep/sub-01/ses-01/func/sub-01_ses-01_task-nback_run-01_space-MNI152NLin2009cAsym_desc-preproc_bold.json
+++ b/synthetic/derivatives/fmriprep/sub-01/ses-01/func/sub-01_ses-01_task-nback_run-01_space-MNI152NLin2009cAsym_desc-preproc_bold.json
@@ -1,6 +1,6 @@
 {
-  "RawSources": [
-    "sub-01/ses-01/sub-01_ses-01_task-nback_run-01_bold.nii"
+  "Sources": [
+    "bids:raw:sub-01/ses-01/sub-01_ses-01_task-nback_run-01_bold.nii"
   ],
   "TaskName": "N-Back",
   "RepetitionTime": 2.5

--- a/synthetic/derivatives/fmriprep/sub-01/ses-01/func/sub-01_ses-01_task-nback_run-01_space-T1w_desc-preproc_bold.json
+++ b/synthetic/derivatives/fmriprep/sub-01/ses-01/func/sub-01_ses-01_task-nback_run-01_space-T1w_desc-preproc_bold.json
@@ -1,6 +1,6 @@
 {
-  "RawSources": [
-    "sub-01/ses-01/sub-01_ses-01_task-nback_run-01_bold.nii"
+  "Sources": [
+    "bids:raw:sub-01/ses-01/sub-01_ses-01_task-nback_run-01_bold.nii"
   ],
   "TaskName": "N-Back",
   "RepetitionTime": 2.5

--- a/synthetic/derivatives/fmriprep/sub-01/ses-01/func/sub-01_ses-01_task-nback_run-02_space-MNI152NLin2009cAsym_desc-preproc_bold.json
+++ b/synthetic/derivatives/fmriprep/sub-01/ses-01/func/sub-01_ses-01_task-nback_run-02_space-MNI152NLin2009cAsym_desc-preproc_bold.json
@@ -1,6 +1,6 @@
 {
-  "RawSources": [
-    "sub-01/ses-01/sub-01_ses-01_task-nback_run-02_bold.nii"
+  "Sources": [
+    "bids:raw:sub-01/ses-01/sub-01_ses-01_task-nback_run-02_bold.nii"
   ],
   "TaskName": "N-Back",
   "RepetitionTime": 2.5

--- a/synthetic/derivatives/fmriprep/sub-01/ses-01/func/sub-01_ses-01_task-nback_run-02_space-T1w_desc-preproc_bold.json
+++ b/synthetic/derivatives/fmriprep/sub-01/ses-01/func/sub-01_ses-01_task-nback_run-02_space-T1w_desc-preproc_bold.json
@@ -1,6 +1,6 @@
 {
-  "RawSources": [
-    "sub-01/ses-01/sub-01_ses-01_task-nback_run-02_bold.nii"
+  "Sources": [
+    "bids:raw:sub-01/ses-01/sub-01_ses-01_task-nback_run-02_bold.nii"
   ],
   "TaskName": "N-Back",
   "RepetitionTime": 2.5

--- a/synthetic/derivatives/fmriprep/sub-01/ses-01/func/sub-01_ses-01_task-rest_space-MNI152NLin2009cAsym_desc-preproc_bold.json
+++ b/synthetic/derivatives/fmriprep/sub-01/ses-01/func/sub-01_ses-01_task-rest_space-MNI152NLin2009cAsym_desc-preproc_bold.json
@@ -1,6 +1,6 @@
 {
-  "RawSources": [
-    "sub-01/ses-01/sub-01_ses-01_task-rest_bold.nii"
+  "Sources": [
+    "bids:raw:sub-01/ses-01/sub-01_ses-01_task-rest_bold.nii"
   ],
   "TaskName": "Rest",
   "RepetitionTime": 2.5

--- a/synthetic/derivatives/fmriprep/sub-01/ses-01/func/sub-01_ses-01_task-rest_space-T1w_desc-preproc_bold.json
+++ b/synthetic/derivatives/fmriprep/sub-01/ses-01/func/sub-01_ses-01_task-rest_space-T1w_desc-preproc_bold.json
@@ -1,6 +1,6 @@
 {
-  "RawSources": [
-    "sub-01/ses-01/sub-01_ses-01_task-rest_bold.nii"
+  "Sources": [
+    "bids:raw:sub-01/ses-01/sub-01_ses-01_task-rest_bold.nii"
   ],
   "TaskName": "Rest",
   "RepetitionTime": 2.5

--- a/synthetic/derivatives/fmriprep/sub-01/ses-02/func/sub-01_ses-02_task-nback_run-01_space-MNI152NLin2009cAsym_desc-preproc_bold.json
+++ b/synthetic/derivatives/fmriprep/sub-01/ses-02/func/sub-01_ses-02_task-nback_run-01_space-MNI152NLin2009cAsym_desc-preproc_bold.json
@@ -1,6 +1,6 @@
 {
-  "RawSources": [
-    "sub-01/ses-02/sub-01_ses-02_task-nback_run-01_bold.nii"
+  "Sources": [
+    "bids:raw:sub-01/ses-02/sub-01_ses-02_task-nback_run-01_bold.nii"
   ],
   "TaskName": "N-Back",
   "RepetitionTime": 2.5

--- a/synthetic/derivatives/fmriprep/sub-01/ses-02/func/sub-01_ses-02_task-nback_run-01_space-T1w_desc-preproc_bold.json
+++ b/synthetic/derivatives/fmriprep/sub-01/ses-02/func/sub-01_ses-02_task-nback_run-01_space-T1w_desc-preproc_bold.json
@@ -1,6 +1,6 @@
 {
-  "RawSources": [
-    "sub-01/ses-02/sub-01_ses-02_task-nback_run-01_bold.nii"
+  "Sources": [
+    "bids:raw:sub-01/ses-02/sub-01_ses-02_task-nback_run-01_bold.nii"
   ],
   "TaskName": "N-Back",
   "RepetitionTime": 2.5

--- a/synthetic/derivatives/fmriprep/sub-01/ses-02/func/sub-01_ses-02_task-nback_run-02_space-MNI152NLin2009cAsym_desc-preproc_bold.json
+++ b/synthetic/derivatives/fmriprep/sub-01/ses-02/func/sub-01_ses-02_task-nback_run-02_space-MNI152NLin2009cAsym_desc-preproc_bold.json
@@ -1,6 +1,6 @@
 {
-  "RawSources": [
-    "sub-01/ses-02/sub-01_ses-02_task-nback_run-02_bold.nii"
+  "Sources": [
+    "bids:raw:sub-01/ses-02/sub-01_ses-02_task-nback_run-02_bold.nii"
   ],
   "TaskName": "N-Back",
   "RepetitionTime": 2.5

--- a/synthetic/derivatives/fmriprep/sub-01/ses-02/func/sub-01_ses-02_task-nback_run-02_space-T1w_desc-preproc_bold.json
+++ b/synthetic/derivatives/fmriprep/sub-01/ses-02/func/sub-01_ses-02_task-nback_run-02_space-T1w_desc-preproc_bold.json
@@ -1,6 +1,6 @@
 {
-  "RawSources": [
-    "sub-01/ses-02/sub-01_ses-02_task-nback_run-02_bold.nii"
+  "Sources": [
+    "bids:raw:sub-01/ses-02/sub-01_ses-02_task-nback_run-02_bold.nii"
   ],
   "TaskName": "N-Back",
   "RepetitionTime": 2.5

--- a/synthetic/derivatives/fmriprep/sub-01/ses-02/func/sub-01_ses-02_task-rest_space-MNI152NLin2009cAsym_desc-preproc_bold.json
+++ b/synthetic/derivatives/fmriprep/sub-01/ses-02/func/sub-01_ses-02_task-rest_space-MNI152NLin2009cAsym_desc-preproc_bold.json
@@ -1,6 +1,6 @@
 {
-  "RawSources": [
-    "sub-01/ses-02/sub-01_ses-02_task-rest_bold.nii"
+  "Sources": [
+    "bids:raw:sub-01/ses-02/sub-01_ses-02_task-rest_bold.nii"
   ],
   "TaskName": "Rest",
   "RepetitionTime": 2.5

--- a/synthetic/derivatives/fmriprep/sub-01/ses-02/func/sub-01_ses-02_task-rest_space-T1w_desc-preproc_bold.json
+++ b/synthetic/derivatives/fmriprep/sub-01/ses-02/func/sub-01_ses-02_task-rest_space-T1w_desc-preproc_bold.json
@@ -1,6 +1,6 @@
 {
-  "RawSources": [
-    "sub-01/ses-02/sub-01_ses-02_task-rest_bold.nii"
+  "Sources": [
+    "bids:raw:sub-01/ses-02/sub-01_ses-02_task-rest_bold.nii"
   ],
   "TaskName": "Rest",
   "RepetitionTime": 2.5

--- a/synthetic/derivatives/fmriprep/sub-02/ses-01/func/sub-02_ses-01_task-nback_run-01_space-MNI152NLin2009cAsym_desc-preproc_bold.json
+++ b/synthetic/derivatives/fmriprep/sub-02/ses-01/func/sub-02_ses-01_task-nback_run-01_space-MNI152NLin2009cAsym_desc-preproc_bold.json
@@ -1,6 +1,6 @@
 {
-  "RawSources": [
-    "sub-02/ses-01/sub-02_ses-01_task-nback_run-01_bold.nii"
+  "Sources": [
+    "bids:raw:sub-02/ses-01/sub-02_ses-01_task-nback_run-01_bold.nii"
   ],
   "TaskName": "N-Back",
   "RepetitionTime": 2.5

--- a/synthetic/derivatives/fmriprep/sub-02/ses-01/func/sub-02_ses-01_task-nback_run-01_space-T1w_desc-preproc_bold.json
+++ b/synthetic/derivatives/fmriprep/sub-02/ses-01/func/sub-02_ses-01_task-nback_run-01_space-T1w_desc-preproc_bold.json
@@ -1,6 +1,6 @@
 {
-  "RawSources": [
-    "sub-02/ses-01/sub-02_ses-01_task-nback_run-01_bold.nii"
+  "Sources": [
+    "bids:raw:sub-02/ses-01/sub-02_ses-01_task-nback_run-01_bold.nii"
   ],
   "TaskName": "N-Back",
   "RepetitionTime": 2.5

--- a/synthetic/derivatives/fmriprep/sub-02/ses-01/func/sub-02_ses-01_task-nback_run-02_space-MNI152NLin2009cAsym_desc-preproc_bold.json
+++ b/synthetic/derivatives/fmriprep/sub-02/ses-01/func/sub-02_ses-01_task-nback_run-02_space-MNI152NLin2009cAsym_desc-preproc_bold.json
@@ -1,6 +1,6 @@
 {
-  "RawSources": [
-    "sub-02/ses-01/sub-02_ses-01_task-nback_run-02_bold.nii"
+  "Sources": [
+    "bids:raw:sub-02/ses-01/sub-02_ses-01_task-nback_run-02_bold.nii"
   ],
   "TaskName": "N-Back",
   "RepetitionTime": 2.5

--- a/synthetic/derivatives/fmriprep/sub-02/ses-01/func/sub-02_ses-01_task-nback_run-02_space-T1w_desc-preproc_bold.json
+++ b/synthetic/derivatives/fmriprep/sub-02/ses-01/func/sub-02_ses-01_task-nback_run-02_space-T1w_desc-preproc_bold.json
@@ -1,6 +1,6 @@
 {
-  "RawSources": [
-    "sub-02/ses-01/sub-02_ses-01_task-nback_run-02_bold.nii"
+  "Sources": [
+    "bids:raw:sub-02/ses-01/sub-02_ses-01_task-nback_run-02_bold.nii"
   ],
   "TaskName": "N-Back",
   "RepetitionTime": 2.5

--- a/synthetic/derivatives/fmriprep/sub-02/ses-01/func/sub-02_ses-01_task-rest_space-MNI152NLin2009cAsym_desc-preproc_bold.json
+++ b/synthetic/derivatives/fmriprep/sub-02/ses-01/func/sub-02_ses-01_task-rest_space-MNI152NLin2009cAsym_desc-preproc_bold.json
@@ -1,6 +1,6 @@
 {
-  "RawSources": [
-    "sub-02/ses-01/sub-02_ses-01_task-rest_bold.nii"
+  "Sources": [
+    "bids:raw:sub-02/ses-01/sub-02_ses-01_task-rest_bold.nii"
   ],
   "TaskName": "Rest",
   "RepetitionTime": 2.5

--- a/synthetic/derivatives/fmriprep/sub-02/ses-01/func/sub-02_ses-01_task-rest_space-T1w_desc-preproc_bold.json
+++ b/synthetic/derivatives/fmriprep/sub-02/ses-01/func/sub-02_ses-01_task-rest_space-T1w_desc-preproc_bold.json
@@ -1,6 +1,6 @@
 {
-  "RawSources": [
-    "sub-02/ses-01/sub-02_ses-01_task-rest_bold.nii"
+  "Sources": [
+    "bids:raw:sub-02/ses-01/sub-02_ses-01_task-rest_bold.nii"
   ],
   "TaskName": "Rest",
   "RepetitionTime": 2.5

--- a/synthetic/derivatives/fmriprep/sub-02/ses-02/func/sub-02_ses-02_task-nback_run-01_space-MNI152NLin2009cAsym_desc-preproc_bold.json
+++ b/synthetic/derivatives/fmriprep/sub-02/ses-02/func/sub-02_ses-02_task-nback_run-01_space-MNI152NLin2009cAsym_desc-preproc_bold.json
@@ -1,6 +1,6 @@
 {
-  "RawSources": [
-    "sub-02/ses-02/sub-02_ses-02_task-nback_run-01_bold.nii"
+  "Sources": [
+    "bids:raw:sub-02/ses-02/sub-02_ses-02_task-nback_run-01_bold.nii"
   ],
   "TaskName": "N-Back",
   "RepetitionTime": 2.5

--- a/synthetic/derivatives/fmriprep/sub-02/ses-02/func/sub-02_ses-02_task-nback_run-01_space-T1w_desc-preproc_bold.json
+++ b/synthetic/derivatives/fmriprep/sub-02/ses-02/func/sub-02_ses-02_task-nback_run-01_space-T1w_desc-preproc_bold.json
@@ -1,6 +1,6 @@
 {
-  "RawSources": [
-    "sub-02/ses-02/sub-02_ses-02_task-nback_run-01_bold.nii"
+  "Sources": [
+    "bids:raw:sub-02/ses-02/sub-02_ses-02_task-nback_run-01_bold.nii"
   ],
   "TaskName": "N-Back",
   "RepetitionTime": 2.5

--- a/synthetic/derivatives/fmriprep/sub-02/ses-02/func/sub-02_ses-02_task-nback_run-02_space-MNI152NLin2009cAsym_desc-preproc_bold.json
+++ b/synthetic/derivatives/fmriprep/sub-02/ses-02/func/sub-02_ses-02_task-nback_run-02_space-MNI152NLin2009cAsym_desc-preproc_bold.json
@@ -1,6 +1,6 @@
 {
-  "RawSources": [
-    "sub-02/ses-02/sub-02_ses-02_task-nback_run-02_bold.nii"
+  "Sources": [
+    "bids:raw:sub-02/ses-02/sub-02_ses-02_task-nback_run-02_bold.nii"
   ],
   "TaskName": "N-Back",
   "RepetitionTime": 2.5

--- a/synthetic/derivatives/fmriprep/sub-02/ses-02/func/sub-02_ses-02_task-nback_run-02_space-T1w_desc-preproc_bold.json
+++ b/synthetic/derivatives/fmriprep/sub-02/ses-02/func/sub-02_ses-02_task-nback_run-02_space-T1w_desc-preproc_bold.json
@@ -1,6 +1,6 @@
 {
-  "RawSources": [
-    "sub-02/ses-02/sub-02_ses-02_task-nback_run-02_bold.nii"
+  "Sources": [
+    "bids:raw:sub-02/ses-02/sub-02_ses-02_task-nback_run-02_bold.nii"
   ],
   "TaskName": "N-Back",
   "RepetitionTime": 2.5

--- a/synthetic/derivatives/fmriprep/sub-02/ses-02/func/sub-02_ses-02_task-rest_space-MNI152NLin2009cAsym_desc-preproc_bold.json
+++ b/synthetic/derivatives/fmriprep/sub-02/ses-02/func/sub-02_ses-02_task-rest_space-MNI152NLin2009cAsym_desc-preproc_bold.json
@@ -1,6 +1,6 @@
 {
-  "RawSources": [
-    "sub-02/ses-02/sub-02_ses-02_task-rest_bold.nii"
+  "Sources": [
+    "bids:raw:sub-02/ses-02/sub-02_ses-02_task-rest_bold.nii"
   ],
   "TaskName": "Rest",
   "RepetitionTime": 2.5

--- a/synthetic/derivatives/fmriprep/sub-02/ses-02/func/sub-02_ses-02_task-rest_space-T1w_desc-preproc_bold.json
+++ b/synthetic/derivatives/fmriprep/sub-02/ses-02/func/sub-02_ses-02_task-rest_space-T1w_desc-preproc_bold.json
@@ -1,6 +1,6 @@
 {
-  "RawSources": [
-    "sub-02/ses-02/sub-02_ses-02_task-rest_bold.nii"
+  "Sources": [
+    "bids:raw:sub-02/ses-02/sub-02_ses-02_task-rest_bold.nii"
   ],
   "TaskName": "Rest",
   "RepetitionTime": 2.5

--- a/synthetic/derivatives/fmriprep/sub-03/ses-01/func/sub-03_ses-01_task-nback_run-01_space-MNI152NLin2009cAsym_desc-preproc_bold.json
+++ b/synthetic/derivatives/fmriprep/sub-03/ses-01/func/sub-03_ses-01_task-nback_run-01_space-MNI152NLin2009cAsym_desc-preproc_bold.json
@@ -1,6 +1,6 @@
 {
-  "RawSources": [
-    "sub-03/ses-01/sub-03_ses-01_task-nback_run-01_bold.nii"
+  "Sources": [
+    "bids:raw:sub-03/ses-01/sub-03_ses-01_task-nback_run-01_bold.nii"
   ],
   "TaskName": "N-Back",
   "RepetitionTime": 2.5

--- a/synthetic/derivatives/fmriprep/sub-03/ses-01/func/sub-03_ses-01_task-nback_run-01_space-T1w_desc-preproc_bold.json
+++ b/synthetic/derivatives/fmriprep/sub-03/ses-01/func/sub-03_ses-01_task-nback_run-01_space-T1w_desc-preproc_bold.json
@@ -1,6 +1,6 @@
 {
-  "RawSources": [
-    "sub-03/ses-01/sub-03_ses-01_task-nback_run-01_bold.nii"
+  "Sources": [
+    "bids:raw:sub-03/ses-01/sub-03_ses-01_task-nback_run-01_bold.nii"
   ],
   "TaskName": "N-Back",
   "RepetitionTime": 2.5

--- a/synthetic/derivatives/fmriprep/sub-03/ses-01/func/sub-03_ses-01_task-nback_run-02_space-MNI152NLin2009cAsym_desc-preproc_bold.json
+++ b/synthetic/derivatives/fmriprep/sub-03/ses-01/func/sub-03_ses-01_task-nback_run-02_space-MNI152NLin2009cAsym_desc-preproc_bold.json
@@ -1,6 +1,6 @@
 {
-  "RawSources": [
-    "sub-03/ses-01/sub-03_ses-01_task-nback_run-02_bold.nii"
+  "Sources": [
+    "bids:raw:sub-03/ses-01/sub-03_ses-01_task-nback_run-02_bold.nii"
   ],
   "TaskName": "N-Back",
   "RepetitionTime": 2.5

--- a/synthetic/derivatives/fmriprep/sub-03/ses-01/func/sub-03_ses-01_task-nback_run-02_space-T1w_desc-preproc_bold.json
+++ b/synthetic/derivatives/fmriprep/sub-03/ses-01/func/sub-03_ses-01_task-nback_run-02_space-T1w_desc-preproc_bold.json
@@ -1,6 +1,6 @@
 {
-  "RawSources": [
-    "sub-03/ses-01/sub-03_ses-01_task-nback_run-02_bold.nii"
+  "Sources": [
+    "bids:raw:sub-03/ses-01/sub-03_ses-01_task-nback_run-02_bold.nii"
   ],
   "TaskName": "N-Back",
   "RepetitionTime": 2.5

--- a/synthetic/derivatives/fmriprep/sub-03/ses-01/func/sub-03_ses-01_task-rest_space-MNI152NLin2009cAsym_desc-preproc_bold.json
+++ b/synthetic/derivatives/fmriprep/sub-03/ses-01/func/sub-03_ses-01_task-rest_space-MNI152NLin2009cAsym_desc-preproc_bold.json
@@ -1,6 +1,6 @@
 {
-  "RawSources": [
-    "sub-03/ses-01/sub-03_ses-01_task-rest_bold.nii"
+  "Sources": [
+    "bids:raw:sub-03/ses-01/sub-03_ses-01_task-rest_bold.nii"
   ],
   "TaskName": "Rest",
   "RepetitionTime": 2.5

--- a/synthetic/derivatives/fmriprep/sub-03/ses-01/func/sub-03_ses-01_task-rest_space-T1w_desc-preproc_bold.json
+++ b/synthetic/derivatives/fmriprep/sub-03/ses-01/func/sub-03_ses-01_task-rest_space-T1w_desc-preproc_bold.json
@@ -1,6 +1,6 @@
 {
-  "RawSources": [
-    "sub-03/ses-01/sub-03_ses-01_task-rest_bold.nii"
+  "Sources": [
+    "bids:raw:sub-03/ses-01/sub-03_ses-01_task-rest_bold.nii"
   ],
   "TaskName": "Rest",
   "RepetitionTime": 2.5

--- a/synthetic/derivatives/fmriprep/sub-03/ses-02/func/sub-03_ses-02_task-nback_run-01_space-MNI152NLin2009cAsym_desc-preproc_bold.json
+++ b/synthetic/derivatives/fmriprep/sub-03/ses-02/func/sub-03_ses-02_task-nback_run-01_space-MNI152NLin2009cAsym_desc-preproc_bold.json
@@ -1,6 +1,6 @@
 {
-  "RawSources": [
-    "sub-03/ses-02/sub-03_ses-02_task-nback_run-01_bold.nii"
+  "Sources": [
+    "bids:raw:sub-03/ses-02/sub-03_ses-02_task-nback_run-01_bold.nii"
   ],
   "TaskName": "N-Back",
   "RepetitionTime": 2.5

--- a/synthetic/derivatives/fmriprep/sub-03/ses-02/func/sub-03_ses-02_task-nback_run-01_space-T1w_desc-preproc_bold.json
+++ b/synthetic/derivatives/fmriprep/sub-03/ses-02/func/sub-03_ses-02_task-nback_run-01_space-T1w_desc-preproc_bold.json
@@ -1,6 +1,6 @@
 {
-  "RawSources": [
-    "sub-03/ses-02/sub-03_ses-02_task-nback_run-01_bold.nii"
+  "Sources": [
+    "bids:raw:sub-03/ses-02/sub-03_ses-02_task-nback_run-01_bold.nii"
   ],
   "TaskName": "N-Back",
   "RepetitionTime": 2.5

--- a/synthetic/derivatives/fmriprep/sub-03/ses-02/func/sub-03_ses-02_task-nback_run-02_space-MNI152NLin2009cAsym_desc-preproc_bold.json
+++ b/synthetic/derivatives/fmriprep/sub-03/ses-02/func/sub-03_ses-02_task-nback_run-02_space-MNI152NLin2009cAsym_desc-preproc_bold.json
@@ -1,6 +1,6 @@
 {
-  "RawSources": [
-    "sub-03/ses-02/sub-03_ses-02_task-nback_run-02_bold.nii"
+  "Sources": [
+    "bids:raw:sub-03/ses-02/sub-03_ses-02_task-nback_run-02_bold.nii"
   ],
   "TaskName": "N-Back",
   "RepetitionTime": 2.5

--- a/synthetic/derivatives/fmriprep/sub-03/ses-02/func/sub-03_ses-02_task-nback_run-02_space-T1w_desc-preproc_bold.json
+++ b/synthetic/derivatives/fmriprep/sub-03/ses-02/func/sub-03_ses-02_task-nback_run-02_space-T1w_desc-preproc_bold.json
@@ -1,6 +1,6 @@
 {
-  "RawSources": [
-    "sub-03/ses-02/sub-03_ses-02_task-nback_run-02_bold.nii"
+  "Sources": [
+    "bids:raw:sub-03/ses-02/sub-03_ses-02_task-nback_run-02_bold.nii"
   ],
   "TaskName": "N-Back",
   "RepetitionTime": 2.5

--- a/synthetic/derivatives/fmriprep/sub-03/ses-02/func/sub-03_ses-02_task-rest_space-MNI152NLin2009cAsym_desc-preproc_bold.json
+++ b/synthetic/derivatives/fmriprep/sub-03/ses-02/func/sub-03_ses-02_task-rest_space-MNI152NLin2009cAsym_desc-preproc_bold.json
@@ -1,6 +1,6 @@
 {
-  "RawSources": [
-    "sub-03/ses-02/sub-03_ses-02_task-rest_bold.nii"
+  "Sources": [
+    "bids:raw:sub-03/ses-02/sub-03_ses-02_task-rest_bold.nii"
   ],
   "TaskName": "Rest",
   "RepetitionTime": 2.5

--- a/synthetic/derivatives/fmriprep/sub-03/ses-02/func/sub-03_ses-02_task-rest_space-T1w_desc-preproc_bold.json
+++ b/synthetic/derivatives/fmriprep/sub-03/ses-02/func/sub-03_ses-02_task-rest_space-T1w_desc-preproc_bold.json
@@ -1,6 +1,6 @@
 {
-  "RawSources": [
-    "sub-03/ses-02/sub-03_ses-02_task-rest_bold.nii"
+  "Sources": [
+    "bids:raw:sub-03/ses-02/sub-03_ses-02_task-rest_bold.nii"
   ],
   "TaskName": "Rest",
   "RepetitionTime": 2.5

--- a/synthetic/derivatives/fmriprep/sub-04/ses-01/func/sub-04_ses-01_task-nback_run-01_space-MNI152NLin2009cAsym_desc-preproc_bold.json
+++ b/synthetic/derivatives/fmriprep/sub-04/ses-01/func/sub-04_ses-01_task-nback_run-01_space-MNI152NLin2009cAsym_desc-preproc_bold.json
@@ -1,6 +1,6 @@
 {
-  "RawSources": [
-    "sub-04/ses-01/sub-04_ses-01_task-nback_run-01_bold.nii"
+  "Sources": [
+    "bids:raw:sub-04/ses-01/sub-04_ses-01_task-nback_run-01_bold.nii"
   ],
   "TaskName": "N-Back",
   "RepetitionTime": 2.5

--- a/synthetic/derivatives/fmriprep/sub-04/ses-01/func/sub-04_ses-01_task-nback_run-01_space-T1w_desc-preproc_bold.json
+++ b/synthetic/derivatives/fmriprep/sub-04/ses-01/func/sub-04_ses-01_task-nback_run-01_space-T1w_desc-preproc_bold.json
@@ -1,6 +1,6 @@
 {
-  "RawSources": [
-    "sub-04/ses-01/sub-04_ses-01_task-nback_run-01_bold.nii"
+  "Sources": [
+    "bids:raw:sub-04/ses-01/sub-04_ses-01_task-nback_run-01_bold.nii"
   ],
   "TaskName": "N-Back",
   "RepetitionTime": 2.5

--- a/synthetic/derivatives/fmriprep/sub-04/ses-01/func/sub-04_ses-01_task-nback_run-02_space-MNI152NLin2009cAsym_desc-preproc_bold.json
+++ b/synthetic/derivatives/fmriprep/sub-04/ses-01/func/sub-04_ses-01_task-nback_run-02_space-MNI152NLin2009cAsym_desc-preproc_bold.json
@@ -1,6 +1,6 @@
 {
-  "RawSources": [
-    "sub-04/ses-01/sub-04_ses-01_task-nback_run-02_bold.nii"
+  "Sources": [
+    "bids:raw:sub-04/ses-01/sub-04_ses-01_task-nback_run-02_bold.nii"
   ],
   "TaskName": "N-Back",
   "RepetitionTime": 2.5

--- a/synthetic/derivatives/fmriprep/sub-04/ses-01/func/sub-04_ses-01_task-nback_run-02_space-T1w_desc-preproc_bold.json
+++ b/synthetic/derivatives/fmriprep/sub-04/ses-01/func/sub-04_ses-01_task-nback_run-02_space-T1w_desc-preproc_bold.json
@@ -1,6 +1,6 @@
 {
-  "RawSources": [
-    "sub-04/ses-01/sub-04_ses-01_task-nback_run-02_bold.nii"
+  "Sources": [
+    "bids:raw:sub-04/ses-01/sub-04_ses-01_task-nback_run-02_bold.nii"
   ],
   "TaskName": "N-Back",
   "RepetitionTime": 2.5

--- a/synthetic/derivatives/fmriprep/sub-04/ses-01/func/sub-04_ses-01_task-rest_space-MNI152NLin2009cAsym_desc-preproc_bold.json
+++ b/synthetic/derivatives/fmriprep/sub-04/ses-01/func/sub-04_ses-01_task-rest_space-MNI152NLin2009cAsym_desc-preproc_bold.json
@@ -1,6 +1,6 @@
 {
-  "RawSources": [
-    "sub-04/ses-01/sub-04_ses-01_task-rest_bold.nii"
+  "Sources": [
+    "bids:raw:sub-04/ses-01/sub-04_ses-01_task-rest_bold.nii"
   ],
   "TaskName": "Rest",
   "RepetitionTime": 2.5

--- a/synthetic/derivatives/fmriprep/sub-04/ses-01/func/sub-04_ses-01_task-rest_space-T1w_desc-preproc_bold.json
+++ b/synthetic/derivatives/fmriprep/sub-04/ses-01/func/sub-04_ses-01_task-rest_space-T1w_desc-preproc_bold.json
@@ -1,6 +1,6 @@
 {
-  "RawSources": [
-    "sub-04/ses-01/sub-04_ses-01_task-rest_bold.nii"
+  "Sources": [
+    "bids:raw:sub-04/ses-01/sub-04_ses-01_task-rest_bold.nii"
   ],
   "TaskName": "Rest",
   "RepetitionTime": 2.5

--- a/synthetic/derivatives/fmriprep/sub-04/ses-02/func/sub-04_ses-02_task-nback_run-01_space-MNI152NLin2009cAsym_desc-preproc_bold.json
+++ b/synthetic/derivatives/fmriprep/sub-04/ses-02/func/sub-04_ses-02_task-nback_run-01_space-MNI152NLin2009cAsym_desc-preproc_bold.json
@@ -1,6 +1,6 @@
 {
-  "RawSources": [
-    "sub-04/ses-02/sub-04_ses-02_task-nback_run-01_bold.nii"
+  "Sources": [
+    "bids:raw:sub-04/ses-02/sub-04_ses-02_task-nback_run-01_bold.nii"
   ],
   "TaskName": "N-Back",
   "RepetitionTime": 2.5

--- a/synthetic/derivatives/fmriprep/sub-04/ses-02/func/sub-04_ses-02_task-nback_run-01_space-T1w_desc-preproc_bold.json
+++ b/synthetic/derivatives/fmriprep/sub-04/ses-02/func/sub-04_ses-02_task-nback_run-01_space-T1w_desc-preproc_bold.json
@@ -1,6 +1,6 @@
 {
-  "RawSources": [
-    "sub-04/ses-02/sub-04_ses-02_task-nback_run-01_bold.nii"
+  "Sources": [
+    "bids:raw:sub-04/ses-02/sub-04_ses-02_task-nback_run-01_bold.nii"
   ],
   "TaskName": "N-Back",
   "RepetitionTime": 2.5

--- a/synthetic/derivatives/fmriprep/sub-04/ses-02/func/sub-04_ses-02_task-nback_run-02_space-MNI152NLin2009cAsym_desc-preproc_bold.json
+++ b/synthetic/derivatives/fmriprep/sub-04/ses-02/func/sub-04_ses-02_task-nback_run-02_space-MNI152NLin2009cAsym_desc-preproc_bold.json
@@ -1,6 +1,6 @@
 {
-  "RawSources": [
-    "sub-04/ses-02/sub-04_ses-02_task-nback_run-02_bold.nii"
+  "Sources": [
+    "bids:raw:sub-04/ses-02/sub-04_ses-02_task-nback_run-02_bold.nii"
   ],
   "TaskName": "N-Back",
   "RepetitionTime": 2.5

--- a/synthetic/derivatives/fmriprep/sub-04/ses-02/func/sub-04_ses-02_task-nback_run-02_space-T1w_desc-preproc_bold.json
+++ b/synthetic/derivatives/fmriprep/sub-04/ses-02/func/sub-04_ses-02_task-nback_run-02_space-T1w_desc-preproc_bold.json
@@ -1,6 +1,6 @@
 {
-  "RawSources": [
-    "sub-04/ses-02/sub-04_ses-02_task-nback_run-02_bold.nii"
+  "Sources": [
+    "bids:raw:sub-04/ses-02/sub-04_ses-02_task-nback_run-02_bold.nii"
   ],
   "TaskName": "N-Back",
   "RepetitionTime": 2.5

--- a/synthetic/derivatives/fmriprep/sub-04/ses-02/func/sub-04_ses-02_task-rest_space-MNI152NLin2009cAsym_desc-preproc_bold.json
+++ b/synthetic/derivatives/fmriprep/sub-04/ses-02/func/sub-04_ses-02_task-rest_space-MNI152NLin2009cAsym_desc-preproc_bold.json
@@ -1,6 +1,6 @@
 {
-  "RawSources": [
-    "sub-04/ses-02/sub-04_ses-02_task-rest_bold.nii"
+  "Sources": [
+    "bids:raw:sub-04/ses-02/sub-04_ses-02_task-rest_bold.nii"
   ],
   "TaskName": "Rest",
   "RepetitionTime": 2.5

--- a/synthetic/derivatives/fmriprep/sub-04/ses-02/func/sub-04_ses-02_task-rest_space-T1w_desc-preproc_bold.json
+++ b/synthetic/derivatives/fmriprep/sub-04/ses-02/func/sub-04_ses-02_task-rest_space-T1w_desc-preproc_bold.json
@@ -1,6 +1,6 @@
 {
-  "RawSources": [
-    "sub-04/ses-02/sub-04_ses-02_task-rest_bold.nii"
+  "Sources": [
+    "bids:raw:sub-04/ses-02/sub-04_ses-02_task-rest_bold.nii"
   ],
   "TaskName": "Rest",
   "RepetitionTime": 2.5

--- a/synthetic/derivatives/fmriprep/sub-05/ses-01/func/sub-05_ses-01_task-nback_run-01_space-MNI152NLin2009cAsym_desc-preproc_bold.json
+++ b/synthetic/derivatives/fmriprep/sub-05/ses-01/func/sub-05_ses-01_task-nback_run-01_space-MNI152NLin2009cAsym_desc-preproc_bold.json
@@ -1,6 +1,6 @@
 {
-  "RawSources": [
-    "sub-05/ses-01/sub-05_ses-01_task-nback_run-01_bold.nii"
+  "Sources": [
+    "bids:raw:sub-05/ses-01/sub-05_ses-01_task-nback_run-01_bold.nii"
   ],
   "TaskName": "N-Back",
   "RepetitionTime": 2.5

--- a/synthetic/derivatives/fmriprep/sub-05/ses-01/func/sub-05_ses-01_task-nback_run-01_space-T1w_desc-preproc_bold.json
+++ b/synthetic/derivatives/fmriprep/sub-05/ses-01/func/sub-05_ses-01_task-nback_run-01_space-T1w_desc-preproc_bold.json
@@ -1,6 +1,6 @@
 {
-  "RawSources": [
-    "sub-05/ses-01/sub-05_ses-01_task-nback_run-01_bold.nii"
+  "Sources": [
+    "bids:raw:sub-05/ses-01/sub-05_ses-01_task-nback_run-01_bold.nii"
   ],
   "TaskName": "N-Back",
   "RepetitionTime": 2.5

--- a/synthetic/derivatives/fmriprep/sub-05/ses-01/func/sub-05_ses-01_task-nback_run-02_space-MNI152NLin2009cAsym_desc-preproc_bold.json
+++ b/synthetic/derivatives/fmriprep/sub-05/ses-01/func/sub-05_ses-01_task-nback_run-02_space-MNI152NLin2009cAsym_desc-preproc_bold.json
@@ -1,6 +1,6 @@
 {
-  "RawSources": [
-    "sub-05/ses-01/sub-05_ses-01_task-nback_run-02_bold.nii"
+  "Sources": [
+    "bids:raw:sub-05/ses-01/sub-05_ses-01_task-nback_run-02_bold.nii"
   ],
   "TaskName": "N-Back",
   "RepetitionTime": 2.5

--- a/synthetic/derivatives/fmriprep/sub-05/ses-01/func/sub-05_ses-01_task-nback_run-02_space-T1w_desc-preproc_bold.json
+++ b/synthetic/derivatives/fmriprep/sub-05/ses-01/func/sub-05_ses-01_task-nback_run-02_space-T1w_desc-preproc_bold.json
@@ -1,6 +1,6 @@
 {
-  "RawSources": [
-    "sub-05/ses-01/sub-05_ses-01_task-nback_run-02_bold.nii"
+  "Sources": [
+    "bids:raw:sub-05/ses-01/sub-05_ses-01_task-nback_run-02_bold.nii"
   ],
   "TaskName": "N-Back",
   "RepetitionTime": 2.5

--- a/synthetic/derivatives/fmriprep/sub-05/ses-01/func/sub-05_ses-01_task-rest_space-MNI152NLin2009cAsym_desc-preproc_bold.json
+++ b/synthetic/derivatives/fmriprep/sub-05/ses-01/func/sub-05_ses-01_task-rest_space-MNI152NLin2009cAsym_desc-preproc_bold.json
@@ -1,6 +1,6 @@
 {
-  "RawSources": [
-    "sub-05/ses-01/sub-05_ses-01_task-rest_bold.nii"
+  "Sources": [
+    "bids:raw:sub-05/ses-01/sub-05_ses-01_task-rest_bold.nii"
   ],
   "TaskName": "Rest",
   "RepetitionTime": 2.5

--- a/synthetic/derivatives/fmriprep/sub-05/ses-01/func/sub-05_ses-01_task-rest_space-T1w_desc-preproc_bold.json
+++ b/synthetic/derivatives/fmriprep/sub-05/ses-01/func/sub-05_ses-01_task-rest_space-T1w_desc-preproc_bold.json
@@ -1,6 +1,6 @@
 {
-  "RawSources": [
-    "sub-05/ses-01/sub-05_ses-01_task-rest_bold.nii"
+  "Sources": [
+    "bids:raw:sub-05/ses-01/sub-05_ses-01_task-rest_bold.nii"
   ],
   "TaskName": "Rest",
   "RepetitionTime": 2.5

--- a/synthetic/derivatives/fmriprep/sub-05/ses-02/func/sub-05_ses-02_task-nback_run-01_space-MNI152NLin2009cAsym_desc-preproc_bold.json
+++ b/synthetic/derivatives/fmriprep/sub-05/ses-02/func/sub-05_ses-02_task-nback_run-01_space-MNI152NLin2009cAsym_desc-preproc_bold.json
@@ -1,6 +1,6 @@
 {
-  "RawSources": [
-    "sub-05/ses-02/sub-05_ses-02_task-nback_run-01_bold.nii"
+  "Sources": [
+    "bids:raw:sub-05/ses-02/sub-05_ses-02_task-nback_run-01_bold.nii"
   ],
   "TaskName": "N-Back",
   "RepetitionTime": 2.5

--- a/synthetic/derivatives/fmriprep/sub-05/ses-02/func/sub-05_ses-02_task-nback_run-01_space-T1w_desc-preproc_bold.json
+++ b/synthetic/derivatives/fmriprep/sub-05/ses-02/func/sub-05_ses-02_task-nback_run-01_space-T1w_desc-preproc_bold.json
@@ -1,6 +1,6 @@
 {
-  "RawSources": [
-    "sub-05/ses-02/sub-05_ses-02_task-nback_run-01_bold.nii"
+  "Sources": [
+    "bids:raw:sub-05/ses-02/sub-05_ses-02_task-nback_run-01_bold.nii"
   ],
   "TaskName": "N-Back",
   "RepetitionTime": 2.5

--- a/synthetic/derivatives/fmriprep/sub-05/ses-02/func/sub-05_ses-02_task-nback_run-02_space-MNI152NLin2009cAsym_desc-preproc_bold.json
+++ b/synthetic/derivatives/fmriprep/sub-05/ses-02/func/sub-05_ses-02_task-nback_run-02_space-MNI152NLin2009cAsym_desc-preproc_bold.json
@@ -1,6 +1,6 @@
 {
-  "RawSources": [
-    "sub-05/ses-02/sub-05_ses-02_task-nback_run-02_bold.nii"
+  "Sources": [
+    "bids:raw:sub-05/ses-02/sub-05_ses-02_task-nback_run-02_bold.nii"
   ],
   "TaskName": "N-Back",
   "RepetitionTime": 2.5

--- a/synthetic/derivatives/fmriprep/sub-05/ses-02/func/sub-05_ses-02_task-nback_run-02_space-T1w_desc-preproc_bold.json
+++ b/synthetic/derivatives/fmriprep/sub-05/ses-02/func/sub-05_ses-02_task-nback_run-02_space-T1w_desc-preproc_bold.json
@@ -1,6 +1,6 @@
 {
-  "RawSources": [
-    "sub-05/ses-02/sub-05_ses-02_task-nback_run-02_bold.nii"
+  "Sources": [
+    "bids:raw:sub-05/ses-02/sub-05_ses-02_task-nback_run-02_bold.nii"
   ],
   "TaskName": "N-Back",
   "RepetitionTime": 2.5

--- a/synthetic/derivatives/fmriprep/sub-05/ses-02/func/sub-05_ses-02_task-rest_space-MNI152NLin2009cAsym_desc-preproc_bold.json
+++ b/synthetic/derivatives/fmriprep/sub-05/ses-02/func/sub-05_ses-02_task-rest_space-MNI152NLin2009cAsym_desc-preproc_bold.json
@@ -1,6 +1,6 @@
 {
-  "RawSources": [
-    "sub-05/ses-02/sub-05_ses-02_task-rest_bold.nii"
+  "Sources": [
+    "bids:raw:sub-05/ses-02/sub-05_ses-02_task-rest_bold.nii"
   ],
   "TaskName": "Rest",
   "RepetitionTime": 2.5

--- a/synthetic/derivatives/fmriprep/sub-05/ses-02/func/sub-05_ses-02_task-rest_space-T1w_desc-preproc_bold.json
+++ b/synthetic/derivatives/fmriprep/sub-05/ses-02/func/sub-05_ses-02_task-rest_space-T1w_desc-preproc_bold.json
@@ -1,6 +1,6 @@
 {
-  "RawSources": [
-    "sub-05/ses-02/sub-05_ses-02_task-rest_bold.nii"
+  "Sources": [
+    "bids:raw:sub-05/ses-02/sub-05_ses-02_task-rest_bold.nii"
   ],
   "TaskName": "Rest",
   "RepetitionTime": 2.5


### PR DESCRIPTION
Closes #303 

I don't think we need to move all examples to use BIDS URIs (at least not all at once), what do you think? The old behavior stays valid (backward compatibility) after all.

In this PR, I touched 3 datasets:
- `7t_trt`, because it was easy to do
- `ieeg_filtered_speech`, because no "full data" exists for this dataset, so we can change it without having to mirror something back
- `ds000117`, ... here I started and stopped again, because a lot would need to be done, AND this dataset actually exists and is widely used, so we perhaps need to be more careful here.

This is what I changed (using regex search+replacement in VScode, limiting the search to the respective dataset via the "include" option):

#### 7t_trt

- search: `"IntendedFor": "ses-(\d)/func/sub-(\d\d)_ses-\d_task-rest_acq-fullbrain_run-(\d)_bold.nii.gz"`
- replace: `"IntendedFor": "bids::sub-$2/ses-$1/func/sub-$2_ses-$1_task-rest_acq-fullbrain_run-$3_bold.nii.gz"`
- update `dataset_description.json`


#### ieeg_filtered_speech

- search: `"IntendedFor": "/sub-(..\d+)/ieeg/sub-..\d+_photo.jpg"`
- replace: `"IntendedFor": "bids::sub-$1/ieeg/sub-$1_photo.jpg"`
- update `dataset_description.json`

#### ds000117

- fix fake arrays in emptyroom files `"a; b; c"` --> `["a", "b", "c"]`

#### ds000246

- manually replace `AssociatedEmptyRoom` fields with local BIDS URIs (=simply prepending `bids::` to the already-dataset-relative links and removing the leading slash after the `::`)

#### synthetic

replace `RawSources` with BIDS URIs via a `DatasetLinks` object in the derivatives `dataset_description.json`, using:

- search: `    "(sub-.+/ses-.+/sub-.+_ses-.+_task-.*_bold.nii")`
- replace: `    "bids:raw:$1`
- search: `"RawSources": \[`
- replace: `"Sources": [`

---
I also bumped the BIDSVersion of these datasets to 1.8.0, which will be the version that supports bids uris.

---

- [x] I think what would be good to do as well is to "deprecate" a few of the `RawSources` fields that we have in some examples, as mentioned in

- https://github.com/bids-standard/bids-examples/issues/303#issue-1105064298

~~Waiting for an answer on this thread to get started with that:~~

- https://github.com/bids-standard/bids-specification/pull/918#discussion_r790291925

- [x] Furthermore we should have the `AssociatedEmptyRoom` field in BIDS URIs in at least one dataset.
- [x] And have a `DatasetLinks` object in at least one `dataset_description.json`
    - Note that unfortunately this is only in a derivatives `dataset_description.json`, and derivatives are currently not validated. However I did not see any other dataset where I could have added this to the "raw" dataset description. So I think this is as good as it gets for now.

What else should we do before we can feel comfortable merging BIDS URIs into the BIDS specification? Suggestions?
