### PR TITLE
Added README file as required by BIDS schema

### DIFF
--- a/hcp_example_bids/README.md
+++ b/hcp_example_bids/README.md
@@ -1,0 +1,3 @@
+# Placeholder README file
+
+With `md` extension to diversify examples


### PR DESCRIPTION
5 other datasets also have missing README's (which [are required](https://github.com/bids-standard/bids-specification/blob/3270d01cfd1d3c359da4a458993b205a3d7950b5/src/schema/rules/files/common/core.yaml#L9)):

```console
chymera@decohost ~/src/bids-examples $ ls -d */ | wc -l
73
chymera@decohost ~/src/bids-examples $ ls */README* | wc -l
68
```

Should I add READMEs to all 5 datasets?