### PR TITLE
fix(7t_trt): Define handedness column to match numeric values

### DIFF
--- a/7t_trt/participants.json
+++ b/7t_trt/participants.json
@@ -17,5 +17,9 @@
   "age_at_first_scan_years": {
     "LongName": "age_at_first_scan_years",
     "Units": "years"
+  },
+  "handedness": {
+    "LongName": "Edinburgh Handedness Inventory",
+    "Units": "arbitrary"
   }
 }


### PR DESCRIPTION
participants.tsv contains numeric values. The [Edinburgh Handedness Inventory](https://www.physio-pedia.com/Edinburgh_Handedness_Inventory_(EHI)) seems a likely source for these values. In any event, they do not match the BIDS default definition of "right", "left" and "ambidextrous".