### PR TITLE
chore(ci): Cache npm packages

### DIFF
--- a/.github/workflows/validate_datasets.yml
+++ b/.github/workflows/validate_datasets.yml
@@ -40,7 +40,8 @@ jobs:
       if: matrix.bids-validator == 'legacy'
       uses: actions/setup-node@v4
       with:
-        node-version: 18
+        node-version: 22
+        cache: 'npm'
 
     - uses: denoland/setup-deno@v2
       if: matrix.bids-validator != 'legacy'

--- a/.github/workflows/validate_datasets.yml
+++ b/.github/workflows/validate_datasets.yml
@@ -41,7 +41,18 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: 22
-        cache: 'npm'
+
+    - name: Set cache name
+      if: matrix.bids-validator == 'legacy'
+      run:
+        echo "MONTH=$( date +%Y%m )" >> $GITHUB_ENV
+
+    - name: Load npm cache
+      if: matrix.bids-validator == 'legacy'
+      uses: actions/cache@v4
+      with:
+        path: ~/.npm
+        key: npm-${{ runner.os }}-${{ env.MONTH }}
 
     - uses: denoland/setup-deno@v2
       if: matrix.bids-validator != 'legacy'


### PR DESCRIPTION
Installation can sometimes be slow and occasionally get a 429 Too Many Requests. A cache should help both things.

Bumping node to 22.