### PR TITLE
Clarified in the README where sourcedata can be found 

### DIFF
--- a/xeeg_hed_score/README
+++ b/xeeg_hed_score/README
@@ -15,9 +15,9 @@ Data are annotated by adding a column for annotations in the _events.tsv. This l
 
 # Source data
 Examples are based on original datasets:
-- sub-eegSeizureTUH    The TUH EEG Seizure Corpus. Database: TUH EEG Seizure Corpus (TUSZ), Version: 1.5.3, Patient: 258, Session: s003 (../tuh_eeg_seizure/v1.5.3/edf/dev/01_tcp_ar/002/00000258/s003_2003_07_22)
-- sub-eegArtifactTUH   The TUH EEG Artifact Corpus. Database: TUH EEG Artifact Corpus (TUAR), Version: v2.0.0, Patient: 715 , Session: s010 (../tuh_eeg_artifact/edf/01_tcp_ar/007/00000715/s010_2014_08_07)
-- sub-ieegModulator    Intracranial EEG dataset collected at Mayo Clinic Rochester, MN during photic stimulation. The photic stimulation is annotated using the HED-SCORE modulator.
+- sub-eegSeizureTUH    Source data can be found on the TUH EEG Seizure Corpus. Database: TUH EEG Seizure Corpus (TUSZ), Version: 1.5.3, Patient: 258, Session: s003 (../tuh_eeg_seizure/v1.5.3/edf/dev/01_tcp_ar/002/00000258/s003_2003_07_22)
+- sub-eegArtifactTUH   Source data can be found on the TUH EEG Artifact Corpus. Database: TUH EEG Artifact Corpus (TUAR), Version: v2.0.0, Patient: 715 , Session: s010 (../tuh_eeg_artifact/edf/01_tcp_ar/007/00000715/s010_2014_08_07)
+- sub-ieegModulator    Intracranial EEG dataset collected at Mayo Clinic Rochester, MN during photic stimulation. The photic stimulation is annotated using the HED-SCORE modulator. Source data are located on: https://openneuro.org/datasets/ds006392/versions/1.0.1
 
 # More information
 HED: https://www.hedtags.org/


### PR DESCRIPTION
The README now more clearly states where the sourcedata can be found, added a link to OpenNeuro.