### PR TITLE
Remove SKIP_VALIDATION from datasets the deno validator can handle

### DIFF
--- a/.github/workflows/validate_datasets.yml
+++ b/.github/workflows/validate_datasets.yml
@@ -103,12 +103,6 @@ jobs:
         fi
       shell: bash
 
-    - name: Mark to be skipped some examples for a deno based
-      if: "matrix.bids-validator == 'master-deno'"
-      run: |
-        touch {ds000117,ds000246,ds000247,ds000248,eeg_ds003645s_hed_demo,ieeg_motorMiller2007,ieeg_visual,7t_trt,ds102,fnirs_automaticity,genetics_ukbb,ieeg_epilepsy,ieeg_epilepsyNWB}/.SKIP_VALIDATION
-      shell: bash
-
     - name: Validate all BIDS datasets using bids-validator
       run: |
         cat ./run_tests.sh


### PR DESCRIPTION
As of https://github.com/bids-standard/bids-validator/pull/1987, these should no longer raise errors.