### PR TITLE
Change fNIRS to NIRS

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ bids-examples (in alphabetical order).
 - [qMRI datasets](#qmri-datasets)
 - [PET datasets](#PET-datasets)
 - [Microscopy datasets](#microscopy-datasets)
-- [fNIRS datasets](#fnirs-datasets)
+- [NIRS datasets](#nirs-datasets)
 - [Multimodal datasets](#multimodal-datasets)
 
 ### EEG datasets
@@ -218,7 +218,7 @@ bids-examples (in alphabetical order).
 | micr_SPIM     | @jcohenadad   | Example SPIM dataset in OME-TIFF format with 2 samples from the same subject with 4 chunks each |
 
 
-### fNIRS datasets
+### NIRS datasets
 
 | name              | maintained by     | description                                                             | link to full data                       |
 | ----------------- | ----------------- | ----------------------------------------------------------------------- | --------------------------------------- |


### PR DESCRIPTION
Changes fNIRS to NIRS as discussed in https://github.com/bids-standard/bids-specification/pull/1325

Note, the dataset descriptions themselves are not changed, as these are functional experiments. Hopefully we can get some datasets that are not functional in the near future.