### PR TITLE
FIX: Add truncated dseg.tsv files for validation

### DIFF
--- a/ds000001-fmriprep/desc-aparcaseg_dseg.tsv
+++ b/ds000001-fmriprep/desc-aparcaseg_dseg.tsv
@@ -1,0 +1,11 @@
+index	name	color
+0	"Unknown"	#000000
+1	"Left-Cerebral-Exterior"	#4682b4
+2	"Left-Cerebral-White-Matter"	#f5f5f5
+3	"Left-Cerebral-Cortex"	#cd3e4e
+4	"Left-Lateral-Ventricle"	#781286
+5	"Left-Inf-Lat-Vent"	#c43afa
+6	"Left-Cerebellum-Exterior"	#009400
+7	"Left-Cerebellum-White-Matter"	#dcf8a4
+8	"Left-Cerebellum-Cortex"	#e69422
+9	"Left-Thalamus-unused"	#00760e

--- a/ds000001-fmriprep/desc-aseg_dseg.tsv
+++ b/ds000001-fmriprep/desc-aseg_dseg.tsv
@@ -1,0 +1,11 @@
+index	name	color
+0	"Unknown"	#000000
+1	"Left-Cerebral-Exterior"	#4682b4
+2	"Left-Cerebral-White-Matter"	#f5f5f5
+3	"Left-Cerebral-Cortex"	#cd3e4e
+4	"Left-Lateral-Ventricle"	#781286
+5	"Left-Inf-Lat-Vent"	#c43afa
+6	"Left-Cerebellum-Exterior"	#009400
+7	"Left-Cerebellum-White-Matter"	#dcf8a4
+8	"Left-Cerebellum-Cortex"	#e69422
+9	"Left-Thalamus-unused"	#00760e


### PR DESCRIPTION
Using the ds000001-fmriprep dataset for testing the new schema-based validator, we currently get:

```console
  ┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ ds000001-fmriprep                                                                                                                 │
  └───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
    NOT_INCLUDED                               .SKIP_VALIDATION                                                                        
                                                                                                                                       
    TSV_COLUMN_MISSING                         desc-aparcaseg_dseg.tsv                    Columns cited as index columns not in        
                                                                                          file: index.                                 
                                                                                          schema.rules.tabular_data.derivatives.co     
                                                                                          mmon_derivatives.SegmentationLookup          
                                                                                                                                       
    JSON_KEY_REQUIRED                          sub-10_desc-aparcaseg_dseg.nii.gz          missing SkullStripped as per                 
                                                                                          schema.rules.sidecars.derivatives.common     
                                                                                          _derivatives.ImageDerivatives                
```