### PR TITLE
[FIX] change several qMRI examples `FieldStrength` to `MagneticFieldStrength`

### DIFF
--- a/qmri_mp2rage/sub-1/anat/sub-1_inv-1_MP2RAGE.json
+++ b/qmri_mp2rage/sub-1/anat/sub-1_inv-1_MP2RAGE.json
@@ -4,5 +4,5 @@
   "RepetitionTimeExcitation": 0.0062,
   "RepetitionTimePreparation": 5.5,
   "NumberShots": 159,
-  "FieldStrength": 7
+  "MagneticFieldStrength": 7
 }

--- a/qmri_mp2rage/sub-1/anat/sub-1_inv-2_MP2RAGE.json
+++ b/qmri_mp2rage/sub-1/anat/sub-1_inv-2_MP2RAGE.json
@@ -4,5 +4,5 @@
   "RepetitionTimeExcitation": 0.0062,
   "RepetitionTimePreparation": 5.5,
   "NumberShots": 159,
-  "FieldStrength": 7
+  "MagneticFieldStrength": 7
 }

--- a/qmri_mp2rageme/sub-1/anat/sub-1_echo-1_inv-2_MP2RAGE.json
+++ b/qmri_mp2rageme/sub-1/anat/sub-1_echo-1_inv-2_MP2RAGE.json
@@ -5,5 +5,5 @@
   "RepetitionTimePreparation": 6.723,
   "NumberShots": 150,
   "EchoTime": 0.006,
-  "FieldStrength": 7
+  "MagneticFieldStrength": 7
 }

--- a/qmri_mp2rageme/sub-1/anat/sub-1_echo-2_inv-2_MP2RAGE.json
+++ b/qmri_mp2rageme/sub-1/anat/sub-1_echo-2_inv-2_MP2RAGE.json
@@ -5,5 +5,5 @@
   "RepetitionTimePreparation": 6.723,
   "NumberShots": 150,
   "EchoTime": 0.0145,
-  "FieldStrength": 7
+  "MagneticFieldStrength": 7
 }

--- a/qmri_mp2rageme/sub-1/anat/sub-1_echo-3_inv-2_MP2RAGE.json
+++ b/qmri_mp2rageme/sub-1/anat/sub-1_echo-3_inv-2_MP2RAGE.json
@@ -5,5 +5,5 @@
   "RepetitionTimePreparation": 6.723,
   "NumberShots": 150,
   "EchoTime": 0.023,
-  "FieldStrength": 7
+  "MagneticFieldStrength": 7
 }

--- a/qmri_mp2rageme/sub-1/anat/sub-1_echo-4_inv-2_MP2RAGE.json
+++ b/qmri_mp2rageme/sub-1/anat/sub-1_echo-4_inv-2_MP2RAGE.json
@@ -5,5 +5,5 @@
   "RepetitionTimePreparation": 6.723,
   "NumberShots": 150,
   "EchoTime": 0.0315,
-  "FieldStrength": 7
+  "MagneticFieldStrength": 7
 }

--- a/qmri_mp2rageme/sub-1/anat/sub-1_inv-1_MP2RAGE.json
+++ b/qmri_mp2rageme/sub-1/anat/sub-1_inv-1_MP2RAGE.json
@@ -4,5 +4,5 @@
   "RepetitionTimeExcitation": 0.0062,
   "RepetitionTimePreparation": 6.723,
   "NumberShots": 150,
-  "FieldStrength": 7
+  "MagneticFieldStrength": 7
 }


### PR DESCRIPTION
Had not noticed that one.