### PR TITLE
Describe ds102 "D" sex level and 7t_trt number_of_scans_before

### DIFF
--- a/7t_trt/participants.json
+++ b/7t_trt/participants.json
@@ -18,6 +18,9 @@
     "LongName": "age_at_first_scan_years",
     "Units": "year"
   },
+  "number_of_scans_before": {
+    "Description": "Number of 7 T scans the participant had taken before the first scan of this study."
+  },
   "handedness": {
     "LongName": "Edinburgh Handedness Inventory",
     "Units": "arbitrary"

--- a/ds102/participants.json
+++ b/ds102/participants.json
@@ -5,7 +5,7 @@
     "TermURL": "http://purl.obolibrary.org/obo/PATO_0001894",
     "Levels": {
       "D": {
-        "Description": "D"
+        "Description": "Undocumented code inherited from the original OpenfMRI ds102 demographics; meaning unknown. Not one of the values RECOMMENDED by BIDS for the sex column."
       },
       "F": {
         "Description": "Female",


### PR DESCRIPTION
`ds102/participants.json` described the `sex` level `"D"` as `"Description": "D"`, which tells a
reader nothing. Its meaning is not recoverable from any source I could
reach, so it is now described as an undocumented inherited code, with **no** `TermURL` asserted —
better an honest "unknown" than a guessed ontology term in a repository people copy from.

From @yarikoptic directly (not claude) : I thought to make "D" into [diandrous](https://ontobee.org/ontology/PATO?iri=http://purl.obolibrary.org/obo/PATO_0040050) with a TermURL -- after all it is just an example so we do not have to strive for factual correspondence to some original source?  ~~likely it was also what was intended.~~ edit: claude suggests that it is not applicable to humans...

Sweeping the other 60 `participants.json` files for the same defect, `"D"` turned out to be the
only opaque unexpanded level code in the repository. One adjacent omission is fixed too:
`7t_trt/participants.json` described 3 of its 4 `participants.tsv` columns, and the missing
`number_of_scans_before` was raising `TSV_ADDITIONAL_COLUMNS_UNDEFINED` on `participants.tsv`.

/cc @Remi-Gau @sappelhoff @surchs — this is the *"feel free to add later: for example what's the
`D` sex?"* item you left open when merging
[#413](https://github.com/bids-standard/bids-examples/pull/413#issuecomment-1792254122).
Short answer: it is not recoverable from anything still published. If any of you know the
original legend, that would beat this description outright.

<details>
<summary>What "D" is, and why no TermURL</summary>

- `ds102/participants.tsv` entered the repo in 2015 with
  [`Added 22 example datasets`](https://github.com/bids-standard/bids-examples/commit/f1d2094c937e972ae26c52a5614a68ffff43fda3),
  converted from OpenfMRI ds102 (NYU Slow Flanker, Kelly et al. 2008).
- The upstream OpenNeuro `ds000102` `README` says age and sex live in a file
  `Slow_Flanker_age_sex.txt` (the copy of the `README` in this repo is truncated and drops that
  paragraph). That file is not
  distributed anywhere reachable — not in the OpenNeuro S3 bucket for `ds000102`, not via the
  OpenNeuro API, and GitHub code search turns up no mirror. The legend went with it.
- OpenNeuro's mirror `ds000102` carries the **same** `D`/`F`/`M` values but names the column
  `gender`, not `sex`. So even the concept the codes belong to is not agreed between the two
  copies of this dataset.
- `PATO_0040050` ("diandrous") is a **plant** term — *"a phenotypic sex quality inhering in a
  plant organism […] in which the flowers have two stamens"* (checked against the OLS API). It is
  not a candidate.
- `D` is not among the values the BIDS schema lists for `sex`
  (`male/m/M/MALE/Male`, `female/f/F/FEMALE/Female`, `other/o/O/OTHER/Other`).
- The distribution is 16 `M`, 1 `F`, 9 `D` across 26 participants. `D` + `F` = 10 is *suggestive*
  of a 10-female / 16-male split, and `D` and `F` are adjacent keys — but the published papers
  (Kelly 2008; Mennes 2010, 2011) give no sex breakdown to check it against, so that stays
  speculation and is deliberately kept out of the sidecar. Note this is a negative result: the
  meaning is unfalsified, not disproven — Kelly 2008 is paywalled and could not be checked.

Recoding `participants.tsv` (`D` → `n/a` or `O`) was considered and not done: the values match
what OpenNeuro distributes, and silently reinterpreting subject metadata is a bigger decision
than a sidecar fix. Happy to do it in a follow-up if maintainers prefer that.

</details>

<details>
<summary>7t_trt/number_of_scans_before</summary>

The source publication for this dataset — Gorgolewski et al. 2015, *Sci Data* 2:140054
([PMC4412153](https://europepmc.org/article/PMC/PMC4412153)) — describes the demographics file as
containing *"sex, age at the first scan in years, handedness, and number of 7 T scans previously
taken"*. Hence the description. No `Units` is given (a count has no SI unit), and no `LongName`,
since it would only restate the column name. The key is placed to match the `participants.tsv`
column order.

</details>

<details>
<summary>Validation</summary>

`bids-validator` 3.0.1 (stable), run through the repo's own runner:

```console
$ ./run_tests.sh ds102 7t_trt
$ echo $?
0
```

No errors. Warning classes are unchanged for both datasets, except that
`7t_trt`'s `TSV_ADDITIONAL_COLUMNS_UNDEFINED` no longer lists `participants.tsv`
(the remaining hits are `*_sessions.tsv` `CCPT_*` columns, untouched here):

```console
# occurrences of participants.tsv under TSV_ADDITIONAL_COLUMNS_UNDEFINED, 7t_trt
before: 1
after:  0
```

`codespell` passes on both files.

</details>

<details>
<summary>Other participants.json files reviewed — deliberately not changed</summary>

Per the brief, only non-uniform or omitted annotation was in scope; datasets that simply have no
`Levels`/`Description` at all were left alone rather than annotating everything. Findings worth
recording:

| Dataset | Observation | Why untouched |
| --- | --- | --- |
| `ds116` | `ethnicity` levels `Asian/Caucasian` and `Caucasian/African/NativeSouthAmerican` have no `TermURL` while the four single-ancestry levels do | Same knowingly-deferred item from [#413](https://github.com/bids-standard/bids-examples/pull/413#issuecomment-1792254122); HANCESTRO has no single term for a composite ancestry, so the gap looks correct |
| `ds009` | 87 of 89 `participants.tsv` columns (BIS, DOSPERT, PANAS, CARE …) undescribed; only `Age` and `Gender` are | Genuine large-scale annotation job, explicitly out of scope |
| `fnirs_automaticity` | `participants.tsv` carries **near-duplicate columns**: `comfortlevel_begin`/`comfortlevel_end` (all `n/a` except sub-01) alongside the populated `comfortlevel_before`/`comfortlevel_after`, and `reasonforexclusion` (all `n/a`) alongside the populated `reason_for_exclusion`. The sidecar describes only the empty variants | This is a TSV data bug, not a sidecar omission; fixing it means deciding which columns are canonical — the dataset maintainer's call |
| `ds000248`, `fnirs_tapping`, `eyetracking_eeg_ds007338` | `participants.tsv` starts with a UTF-8 BOM, so a naive reader sees a column named `﻿participant_id` | The validator tolerates it; cosmetic, but worth knowing for a repo whose purpose is testing readers |
| `emg_Multimodal` | `handedness` level `ambidextrous` is described as `"ambidextrous"` while its siblings are `"left-handed"`/`"right-handed"` | Self-explanatory term, not an opaque code — no information is lost |
| various (`ds000246`, `ds114`, `genetics_ukbb`, `fnirs_automaticity`, …) | levels whose `Description` repeats a self-explanatory label (`"Male": "Male"`, `"left": "left"`, `"blond": "blond"`) | Uniform within each file and readable as-is |

Audit scripts used for the sweep are throwaway and not included.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G51JgTE7SSAb67RoW7XL8b
