### PR TITLE
fix: Update column definitions that do not match column contents

### DIFF
--- a/eeg_rishikesh/task-meditation_events.json
+++ b/eeg_rishikesh/task-meditation_events.json
@@ -11,7 +11,8 @@
     "Description": "Type of event (different from EEGLAB convention)",
     "Levels": {
       "stimulus": "Onset of first question",
-      "response": "Response to question 1, 2 or 3"
+      "response": "Response to question 1, 2 or 3",
+      "STATUS": "Status event"
     }
   },
   "response_time": {
@@ -27,7 +28,8 @@
       "4": "Response 2 (this may be a response to question 1, 2 or 3)",
       "8": "Response 3 (this may be a response to question 1, 2 or 3)",
       "16": "Indicate involuntary response",
-      "128": "First question onset (most important marker)"
+      "128": "First question onset (most important marker)",
+      "254": "Status event"
     }
   }
 }

--- a/mrs_fmrs/participants.json
+++ b/mrs_fmrs/participants.json
@@ -1,6 +1,6 @@
 {
   "participant_id": {
-      "Description": "Unique participant identifier"
+    "Description": "Unique participant identifier"
   },
   "sex": {
     "Description": "Sex of the participant",
@@ -10,7 +10,13 @@
     }
   },
   "age": {
-    "Description": "Age of the participant",
-    "Units": "years"
+    "Description": "Age of the participant, in 5-year intervals",
+    "Format": "string",
+    "Levels": {
+      "20-25": "20 to 25 years",
+      "25-30": "25 to 30 years",
+      "30-35": "30 to 35 years",
+      "35-40": "35 to 40 years"
+    }
   }
 }


### PR DESCRIPTION
Working on improving column validation in the validator, we decided that failure to match declared column values should be an error, not a warning (https://github.com/bids-standard/bids-validator/pull/247). This produces errors in a couple examples, so this PR fixes those examples.

@arnodelorme You are listed as the maintainer of eeg_rishikesh
@markmikkelsen You are listed as the maintainer of mrs_fmrs

Would you mind reviewing these changes?