### PR TITLE
ci: Test on both main and dev validator branches

### DIFF
--- a/.github/workflows/validate_datasets.yml
+++ b/.github/workflows/validate_datasets.yml
@@ -100,12 +100,16 @@ jobs:
       if: matrix.bids-validator == 'legacy'
       shell: bash
 
+    - name: Set BIDS_SCHEMA variable for dev version
+      if: matrix.bids-validator == 'dev'
+      # When proposing new features, schema changes may be necessary.
+      # Update this URL to the schema.json from PRs to the spec, when needed.
+      # If this variable is unset, dev will generally track the latest development
+      # release of https://jsr.io/@bids/schema
+      run: echo BIDS_SCHEMA=https://bids-specification.readthedocs.io/en/latest/schema.json >> $GITHUB_ENV
+
     - name: Validate all BIDS datasets using bids-validator
       run: |
         cat ./run_tests.sh
         ./run_tests.sh
       shell: bash
-      env:
-        # When proposing new features, schema changes may be necessary.
-        # Update this URL to the schema.json from PRs to the spec, when needed.
-        BIDS_SCHEMA: https://bids-specification.readthedocs.io/en/latest/schema.json

--- a/.github/workflows/validate_datasets.yml
+++ b/.github/workflows/validate_datasets.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        bids-validator: [stable, dev, legacy]
+        bids-validator: [stable, main, dev, legacy]
 
     runs-on: ${{ matrix.platform }}
 
@@ -49,12 +49,20 @@ jobs:
           deno install -Agf -n bids-validator jsr:@bids/validator
       shell: bash
 
-    - name: Install BIDS validator (dev)
-      if: matrix.bids-validator == 'dev'
+    - name: Install BIDS validator (main)
+      if: matrix.bids-validator == 'main'
       run: |
         # If unmerged validator PRs are needed for testing, you can use
         # https://github.com/<FORK>/bids-validator/raw/<BRANCH>/bids-validator/src/bids-validator.ts
         deno install -Agf https://github.com/bids-standard/bids-validator/raw/deno-build/bids-validator.js
+      shell: bash
+
+    - name: Install BIDS validator (dev)
+      if: matrix.bids-validator == 'dev'
+      run: |
+        git clone -b dev https://github.com/bids-standard/bids-validator/ ../bids-validator
+        cd ../bids-validator
+        deno compile -A -o $HOME/.deno/bin/bids-validator src/bids-validator.ts
       shell: bash
 
     - name: Install BIDS validator (legacy)

--- a/.github/workflows/validate_datasets.yml
+++ b/.github/workflows/validate_datasets.yml
@@ -95,9 +95,14 @@ jobs:
         fi
       shell: bash
 
-    - name: Skip MRS validation for legacy validator
+    - name: Skip legacy validation for post-legacy datasets
       run: for DS in mrs_* dwi_deriv; do touch $DS/.SKIP_VALIDATION; done
       if: matrix.bids-validator == 'legacy'
+      shell: bash
+
+    - name: Skip stable validation for datasets with unreleased features
+      run: for DS in dwi_deriv; do touch $DS/.SKIP_VALIDATION; done
+      if: matrix.bids-validator != 'dev'
       shell: bash
 
     - name: Set BIDS_SCHEMA variable for dev version


### PR DESCRIPTION
The bids-validator is going to start diverging its `main` and `dev` branches. The idea with `main` is to continue to target the latest BIDS release, while `dev` will include changes proposed for upcoming releases.