### PR TITLE
Fix a few participants.tsv files

### DIFF
--- a/ds000246/participants.tsv
+++ b/ds000246/participants.tsv
@@ -1,4 +1,3 @@
 participant_id	age	sex	dominant_hand
 sub-emptyroom	n/a	n/a	n/a
 sub-0001	25	Male	Right
-

--- a/ieeg_epilepsy/participants.tsv
+++ b/ieeg_epilepsy/participants.tsv
@@ -1,2 +1,2 @@
 participant_id	age	sex
-sub-01	XX	m
+sub-01	n/a	m

--- a/ieeg_epilepsyNWB/participants.tsv
+++ b/ieeg_epilepsyNWB/participants.tsv
@@ -1,2 +1,2 @@
 participant_id	age	sex
-sub-01	XX	m
+sub-01	n/a	m


### PR DESCRIPTION
A handy tool I discovered, to e.g. find all values which are not numeric

```
$ for f in */participants.tsv; do echo $f; mlr --itsv --otsv cut -f age $f; done
```

to just dump all the file names and their values for age if any

```
❯ mlr --itsv --otsv filter 'string($age) =~ "[^0-9]"' cut -f age ds000117/participants.tsv
participant_id	age	sex	first_ses
sub-emptyroom	n/a	n/a	n/a

```
to dump those which are not numeric in a particular file