### PR TITLE
[BEP028] provenance - dcm2niix conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,3 +362,14 @@ DO NOT EDIT DIRECTLY.
 | name                                                                            | description                                                      | datatypes       | suffixes   | link to full data   | maintained by                            |
 |:--------------------------------------------------------------------------------|:-----------------------------------------------------------------|:----------------|:-----------|:--------------------|:-----------------------------------------|
 | [pheno004](https://github.com/bids-standard/bids-examples/tree/master/pheno004) | Minimal dataset with subjects with imaging and/or phenotype data | phenotype, anat | T1w        | n/a                 | [@ericearl](https://github.com/ericearl) |
+
+### Provenance
+
+<!--
+TABLE BELOW IS GENERATED AUTOMATICALLY.
+DO NOT EDIT DIRECTLY.
+-->
+
+| name                                                                                                  | description                                                                                                                                   | datatypes   | suffixes                 | link to full data                                                                               | maintained by                          |
+|:------------------------------------------------------------------------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------|:------------|:-------------------------|:------------------------------------------------------------------------------------------------|:---------------------------------------|
+| [provenance_dcm2niix](https://github.com/bids-standard/bids-examples/tree/master/provenance_dcm2niix) | Shows minimal example of provenance records for a DICOM to Nifti conversion, performed by [`dcm2niix`](https://github.com/rordenlab/dcm2niix) | anat        | T1w, act, ent, env, soft | This example is buid upon [hirni-demo](https://github.com/psychoinformatics-de/hirni-demo) data | [@bclenet](https://github.com/bclenet) |

--- a/dataset_listing.tsv
+++ b/dataset_listing.tsv
@@ -83,3 +83,4 @@ mrs_fmrs	Functional MRS data involving a pain stimulus task from 15 subjects	[li
 xeeg_hed_score	EEG and iEEG data with annotations of artifacts, seizures and modulators using HED-SCORE 		[@dorahermes](https://github.com/dorahermes)	anat, eeg, ieeg	T1w, channels, coordsystem, eeg, electrodes, events, ieeg
 dwi_deriv	exemplifies the storage of diffusion MRI derivates that may be generated on the Siemens XA platform.			dwi	dwi
 pheno004	Minimal dataset with subjects with imaging and/or phenotype data		[@ericearl](https://github.com/ericearl)	phenotype, anat	T1w
+provenance_dcm2niix	Shows minimal example of provenance records for a DICOM to Nifti conversion, performed by [`dcm2niix`](https://github.com/rordenlab/dcm2niix)	This example is buid upon [hirni-demo](https://github.com/psychoinformatics-de/hirni-demo) data	[@bclenet](https://github.com/bclenet)	anat	T1w, act, ent, env, soft

--- a/provenance_dcm2niix/README.md
+++ b/provenance_dcm2niix/README.md
@@ -1,0 +1,21 @@
+# BEP028 example dataset - Provenance records for `dcm2niix`
+
+This example aims at showing provenance records for a DICOM to Nifti conversion, performed by [`dcm2niix`](https://github.com/rordenlab/dcm2niix
+). Provenance records were created manually ; they act as a guideline for further machine-generated records by `dcm2niix`. 
+
+After conversion, and adding provenance traces, the directory tree is as follows:
+
+```
+prov/
+├── prov-dcm2niix_act.json
+├── prov-dcm2niix_ent.json
+├── prov-dcm2niix_env.json
+└── prov-dcm2niix_soft.json
+sourcedata/
+sub-02/
+└── anat
+    ├── sub-02_T1w.json
+    └── sub-02_T1w.nii
+```
+
+Note that the `sourcedata/` directory contains the source dataset (DICOM files) known as [hirni-demo](https://github.com/psychoinformatics-de/hirni-demo).

--- a/provenance_dcm2niix/dataset_description.json
+++ b/provenance_dcm2niix/dataset_description.json
@@ -1,0 +1,14 @@
+{
+    "Name": "Provenance records for dcm2niix",
+    "BIDSVersion": "1.10.0",
+    "DatasetType": "raw",
+    "License": "CC0",
+    "Authors": [
+        "Boris Clénet"
+    ],
+    "SourceDatasets": [
+        {
+            "URL": "https://github.com/psychoinformatics-de/hirni-demo"
+        }
+    ]
+}

--- a/provenance_dcm2niix/prov/prov-dcm2niix_act.json
+++ b/provenance_dcm2niix/prov/prov-dcm2niix_act.json
@@ -1,0 +1,14 @@
+{
+  "Activities": [
+    {
+      "Id": "bids::prov/#conversion-00f3a18f",
+      "Label": "Conversion",
+      "Command": "dcm2niix -o . -f sub-%i/anat/sub-%i_T1w sourcedata/hirni-demo/acq1/dicoms/example-dicom-structural-master/dicoms",
+      "AssociatedWith": "bids::prov/#dcm2niix-khhkm7u1",
+      "Used": [
+        "bids::prov/#fedora-uldfv058",
+        "bids::sourcedata/hirni-demo/acq1/dicoms/example-dicom-structural-master/dicoms"
+      ]
+    }
+  ]
+}

--- a/provenance_dcm2niix/prov/prov-dcm2niix_ent.json
+++ b/provenance_dcm2niix/prov/prov-dcm2niix_ent.json
@@ -1,0 +1,9 @@
+{
+  "Entities": [
+    {
+      "Id": "bids::sourcedata/hirni-demo/acq1/dicoms/example-dicom-structural-master/dicoms",
+      "Type": "Entity",
+      "Label": "dicoms"
+    }
+  ]
+}

--- a/provenance_dcm2niix/prov/prov-dcm2niix_env.json
+++ b/provenance_dcm2niix/prov/prov-dcm2niix_env.json
@@ -1,0 +1,9 @@
+{
+  "Environments": [
+    {
+      "Id": "bids::prov/#fedora-uldfv058",
+      "Label": "Fedora release 36 (Thirty Six)",
+      "OperatingSystem": "GNU/Linux 6.2.15-100.fc36.x86_64"
+    }
+  ]
+}

--- a/provenance_dcm2niix/prov/prov-dcm2niix_soft.json
+++ b/provenance_dcm2niix/prov/prov-dcm2niix_soft.json
@@ -1,0 +1,9 @@
+{
+  "Software": [
+    {
+      "Id": "bids::prov/#dcm2niix-khhkm7u1",
+      "Label": "dcm2niix",
+      "Version": "v1.0.20220720"
+    }
+  ]
+}

--- a/provenance_dcm2niix/sub-02/anat/sub-02_T1w.json
+++ b/provenance_dcm2niix/sub-02/anat/sub-02_T1w.json
@@ -1,0 +1,25 @@
+{
+    "Modality": "MR",
+    "ManufacturersModelName": "nifti2dicom",
+    "SoftwareVersions": "0.4.11",
+    "SeriesDescription": "anat-T1w",
+    "ProtocolName": "anat-T1w",
+    "ImageType": ["DERIVED", "SECONDARY"],
+    "RawImage": false,
+    "SeriesNumber": 401,
+    "AcquisitionTime": "13:25:18.000000",
+    "AcquisitionNumber": 1,
+    "SliceThickness": 0.666667,
+    "SpacingBetweenSlices": 0.666667,
+    "ImageOrientationPatientDICOM": [
+        0.999032,
+        -0.0217884,
+        0.0382096,
+        0.0265195,
+        0.991414,
+        -0.128044   ],
+    "ConversionSoftware": "dcm2niix",
+    "ConversionSoftwareVersion": "v1.0.20220720",
+    "GeneratedBy": "bids::prov/#conversion-00f3a18f",
+    "SidecarGeneratedBy": "bids::prov/#conversion-00f3a18f"
+}

--- a/tools/print_dataset_listing.py
+++ b/tools/print_dataset_listing.py
@@ -57,6 +57,7 @@ tables_order = {
     "PET": "pet",
     "qMRI": "",
     "Phenotype": "phenotype",
+    "Provenance": "",
 }
 
 DELIMITER = "<!-- ADD EXAMPLE LISTING HERE -->"
@@ -176,6 +177,8 @@ def add_tables(df: pd.DataFrame, output_file: Path, names) -> None:
             mask = names.str.contains("qmri_")
         elif table_name == "HED":
             mask = names.str.contains("_hed_")
+        elif table_name == "Provenance":
+            mask = names.str.contains("provenance_")
         else:
             mask = df["datatypes"].str.contains(table_datatypes, regex=True)
 


### PR DESCRIPTION
This example aims at showing provenance records for a DICOM to Nifti conversion, performed by [`dcm2niix`](https://github.com/rordenlab/dcm2niix).

The PR also adds a new table to the README.md for datasets related to provenance

