### PR TITLE
Fixup and enhance invocation of run_tests.sh

### DIFF
--- a/.github/workflows/validate_datasets.yml
+++ b/.github/workflows/validate_datasets.yml
@@ -86,5 +86,5 @@ jobs:
     - name: Validate all BIDS datasets using bids-validator
       run: |
         cat ./run_tests.sh
-        bash ./run_tests.sh
+        ./run_tests.sh
       shell: bash

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ script that is provided in this repository. This script makes use of the
 handles some special case examples (see
 [Validator Exceptions](#validator-exceptions)).
 
-Simply run `bash run_tests.sh` in a command line from the root of the
+Simply run `./run_tests.sh` in a command line from the root of the
 `bids-examples` repository.
 
 ### Validator exceptions

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-rc = 0;
+rc=0;
 for i in $(ls -d */ | grep -v node_modules); do
     echo "Validating dataset" $i
 


### PR DESCRIPTION
ATM it would complain that rc is not legit command due to all those spaces. Because no set -e used it just continues.

Also made it executable and adjusted shebang to be universaly working. There should be no need to invoke directly via bash -- shebang would do that

Script likely worked correctly anyways since there is explicit `exit $rc` so if `$rc` remained undefined and no failed validator runs, it was just `exit` - clean exit?