### PR TITLE
Add URLs to full data for microscopy datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,10 +222,10 @@ bids-examples (in alphabetical order).
 ### Microscopy datasets
 
 | name          | maintained by | description                                                                                     | link to full data |
-| ------------- | ------------- | ----------------------------------------------------------------------------------------------- | ----------------- |
-| micr_SEM      | @jcohenadad   | Example SEM dataset in PNG format with 1 sample imaged over 2 sessions                          |                   |
-| micr_SEMzarr  | @TheChymera   | Example SEM dataset in PNG and OME-ZARR format with 1 sample imaged over 2 sessions             |                   |
-| micr_SPIM     | @jcohenadad   | Example SPIM dataset in OME-TIFF format with 2 samples from the same subject with 4 chunks each |                   |
+| ------------- | ------------- | ----------------------------------------------------------------------------------------------- | -------------------------------------- |
+| micr_SEM      | @jcohenadad   | Example SEM dataset in PNG format with 1 sample imaged over 2 sessions                          | https://doi.org/10.5281/zenodo.5498378 |
+| micr_SEMzarr  | @TheChymera   | Example SEM dataset in PNG and OME-ZARR format with 1 sample imaged over 2 sessions             |                                                      |
+| micr_SPIM     | @jcohenadad   | Example SPIM dataset in OME-TIFF format with 2 samples from the same subject with 4 chunks each | https://doi.org/10.5281/zenodo.5517223 |
 
 
 ### NIRS datasets


### PR DESCRIPTION
This PR adds missing links to full data for 2 microscopy datasets. To be clear, these full datasets are not directly related to the dummy datasets  `micr_SEM` and `micr_SPIM`. However, they are BIDS-compliant and good examples of actual SEM/SPIM microscopy data.

Fixes #369 