### PR TITLE
Require Node 18 for validation

### DIFF
--- a/.github/workflows/validate_datasets.yml
+++ b/.github/workflows/validate_datasets.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Set up Node.js
       uses: actions/setup-node@v3
       with:
-        node-version: 14
+        node-version: 18
 
     - name: Install BIDS validator (stable)
       if: "matrix.bids-validator == 'stable'"
@@ -47,7 +47,7 @@ jobs:
       run: |
         pushd ..
         # Get npm 7+
-        npm install -g npm@^7
+        npm install -g npm
         git clone --depth 1 https://github.com/bids-standard/bids-validator
         cd bids-validator
         # Generate the full development node_modules


### PR DESCRIPTION
Incorporating updates to the HED validator resulted in a dependency on Node 18.