### PR TITLE
Removed trial annotation from HED FacePerception_events.json example

### DIFF
--- a/eeg_ds003645s_hed/task-FacePerception_events.json
+++ b/eeg_ds003645s_hed/task-FacePerception_events.json
@@ -60,8 +60,7 @@
     }
   },
   "trial": {
-    "Description": "Indicates which trial this event belongs to.",
-    "HED": "Experimental-trial/#"
+    "Description": "Indicates which trial this event belongs to."
   },
   "rep_lag": {
     "Description": "How face images before this one was the image was previously presented.",

--- a/eeg_ds003645s_hed_inheritance/task-FacePerception_events.json
+++ b/eeg_ds003645s_hed_inheritance/task-FacePerception_events.json
@@ -43,8 +43,7 @@
     }
   },
   "trial": {
-    "Description": "Indicates which trial this event belongs to.",
-    "HED": "Experimental-trial/#"
+    "Description": "Indicates which trial this event belongs to."
   },
   "stim_file": {
     "Description": "Path of the stimulus file in the stimuli directory.",

--- a/eeg_ds003645s_hed_library/task-FacePerception_events.json
+++ b/eeg_ds003645s_hed_library/task-FacePerception_events.json
@@ -60,12 +60,11 @@
     }
   },
   "trial": {
-    "Description": "Indicates which trial this event belongs to.",
-    "HED": "Experimental-trial/#, test:Informational-property, sc:Discontinuous-background-activity"
+    "Description": "Indicates which trial this event belongs to."
   },
   "rep_lag": {
     "Description": "How face images before this one was the image was previously presented.",
-    "HED": "(Face, Item-interval/#)"
+    "HED": "(Face, Item-interval/#), test:Informational-property, sc:Discontinuous-background-activity"
   },
   "stim_file": {
     "Description": "Path of the stimulus file in the stimuli directory.",

--- a/eeg_ds003645s_hed_longform/task-FacePerception_events.json
+++ b/eeg_ds003645s_hed_longform/task-FacePerception_events.json
@@ -60,8 +60,7 @@
         }
     },
     "trial": {
-        "Description": "Indicates which trial this event belongs to.",
-        "HED": "Property/Organizational-property/Experimental-trial/#"
+        "Description": "Indicates which trial this event belongs to."
     },
     "rep_lag": {
         "Description": "How face images before this one was the image was previously presented.",


### PR DESCRIPTION
There is one event file in the HED examples that has two event consecutive event markers at exactly the same time. The `trial` column in the example was annotated as a value column, resulting in duplicate tags when event marker annotations over multiple rows corresponding to the same time are combined.  

The trial information can be correctly incorporated using the curly brace notation, but the hed-javascript validator's handling of this feature is still under development as is the detecting of errors when multiple rows in the `events.tsv` file have the same onset values.

Both types of errors are now detected by the hed-python validator, so we realized the need to correct the examples.