### PR TITLE
[MAINT] check format 'IntendedFor' fields in json files

### DIFF
--- a/.github/workflows/check_intended_for.yml
+++ b/.github/workflows/check_intended_for.yml
@@ -1,0 +1,24 @@
+name: check intended for
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+on: [push, pull_request]
+
+jobs:
+    cehck_intended_for:
+        runs-on: ubuntu-latest
+        steps:
+            -   name: Checkout 🛎️
+                uses: actions/checkout@v3
+            -   uses: actions/setup-python@v4
+                with:
+                    python-version: "3.11"
+            -   name: Install dependencies 🔧
+                run: |
+                    python -m pip install --upgrade pip
+                    python -m pip install -r tools/requirements.txt
+
+            -   name: Run script 🚀
+                run: python tools/check_intended_for.py

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ env/
 *.asv
 
 site/
+
+deprecated_intended_for.log

--- a/ieeg_epilepsy/derivatives/brainvisa/dataset_description.json
+++ b/ieeg_epilepsy/derivatives/brainvisa/dataset_description.json
@@ -1,0 +1,5 @@
+{
+    "Name": "Brainvisa dertivatives",
+    "DatasetType": "derivative",
+    "BIDSVersion": "1.7.0"
+}

--- a/ieeg_epilepsyNWB/derivatives/brainvisa/dataset_description.json
+++ b/ieeg_epilepsyNWB/derivatives/brainvisa/dataset_description.json
@@ -1,0 +1,5 @@
+{
+    "Name": "Brainvisa dertivatives",
+    "DatasetType": "derivative",
+    "BIDSVersion": "1.7.0"
+}

--- a/tools/check_intended_for.py
+++ b/tools/check_intended_for.py
@@ -1,0 +1,71 @@
+"""Check jsons of all datasets for IntendedFor field.
+
+Make sure that the format is not one of the deprecated ones.
+
+https://bids-specification.readthedocs.io/en/latest/common-principles.html#bids-uri
+
+Example:
+
+- bad
+
+    .. code-block:: json
+
+        "IntendedFor": ["anat/sub-01_T1w.nii.gz"]
+
+
+- good
+
+    .. code-block:: json
+
+        "IntendedFor": ["bids::sub-01/anat/sub-01_T1w.nii.gz"]
+"""
+
+from pathlib import Path
+import json
+from warnings import warn
+from rich import print
+
+VERBOSE = False
+
+root_dir = Path(__file__).parent.parent
+
+deprecated_formats = {}
+
+for json_path in root_dir.glob("**/*.json"):
+
+    if VERBOSE:
+        print(f"Checking {json_path.relative_to(root_dir)}")
+
+    with open(json_path) as f:
+        content = json.load(f)
+
+    if "IntendedFor" in content:
+        intended_for = content["IntendedFor"]
+        if isinstance(intended_for, str):
+            intended_for = [intended_for]
+
+        for intended_for_path in intended_for:
+            if not intended_for_path.startswith("bids"):
+                if json_path not in deprecated_formats:
+                    deprecated_formats[json_path] = []
+                deprecated_formats[json_path].append(intended_for_path)
+
+if deprecated_formats:
+
+    log_file = root_dir / "deprecated_intended_for.log"
+
+    with open(log_file, "w") as f:
+        for json_path, deprecated_paths in deprecated_formats.items():
+            f.write(f"{json_path.relative_to(root_dir)}\n")
+            print(f"{json_path.relative_to(root_dir)}")
+            for deprecated_path in deprecated_paths:
+                f.write(f"  {deprecated_path}\n")
+                print(f"  {deprecated_path}")
+
+    raise(ValueError)(
+        f"Found {len(deprecated_formats)} jsons with deprecated IntendedFor formats.\n"
+        f"See {log_file}\n"
+        "Please update them to the new format.\n"
+        "See https://bids-specification.readthedocs.io/en/latest/common-principles.html#bids-uri"
+    )
+

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,3 +1,4 @@
 pybids  
 pandas
 tabulate
+rich


### PR DESCRIPTION
Preferably this should be the non deprecated format: https://bids-specification.readthedocs.io/en/latest/glossary.html#objects.metadata.IntendedFor

So adding a script to check that in CI.