### PR TITLE
FIX: Remove empty/`n/a` entries from dataset_description.json

### DIFF
--- a/ieeg_epilepsy_ecog/dataset_description.json
+++ b/ieeg_epilepsy_ecog/dataset_description.json
@@ -10,11 +10,5 @@
     "License": "Property of the Epilepsy Centre, University Hospital Freiburg, Germany",
     "ReferencesAndLinks": [
         "https://neuroimage.usc.edu/brainstorm/Tutorials/ECoG"
-    ],
-    "Acknowledgements": "n/a",
-    "HowToAcknowledge": "n/a",
-    "Funding": [],
-	"EthicsApprovals": [],
-    "DatasetDOI": "n/a",
-	"HEDVersion": "n/a"
+    ]
 }


### PR DESCRIPTION
I believe this the reason that https://github.com/bids-standard/bids-validator/pull/2014 is failing. In any case, there's no advantage to having optional keys with empty or invalid contents.