### PR TITLE
Added BEP032 example dataset

### DIFF
--- a/ephys_BEP032/README.md
+++ b/ephys_BEP032/README.md
@@ -1,0 +1,3 @@
+# Dataset Description
+
+Example dataset for BEP032 ( https://gin.g-node.org/NeuralEnsemble/BEP032-examples )

--- a/ephys_BEP032/dataset_description.json
+++ b/ephys_BEP032/dataset_description.json
@@ -1,0 +1,10 @@
+{
+  "LICENCE": "CC-by 4.0",
+  "Name": "Toy example dataset for patchclamp recordings in BIDS",
+  "BIDSVersion": "1.0.X",
+  "License": "CC BY 4.0",
+  "Authors": [
+    "Sprenger, Julia",
+    "Takerkart, Sylvain"
+  ]
+}

--- a/ephys_BEP032/participants.tsv
+++ b/ephys_BEP032/participants.tsv
@@ -1,0 +1,3 @@
+subject_id	species	strain	sex	age
+sub-20220101A	rattus norvegicus	C57BL/6J	male	30
+sub-20220101B	rattus norvegicus	C57BL/6J	female	30

--- a/ephys_BEP032/samples.json
+++ b/ephys_BEP032/samples.json
@@ -1,0 +1,8 @@
+{
+    "sample_type": {
+        "Description": "type of sample from ENCODE Biosample Type (https://www.encodeproject.org/profiles/biosample_type)",
+    },
+    "derived_from": {
+        "Description": "sample_id from which the sample is derived"
+    }
+}

--- a/ephys_BEP032/samples.tsv
+++ b/ephys_BEP032/samples.tsv
@@ -1,0 +1,6 @@
+sample_id	sample_type	participant_id	derived_from
+sample-tissue01	tissue	sub-20220101A	n/a
+sample-cell001	in vitro differentiated cells	sub-20220101A	sample-tissue01
+sample-tissue02	tissue	sub-20220101B	n/a
+sample-cell002	in vitro differentiated cells	sub-20220101B	sample-tissue02
+sample-cell003	in vitro differentiated cells	sub-20220101B	sample-tissue02

--- a/ephys_BEP032/sub-20220101A/ephys/sub-20220101A_channels.tsv
+++ b/ephys_BEP032/sub-20220101A/ephys/sub-20220101A_channels.tsv
@@ -1,0 +1,3 @@
+channel_id	contact_id	gain	type	unit	samping_frequency	sampling_frequency_unit	channel_name	hardware_filters	recording_mode
+chan-01	con-01	20	CAT	mV	30000	Hz	attached patch	LP_filter_1	current clamp
+chan-02	con-02	50	PP	mV	50000	Hz	perforated patch	LP_filter_2	current clamp

--- a/ephys_BEP032/sub-20220101A/ephys/sub-20220101A_contacts.tsv
+++ b/ephys_BEP032/sub-20220101A/ephys/sub-20220101A_contacts.tsv
@@ -1,0 +1,3 @@
+contact_id	probe_id	x	y	z	physical_unit	impedance	impedance_unit	contact_size	contact_shape	material	location	pipette_solution	internal_pipette_diameter	external_pipette_diameter
+con-01	probe-0234	0	0	0	um	5	GOhm	3	circular	glass	cortical layer 3	5% NaCl	2	4
+con-02	probe-0235	0	0	0	um	6.9	GOhm	4	circular	glass	cortical layer 3	5% NaCl	2	4

--- a/ephys_BEP032/sub-20220101A/ephys/sub-20220101A_ephys.json
+++ b/ephys_BEP032/sub-20220101A/ephys/sub-20220101A_ephys.json
@@ -1,19 +1,18 @@
 {
-    "InstitutionName": "Institute XY",
-    "Location": "Somewhere on the globe",
-    "PowerLineFrequency": 50,
-    "SamplingFrequency": 30000,
-    "SamplingFrequencyUnit": "Hz",
-    "Maintainer": "Charly C",
-    "SoftwareFilters": {
-      "LP_filter_1":{
-        "Half amplitude cutoff(Hz)": 0.0159,
-        "Roll-off":"6dB/Octave"
-      },
-      "LP_filter_2":{
-        "Half amplitude cutoff(Hz)": 0.1159,
-         "Roll-off":"9 dB/Octave"
-      }
+  "InstitutionName": "Institute XY",
+  "Location": "Somewhere on the globe",
+  "PowerLineFrequency": 50,
+  "SamplingFrequency": 30000,
+  "SamplingFrequencyUnit": "Hz",
+  "Maintainer": "Charly C",
+  "SoftwareFilters": {
+    "LP_filter_1":{
+      "Half amplitude cutoff(Hz)": 0.0159,
+      "Roll-off":"6dB/Octave"
+    },
+    "LP_filter_2":{
+      "Half amplitude cutoff(Hz)": 0.1159,
+       "Roll-off":"9 dB/Octave"
     }
   }
 }

--- a/ephys_BEP032/sub-20220101A/ephys/sub-20220101A_ephys.json
+++ b/ephys_BEP032/sub-20220101A/ephys/sub-20220101A_ephys.json
@@ -1,0 +1,19 @@
+{
+    "InstitutionName": "Institute XY",
+    "Location": "Somewhere on the globe",
+    "PowerLineFrequency": 50,
+    "SamplingFrequency": 30000,
+    "SamplingFrequencyUnit": "Hz",
+    "Maintainer": "Charly C",
+    "SoftwareFilters": {
+      "LP_filter_1":{
+        "Half amplitude cutoff(Hz)": 0.0159,
+        "Roll-off":"6dB/Octave"
+      },
+      "LP_filter_2":{
+        "Half amplitude cutoff(Hz)": 0.1159,
+         "Roll-off":"9 dB/Octave"
+      }
+    }
+  }
+}

--- a/ephys_BEP032/sub-20220101A/ephys/sub-20220101A_events.json
+++ b/ephys_BEP032/sub-20220101A/ephys/sub-20220101A_events.json
@@ -1,0 +1,11 @@
+{
+    "stim_type": {
+        "Description": "type of the stimulation (square pulse, sinusoid, ...)",
+    },
+    "stim_unit": {
+        "Description": "physical unit of the stimulation"
+    },
+    "stim_amplitude": {
+        "Description": "physical amplitude of the stimulation"
+    }
+}

--- a/ephys_BEP032/sub-20220101A/ephys/sub-20220101A_events.tsv
+++ b/ephys_BEP032/sub-20220101A/ephys/sub-20220101A_events.tsv
@@ -1,0 +1,5 @@
+onset	duration	trial_type	data_entity_id	channel_id	sample_id	response_time	stim_type	stim_unit	stim_amplitude
+1.23	0.65	start	62342cc5-fe7d-4eca-b702-404f9e7f2ccd	chan-01	sample-cell001	1.435	square pulse	1	mV
+5.65	0.65	stop	3aca136f-0851-4eb4-bb37-2070b9745537	chan-02	sample-cell001	1.739	square pulse	5	mV
+6.21	0.65	start	cd16b031-5288-42f5-9a7f-17de24eb1004	chan-01	sample-cell001	2.43	square pulse	10	uA
+15.65	0.65	stop	b35b9e87-d232-4cb3-9d6a-f8797c859c83	chan-02	sample-cell001	5.68	square pulse	45	uA

--- a/ephys_BEP032/sub-20220101A/ephys/sub-20220101A_probes.tsv
+++ b/ephys_BEP032/sub-20220101A/ephys/sub-20220101A_probes.tsv
@@ -1,0 +1,3 @@
+probe_id	type	x	y	z	xyz_position_unit	coordinate_space	coordinate_reference_point	contact_count	height	dimension_unit
+probe-0234	pipette	4	3	2	um	sample	cortical surface	1	5	cm
+probe-0235	pipette	4	3	1	um	sample	cortical surface	1	5	cm

--- a/ephys_BEP032/sub-20220101A/sub-20220101A_scans.tsv
+++ b/ephys_BEP032/sub-20220101A/sub-20220101A_scans.tsv
@@ -1,0 +1,2 @@
+filename	acq_time
+ephys/sub-20220101A_ephys.nwb	2022-01-01T10:00:00

--- a/ephys_BEP032/sub-20220101B/ephys/sub-20220101B_channels.tsv
+++ b/ephys_BEP032/sub-20220101B/ephys/sub-20220101B_channels.tsv
@@ -1,0 +1,4 @@
+channel_id	contact_id	gain	type	unit	samping_frequency	sampling_frequency_unit	channel_name	hardware_filters	recording_mode
+chan-01	con-01	20	WCP	mV	30000	Hz	whole cell patch	LP_filter_1	current clamp
+chan-02	con-02	15	CAT	mV	30000	Hz	cell attached patch	LP_filter_2	current clamp
+

--- a/ephys_BEP032/sub-20220101B/ephys/sub-20220101B_contacts.tsv
+++ b/ephys_BEP032/sub-20220101B/ephys/sub-20220101B_contacts.tsv
@@ -1,0 +1,4 @@
+contact_id	probe_id	x	y	z	physical_unit	impedance	impedance_unit	contact_size	contact_shape	material	location	pipette_solution	internal_pipette_diameter	external_pipette_diameter
+con-01	probe-0236	0	0	0	um	5	GOhm	3	circular	glass	cortical layer 3	7% NaCl	2.5	4
+con-02	probe-0237	0	0	0	um	4.5	GOhm	2.8	circular	glass	cortical layer 3	8% NaCl	2.2	3.5
+

--- a/ephys_BEP032/sub-20220101B/ephys/sub-20220101B_ephys.json
+++ b/ephys_BEP032/sub-20220101B/ephys/sub-20220101B_ephys.json
@@ -1,19 +1,18 @@
 {
-    "InstitutionName": "Institute XY",
-    "Location": "Somewhere on the globe",
-    "PowerLineFrequency": 50,
-    "SamplingFrequency": 30000,
-    "SamplingFrequencyUnit": "Hz",
-    "Maintainer": "Charly C",
-    "SoftwareFilters": {
-      "LP_filter_1":{
-        "Half amplitude cutoff(Hz)": 0.0159,
-        "Roll-off":"6dB/Octave"
-      },
-      "LP_filter_2":{
-        "Half amplitude cutoff(Hz)": 0.1159,
-         "Roll-off":"9 dB/Octave"
-      }
+  "InstitutionName": "Institute XY",
+  "Location": "Somewhere on the globe",
+  "PowerLineFrequency": 50,
+  "SamplingFrequency": 30000,
+  "SamplingFrequencyUnit": "Hz",
+  "Maintainer": "Charly C",
+  "SoftwareFilters": {
+    "LP_filter_1":{
+      "Half amplitude cutoff(Hz)": 0.0159,
+      "Roll-off":"6dB/Octave"
+    },
+    "LP_filter_2":{
+      "Half amplitude cutoff(Hz)": 0.1159,
+       "Roll-off":"9 dB/Octave"
     }
   }
 }

--- a/ephys_BEP032/sub-20220101B/ephys/sub-20220101B_ephys.json
+++ b/ephys_BEP032/sub-20220101B/ephys/sub-20220101B_ephys.json
@@ -1,0 +1,19 @@
+{
+    "InstitutionName": "Institute XY",
+    "Location": "Somewhere on the globe",
+    "PowerLineFrequency": 50,
+    "SamplingFrequency": 30000,
+    "SamplingFrequencyUnit": "Hz",
+    "Maintainer": "Charly C",
+    "SoftwareFilters": {
+      "LP_filter_1":{
+        "Half amplitude cutoff(Hz)": 0.0159,
+        "Roll-off":"6dB/Octave"
+      },
+      "LP_filter_2":{
+        "Half amplitude cutoff(Hz)": 0.1159,
+         "Roll-off":"9 dB/Octave"
+      }
+    }
+  }
+}

--- a/ephys_BEP032/sub-20220101B/ephys/sub-20220101B_events.json
+++ b/ephys_BEP032/sub-20220101B/ephys/sub-20220101B_events.json
@@ -1,0 +1,11 @@
+{
+    "stim_type": {
+        "Description": "type of the stimulation (square pulse, sinusoid, ...)",
+    },
+    "stim_unit": {
+        "Description": "physical unit of the stimulation"
+    },
+    "stim_amplitude": {
+        "Description": "physical amplitude of the stimulation"
+    }
+}

--- a/ephys_BEP032/sub-20220101B/ephys/sub-20220101B_events.tsv
+++ b/ephys_BEP032/sub-20220101B/ephys/sub-20220101B_events.tsv
@@ -1,0 +1,5 @@
+onset	duration	trial_id	trial_type	data_entity_id	channel_id	sample_id	response_time	stim_type	stim_unit	stim_amplitude
+5	4	start	d7614bcb-8f7d-43e6-879e-877bf227687c	chan-01		sample-cell002	2.5	square pulse	3	mV
+10	4	stop	0d6df00b-70c9-4785-bf0c-71a7acf39974	chan-01		sample-cell002	2.5	square pulse	3	mV
+15	4	start	025c20fc-05e6-401a-9620-95b5e9c9b4bc	chan-02		sample-cell003	3	square pulse	3.3	mV
+20	4	stop	1fad915b-c2c6-46aa-9755-a7454805f6fc	chan-02		sample-cell003	3	square pulse	3.3	mV

--- a/ephys_BEP032/sub-20220101B/ephys/sub-20220101B_probes.tsv
+++ b/ephys_BEP032/sub-20220101B/ephys/sub-20220101B_probes.tsv
@@ -1,0 +1,3 @@
+probe_id	type	x	y	z	xyz_position_unit	coordinate_space	coordinate_reference_point	contact_count	height	dimension_unit
+probe-0236	pipette	2	4	1	um	sample	cortical surface	1	5	cm
+probe-0237	pipette	2	4	0	um	sample	cortical surface	1	5	cm

--- a/ephys_BEP032/sub-20220101B/sub-20220101B_scans.tsv
+++ b/ephys_BEP032/sub-20220101B/sub-20220101B_scans.tsv
@@ -1,0 +1,2 @@
+filename	acq_time
+ephys/sub-20220101B_ephys.nwb	2022-01-01T15:00:00


### PR DESCRIPTION
So as I submitted this pull request, I saw we already have a [BEP032 branch](https://github.com/bids-standard/bids-examples/tree/bep032). Is that the same thing but with a more up-to-date example? That one seems to be dealing with an eeg face perception dataset though 🤔

```console
[deco]~/src/bids-examples ❱ git diff bep032 master --name-only | head -10
README.md
dataset_listing.tsv
eeg_ds003645s_hed/README
eeg_ds003645s_hed/dataset_description.json
eeg_ds003645s_hed/participants.json
eeg_ds003645s_hed/participants.tsv
eeg_ds003645s_hed/sub-002/eeg/sub-002_task-FacePerception_run-1_events.tsv
eeg_ds003645s_hed/sub-002/eeg/sub-002_task-FacePerception_run-2_events.tsv
eeg_ds003645s_hed/sub-002/eeg/sub-002_task-FacePerception_run-3_events.tsv
eeg_ds003645s_hed/sub-003/eeg/sub-003_task-FacePerception_run-1_events.tsv
[deco]~/src/bids-examples ❱ git diff bep032 master --name-only | rg ephys€
[deco]~/src/bids-examples ❱
```

@effigies 