### PR TITLE
fix: Update missing metadata to qMRI sequences

### DIFF
--- a/qmri_irt1/IRT1.json
+++ b/qmri_irt1/IRT1.json
@@ -3,7 +3,7 @@
   "Manufacturer": "Siemens",
   "ManufacturerModelName": "Skyra",
   "PulseSequenceType": "IR",
-  "RepetitionTime": 2.550,
+  "RepetitionTimeExcitation": 2.550,
   "FlipAngle": 3,
   "EchoTime": 0.014
 }

--- a/qmri_irt1/derivatives/qMRLab/sub-01/anat/sub-01_M0map.json
+++ b/qmri_irt1/derivatives/qMRLab/sub-01/anat/sub-01_M0map.json
@@ -9,7 +9,7 @@
   "Manufacturer": "Siemens",
   "ManufacturerModelName": "Skyra",
   "PulseSequenceType": "IR",
-  "RepetitionTime": "2.250",
+  "RepetitionTimeExcitation": "2.250",
   "EchoTime": "0.014",
   "InversionTime": ["0.05","0.4","1.1","2.5"],
   "EstimationPaper": "Barral et. al.MRM, 2010",

--- a/qmri_irt1/derivatives/qMRLab/sub-01/anat/sub-01_T1map.json
+++ b/qmri_irt1/derivatives/qMRLab/sub-01/anat/sub-01_T1map.json
@@ -9,7 +9,7 @@
   "Manufacturer": "Siemens",
   "ManufacturerModelName": "Skyra",
   "PulseSequenceType": "IR",
-  "RepetitionTime": "2.250",
+  "RepetitionTimeExcitation": "2.250",
   "EchoTime": "0.014",
   "InversionTime": ["0.05","0.4","1.1","2.5"],
   "EstimationPaper": "Barral et. al.MRM, 2010",

--- a/qmri_mpm/derivatives/hmri/sub-01/anat/sub-01_MTsat.json
+++ b/qmri_mpm/derivatives/hmri/sub-01/anat/sub-01_MTsat.json
@@ -36,7 +36,7 @@
   "ScanningSequence": "RM",
   "SequenceVariant": "SP",
   "SequenceName": "fl3d_1i3d8",
-  "RepetitionTime": "0.025",
+  "RepetitionTimeExcitation": "0.025",
   "FlipAngle": [
     "6",
     "21"

--- a/qmri_mpm/derivatives/hmri/sub-01/anat/sub-01_R1map.json
+++ b/qmri_mpm/derivatives/hmri/sub-01/anat/sub-01_R1map.json
@@ -36,7 +36,7 @@
   "ScanningSequence": "RM",
   "SequenceVariant": "SP",
   "SequenceName": "fl3d_1i3d8",
-  "RepetitionTime": "0.025",
+  "RepetitionTimeExcitation": "0.025",
   "FlipAngle": [
     "6",
     "21"

--- a/qmri_mpm/derivatives/hmri/sub-01/anat/sub-01_R2starmap.json
+++ b/qmri_mpm/derivatives/hmri/sub-01/anat/sub-01_R2starmap.json
@@ -36,7 +36,7 @@
   "ScanningSequence": "RM",
   "SequenceVariant": "SP",
   "SequenceName": "fl3d_1i3d8",
-  "RepetitionTime": "0.025",
+  "RepetitionTimeExcitation": "0.025",
   "FlipAngle": [
     "6",
     "21"

--- a/qmri_mtsat/derivatives/qMRLab/sub-01/anat/sub-01_M0map.json
+++ b/qmri_mtsat/derivatives/qMRLab/sub-01/anat/sub-01_M0map.json
@@ -8,7 +8,7 @@
     "Manufacturer": "Siemens",
     "ManufacturerModelName": "TrioTim",
     "PulseSequenceType": "SPGR",
-    "RepetitionTime": 0.028,
+    "RepetitionTimeExcitation": 0.028,
     "FlipAngle": ["6","6","20"],
     "MTState": [false,false,true],
     "EstimationPaper": "Helms et al. MRM, 2008",

--- a/qmri_mtsat/derivatives/qMRLab/sub-01/anat/sub-01_MTRmap.json
+++ b/qmri_mtsat/derivatives/qMRLab/sub-01/anat/sub-01_MTRmap.json
@@ -7,7 +7,7 @@
     "Manufacturer": "Siemens",
     "ManufacturerModelName": "TrioTim",
     "PulseSequenceType": "SPGR",
-    "RepetitionTime": 0.028,
+    "RepetitionTimeExcitation": 0.028,
     "FlipAngle": "6",
     "MTState": [false, true],
     "EstimationPaper": "Helms et al. MRM, 2008",

--- a/qmri_mtsat/derivatives/qMRLab/sub-01/anat/sub-01_MTsat.json
+++ b/qmri_mtsat/derivatives/qMRLab/sub-01/anat/sub-01_MTsat.json
@@ -8,7 +8,7 @@
     "Manufacturer": "Siemens",
     "ManufacturerModelName": "TrioTim",
     "PulseSequenceType": "SPGR",
-    "RepetitionTime": 0.028,
+    "RepetitionTimeExcitation": 0.028,
     "FlipAngle": ["6","6","20"],
     "MTState": [false,false,true],
     "EstimationPaper": "Helms et al. MRM, 2008",

--- a/qmri_mtsat/derivatives/qMRLab/sub-01/anat/sub-01_T1map.json
+++ b/qmri_mtsat/derivatives/qMRLab/sub-01/anat/sub-01_T1map.json
@@ -8,7 +8,7 @@
     "Manufacturer": "Siemens",
     "ManufacturerModelName": "TrioTim",
     "PulseSequenceType": "SPGR",
-    "RepetitionTime": 0.028,
+    "RepetitionTimeExcitation": 0.028,
     "FlipAngle": ["6","6","20"],
     "MTState": [false,false,true],
     "EstimationPaper": "Helms et al. MRM, 2008",

--- a/qmri_mtsat/sub-01/anat/sub-01_flip-1_mt-off_MTS.json
+++ b/qmri_mtsat/sub-01/anat/sub-01_flip-1_mt-off_MTS.json
@@ -1,5 +1,5 @@
 {
   "FlipAngle": 6,
   "MTState": false,
-  "RepetitionTime": 0.028
+  "RepetitionTimeExcitation": 0.028
 }

--- a/qmri_mtsat/sub-01/anat/sub-01_flip-1_mt-on_MTS.json
+++ b/qmri_mtsat/sub-01/anat/sub-01_flip-1_mt-on_MTS.json
@@ -1,5 +1,5 @@
 {
   "FlipAngle": 6,
   "MTState": true,
-  "RepetitionTime": 0.028
+  "RepetitionTimeExcitation": 0.028
 }

--- a/qmri_mtsat/sub-01/anat/sub-01_flip-2_mt-off_MTS.json
+++ b/qmri_mtsat/sub-01/anat/sub-01_flip-2_mt-off_MTS.json
@@ -1,5 +1,5 @@
 {
   "FlipAngle": 20,
   "MTState": false,
-  "RepetitionTime": 0.028
+  "RepetitionTimeExcitation": 0.028
 }

--- a/qmri_sa2rage/sub-01/fmap/sub-01_flip-1_inv-1_TB1SRGE.json
+++ b/qmri_sa2rage/sub-01/fmap/sub-01_flip-1_inv-1_TB1SRGE.json
@@ -32,6 +32,7 @@
   "InstitutionName": "Robarts_Reserch_Institute",
   "InstitutionalDepartmentName": "Department",
   "InversionTime": 45,
+  "NumberShots": 1,
   "MRAcquisitionType": "3D",
   "MagneticFieldStrength": 6.98,
   "Manufacturer": "Siemens",

--- a/qmri_sa2rage/sub-01/fmap/sub-01_flip-2_inv-2_TB1SRGE.json
+++ b/qmri_sa2rage/sub-01/fmap/sub-01_flip-2_inv-2_TB1SRGE.json
@@ -49,7 +49,6 @@
   "ReceiveCoilName": "CFMM_8Tx32Rx",
   "ReconMatrixPE": 128,
   "RefLinesPE": 30,
-  "RepetitionTime": 2.4,
   "ScanOptions": "SR_PFP",
   "ScanningSequence": "GR",
   "SequenceName": "sa2rage3d1_ns",

--- a/qmri_sa2rage/sub-01/fmap/sub-01_flip-2_inv-2_TB1SRGE.json
+++ b/qmri_sa2rage/sub-01/fmap/sub-01_flip-2_inv-2_TB1SRGE.json
@@ -3,6 +3,7 @@
   "RepetitionTimeExcitation": 0.0275,
   "InversionTime": 1.8,
   "FlipAngle": 11,
+  "NumberShots": 1,
   "AcquisitionMatrixPE": 128,
   "AcquisitionNumber": 1,
   "AcquisitionTime": "16:14:17.007500",

--- a/qmri_tb1tfl/sub-01/fmap/sub-01_acq-anat_TB1TFL.json
+++ b/qmri_tb1tfl/sub-01/fmap/sub-01_acq-anat_TB1TFL.json
@@ -4,7 +4,7 @@
   "ManufacturerModelName": "TrioTim",
   "PulseSequenceType": "GR",
   "SequenceName": "tfl_b1_map",
-  "RepetitionTime": "6.8",
+  "RepetitionTimeExcitation": "6.8",
   "FlipAngle": 38,
   "EchoTime": 1.97,
   "AcquisitionVoxelSize": ["3","3","5"]

--- a/qmri_tb1tfl/sub-01/fmap/sub-01_acq-famp_TB1TFL.json
+++ b/qmri_tb1tfl/sub-01/fmap/sub-01_acq-famp_TB1TFL.json
@@ -4,7 +4,7 @@
   "ManufacturerModelName": "TrioTim",
   "PulseSequenceType": "GR",
   "SequenceName": "tfl_b1_map",
-  "RepetitionTime": "6.8",
+  "RepetitionTimeExcitation": "6.8",
   "FlipAngle": 38,
   "EchoTime": 1.97,
   "AcquisitionVoxelSize": ["3","3","5"]

--- a/qmri_vfa/VFA.json
+++ b/qmri_vfa/VFA.json
@@ -3,5 +3,5 @@
   "Manufacturer": "Siemens",
   "ManufacturerModelName": "TrioTim",
   "PulseSequenceType": "SPGR",
-  "RepetitionTime": 0.0150
+  "RepetitionTimeExcitation": 0.0150
 }

--- a/qmri_vfa/derivatives/qMRLab/sub-01/anat/sub-01_M0map.json
+++ b/qmri_vfa/derivatives/qMRLab/sub-01/anat/sub-01_M0map.json
@@ -8,7 +8,7 @@
   "Manufacturer": "Siemens",
   "ManufacturerModelName": "TrioTim",
   "PulseSequenceType": "SPGR",
-  "RepetitionTime": 0.0150,
+  "RepetitionTimeExcitation": 0.0150,
   "FlipAngle": [
     "3",
     "20"

--- a/qmri_vfa/derivatives/qMRLab/sub-01/anat/sub-01_T1map.json
+++ b/qmri_vfa/derivatives/qMRLab/sub-01/anat/sub-01_T1map.json
@@ -8,7 +8,7 @@
   "Manufacturer": "Siemens",
   "ManufacturerModelName": "TrioTim",
   "PulseSequenceType": "SPGR",
-  "RepetitionTime": 0.0150,
+  "RepetitionTimeExcitation": 0.0150,
   "FlipAngle": [
     "3",
     "20"

--- a/qmri_vfa/derivatives/qMRLab/sub-01/fmap/sub-01_TB1map.json
+++ b/qmri_vfa/derivatives/qMRLab/sub-01/fmap/sub-01_TB1map.json
@@ -10,7 +10,7 @@
     "ManufacturerModelName": "Skyra",
     "MRAcquisitionType": "3D",
     "PulseSequenceType": "SPGR",
-    "RepetitionTime": [0.02,0.1],
+    "RepetitionTimeExcitation": [0.02,0.1],
     "SpoilingState": true,
     "SpoilingType": "COMBINED",
     "SpoilingGradientMoment": [0.540,2.250],

--- a/qmri_vfa/sub-01/anat/sub-01_flip-1_VFA.json
+++ b/qmri_vfa/sub-01/anat/sub-01_flip-1_VFA.json
@@ -1,4 +1,4 @@
 {
   "FlipAngle": 3,
-  "RepetitionTime": 0.0150
+  "RepetitionTimeExcitation": 0.0150
 }

--- a/qmri_vfa/sub-01/anat/sub-01_flip-2_VFA.json
+++ b/qmri_vfa/sub-01/anat/sub-01_flip-2_VFA.json
@@ -1,4 +1,4 @@
 {
   "FlipAngle": 20,
-  "RepetitionTime": 0.0150
+  "RepetitionTimeExcitation": 0.0150
 }

--- a/qmri_vfa/sub-01/fmap/sub-01_acq-tr1_TB1AFI.json
+++ b/qmri_vfa/sub-01/fmap/sub-01_acq-tr1_TB1AFI.json
@@ -5,7 +5,7 @@
     "ManufacturerModelName": "Skyra",
     "MRAcquisitionType": "3D",
     "PulseSequenceType": "SPGR",
-    "RepetitionTime": 0.02,
+    "RepetitionTimeExcitation": 0.02,
     "SpoilingState": true,
     "SpoilingType": "COMBINED",
     "SpoilingGradientMoment": 0.540,

--- a/qmri_vfa/sub-01/fmap/sub-01_acq-tr2_TB1AFI.json
+++ b/qmri_vfa/sub-01/fmap/sub-01_acq-tr2_TB1AFI.json
@@ -5,7 +5,7 @@
     "ManufacturerModelName": "Skyra",
     "MRAcquisitionType": "3D",
     "PulseSequenceType": "SPGR",
-    "RepetitionTime": 0.1,
+    "RepetitionTimeExcitation": 0.1,
     "SpoilingState": true,
     "SpoilingType": "COMBINED",
     "SpoilingGradientMoment": 2.250,


### PR DESCRIPTION
After merging https://github.com/bids-standard/bids-specification/pull/2020, attempting to update the schema for the validator produces:

```
  ┌─────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ qmri_mtsat                                                                                                      │
  └─────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
    SIDECAR_KEY_REQUIRED -               /sub-01/anat/sub-01_flip-1_mt-off_MTS.ni                                    
    RepetitionTimeExcitation             i.gz                                                                        
                                                                                                                     
    SIDECAR_KEY_REQUIRED -               /sub-01/anat/sub-01_flip-1_mt-on_MTS.nii                                    
    RepetitionTimeExcitation             .gz                                                                         
                                                                                                                     
    SIDECAR_KEY_REQUIRED -               /sub-01/anat/sub-01_flip-2_mt-off_MTS.ni                                    
    RepetitionTimeExcitation             i.gz                                                                        
  ┌─────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ qmri_sa2rage                                                                                                    │
  └─────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
    SIDECAR_KEY_REQUIRED - NumberShots   /sub-01/fmap/sub-01_flip-1_inv-1_TB1SRGE                                    
                                         .nii.gz                                                                     
                                                                                                                     
    SIDECAR_KEY_REQUIRED - NumberShots   /sub-01/fmap/sub-01_flip-2_inv-2_TB1SRGE                                    
                                         .nii.gz                                                                     
  ┌─────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ qmri_vfa                                                                                                        │
  └─────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
    SIDECAR_KEY_REQUIRED -               /sub-01/anat/sub-01_flip-1_VFA.nii.gz                                       
    RepetitionTimeExcitation                                                                                         
                                                                                                                     
    SIDECAR_KEY_REQUIRED -               /sub-01/anat/sub-01_flip-2_VFA.nii.gz                                       
    RepetitionTimeExcitation                                                                                         
                                                                                                                     
    SIDECAR_KEY_REQUIRED -               /sub-01/fmap/sub-01_acq-tr1_TB1AFI.nii.g                                    
    RepetitionTimeExcitation             z                                                                           
                                                                                                                     
    SIDECAR_KEY_REQUIRED -               /sub-01/fmap/sub-01_acq-tr2_TB1AFI.nii.g                                    
    RepetitionTimeExcitation             z  
```

In most cases, the problem is that `RepetitionTime` is used instead of `RepetitionTimeExcitation` in qMRI sequences. I updated across the board, even for those where it is not a required field.

For `qmri_sa2rage`, the `NumberShots` field is required, but absent. I don't know how to derive it; there's nothing in the paper (doi:[10.1002/mrm.23145](https://doi.org/10.1002/mrm.23145)), so I just set it to 1.

@agahkarakuzu @ChristophePhillips This affects examples you've provided. Can you please review these changes?